### PR TITLE
fix: merge `config.external` with defaults if it's an array

### DIFF
--- a/src/node/_resolveBuildContext.ts
+++ b/src/node/_resolveBuildContext.ts
@@ -79,7 +79,11 @@ export async function _resolveBuildContext(options: {
     ...(pkg.peerDependencies ? Object.keys(pkg.peerDependencies) : []),
   ]
 
-  const external = _resolveConfigProperty(config?.external, parsedExternal)
+  // Merge externals if an array is provided, replace if it's a function
+  const external =
+    config && Array.isArray(config.external)
+      ? [...parsedExternal, ...config.external]
+      : _resolveConfigProperty(config?.external, parsedExternal)
 
   const outputPaths = Object.values(exports)
     .flatMap((exportEntry) => {


### PR DESCRIPTION
This helps prevent accidents like: https://github.com/sanity-io/sanity/pull/3758

But you can still override the `external` setting by using a function callback:

```js
export default {
  external: () => ['only-make-this-external']
}
```