### PR TITLE
feat: add support for `./package.json` in `pkg.exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
       "import": "./dist/index.esm.js",
       "require": "./dist/index.js",
       "default": "./dist/index.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "bin": {
     "pkg": "./bin/pkg-utils.js",

--- a/playground/custom-dist/package.json
+++ b/playground/custom-dist/package.json
@@ -15,7 +15,8 @@
       "import": "./lib/index.js",
       "require": "./lib/index.cjs",
       "default": "./lib/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "rimraf lib && pkg build --tsconfig tsconfig.lib.json && pkg --tsconfig tsconfig.lib.json --strict"

--- a/playground/exports-dummy/package.json
+++ b/playground/exports-dummy/package.json
@@ -36,7 +36,8 @@
       "import": "./dist/extra.js",
       "require": "./dist/extra.cjs",
       "default": "./dist/extra.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {

--- a/playground/multi-export/package.json
+++ b/playground/multi-export/package.json
@@ -22,7 +22,8 @@
       "import": "./dist/plugin.js",
       "require": "./dist/plugin.cjs",
       "default": "./dist/plugin.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {

--- a/playground/ts/package.json
+++ b/playground/ts/package.json
@@ -15,7 +15,8 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",
       "default": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "rimraf dist && pkg build --tsconfig tsconfig.dist.json && pkg --tsconfig tsconfig.dist.json --strict"

--- a/src/node/_core/pkg/_parseExports.ts
+++ b/src/node/_core/pkg/_parseExports.ts
@@ -27,8 +27,18 @@ export function _parseExports(options: {pkg: _PackageJSON}): (PkgExport & {_path
   const errors: string[] = []
 
   if (pkg.exports) {
+    if (!pkg.exports['./package.json']) {
+      errors.push('package.json: `exports["./package.json"] must be declared.')
+    }
+
     for (const [exportPath, exportEntry] of Object.entries(pkg.exports)) {
-      if (_isRecord(exportEntry)) {
+      if (exportPath.endsWith('.json')) {
+        if (exportPath === './package.json') {
+          if (exportEntry !== './package.json') {
+            errors.push('package.json: `exports["./package.json"] must be "./package.json".')
+          }
+        }
+      } else if (_isRecord(exportEntry)) {
         if (exportPath === '.') {
           if (
             exportEntry.require &&

--- a/src/node/_core/pkg/_types.ts
+++ b/src/node/_core/pkg/_types.ts
@@ -10,23 +10,24 @@ export interface _PackageJSON {
   peerDependencies?: Record<string, string>
   exports?: Record<
     string,
-    {
-      source: string
-      types?: string
-      browser?: {
+    | `./${string}.json`
+    | {
         source: string
-        require?: string
+        types?: string
+        browser?: {
+          source: string
+          require?: string
+          import?: string
+        }
+        node?: {
+          source: string
+          require?: string
+          import?: string
+        }
         import?: string
-      }
-      node?: {
-        source: string
         require?: string
-        import?: string
+        default: string
       }
-      import?: string
-      require?: string
-      default: string
-    }
   >
   main?: string
   browser?: Record<string, string>

--- a/src/node/_core/pkg/_validatePkg.ts
+++ b/src/node/_core/pkg/_validatePkg.ts
@@ -17,27 +17,30 @@ const pkgSchema = z.object({
   types: z.optional(z.string()),
   exports: z.optional(
     z.record(
-      z.object({
-        types: z.optional(z.string()),
-        source: z.string(),
-        browser: z.optional(
-          z.object({
-            source: z.string(),
-            require: z.optional(z.string()),
-            import: z.optional(z.string()),
-          })
-        ),
-        node: z.optional(
-          z.object({
-            source: z.string(),
-            require: z.optional(z.string()),
-            import: z.optional(z.string()),
-          })
-        ),
-        require: z.optional(z.string()),
-        import: z.optional(z.string()),
-        default: z.string(),
-      })
+      z.union([
+        z.custom<`./${string}.json`>((val) => /^\.\/.*\.json$/.test(val as string)),
+        z.object({
+          types: z.optional(z.string()),
+          source: z.string(),
+          browser: z.optional(
+            z.object({
+              source: z.string(),
+              require: z.optional(z.string()),
+              import: z.optional(z.string()),
+            })
+          ),
+          node: z.optional(
+            z.object({
+              source: z.string(),
+              require: z.optional(z.string()),
+              import: z.optional(z.string()),
+            })
+          ),
+          require: z.optional(z.string()),
+          import: z.optional(z.string()),
+          default: z.string(),
+        }),
+      ])
     )
   ),
   browserslist: z.optional(z.array(z.string())),

--- a/test/_parseExports.test.ts
+++ b/test/_parseExports.test.ts
@@ -16,6 +16,7 @@ describe('_parseExports', () => {
           require: './dist/index.js',
           default: './dist/index.js',
         },
+        './package.json': './package.json',
       },
     }
 
@@ -33,6 +34,28 @@ describe('_parseExports', () => {
         default: './dist/index.js',
       },
     ])
+  })
+
+  test('should throw if `package.json` is missing from the exports', () => {
+    const pkg: _PackageJSON = {
+      type: 'commonjs',
+      name: 'test',
+      version: '0.0.0-test',
+      bin: {test: './dist/cli.js'},
+      source: './src/index.ts',
+      main: './dist/index.js',
+      exports: {
+        '.': {
+          source: './src/index.ts',
+          require: './dist/index.js',
+          default: './dist/index.js',
+        },
+      },
+    }
+
+    expect(() => _parseExports({pkg})).toThrow(
+      '\n- package.json: `exports["./package.json"] must be declared.'
+    )
   })
 
   test('parse package.json with browser files', () => {
@@ -53,6 +76,7 @@ describe('_parseExports', () => {
           import: './dist/index.js',
           default: './dist/index.js',
         },
+        './package.json': './package.json',
       },
     }
 
@@ -90,6 +114,7 @@ describe('_parseExports', () => {
           require: './lib/index.wrong.suffix',
           default: './lib/index.js',
         },
+        './package.json': './not/package.json',
       },
       main: './lib/index.js',
       module: './lib/index.esm.js',
@@ -99,6 +124,7 @@ describe('_parseExports', () => {
     expect(() => _parseExports({pkg})).toThrow(
       '\n- package.json: mismatch between "main" and "exports.require". These must be equal.' +
         '\n- package.json: mismatch between "module" and "exports.import" These must be equal.' +
+        '\n- package.json: `exports["./package.json"] must be "./package.json".' +
         '\n- package.json with `type: "commonjs"` - `exports["."].require` must end with ".js"' +
         '\n- package.json with `type: "commonjs"` - `exports["."].import` must end with ".esm.js"'
     )


### PR DESCRIPTION
When adding `pkg.exports` it's important to add `./package.json` to the list, otherwise, we're blocking people from being able to [read metadata from it](https://github.com/sanity-io/incompatible-plugin#usage) when in a native node env:

```ts
const {version} = require('sanity/package.json')
```
or
```ts
import {version} from 'sanity/package.json' assert {type: 'json'}
```
or
```ts
const {version} = await import('sanity/package.json', {assert: {type: 'json'}})
```

[Here's a PR with a repro case.](https://github.com/sanity-io/next-sanity/pull/134)