### PR TITLE
fix: filter out test modules and comments

### DIFF
--- a/playground/ts/src/index.ts
+++ b/playground/ts/src/index.ts
@@ -1,2 +1,3 @@
 /** @public */
 export const VERSION = '1.0.0'
+export * from './module1'

--- a/playground/ts/src/index.ts
+++ b/playground/ts/src/index.ts
@@ -1,3 +1,6 @@
 /** @public */
 export const VERSION = '1.0.0'
 export * from './module1'
+
+//if this line is uncommented, a test should fail
+//export * from './not-imported'

--- a/playground/ts/src/module1.ts
+++ b/playground/ts/src/module1.ts
@@ -1,0 +1,37 @@
+export * from './module2'
+
+/**
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export interface _Dummy {
+  field: string
+}
+
+declare module './module2' {
+  export interface IncludedModuleDummy {
+    addedField: string
+  }
+}
+
+/**
+ * declare namespace ExcludedModule {
+ *  interface TSDocsDummy {
+ *    field: string
+ *  }
+ * }
+ */
+
+/*
+  declare namespace ExcludedModule {
+   interface BlockCommentDummy {
+     field: string
+   }
+  }
+    */
+
+// declare namespace ExcludedModule {
+//  interface CommentDummy {
+//    field: string
+//  }
+// }

--- a/playground/ts/src/module1.ts
+++ b/playground/ts/src/module1.ts
@@ -14,6 +14,8 @@ declare module './module2' {
   }
 }
 
+// Note: dont remove these blocks, they test that we dont include them in the final bundle
+
 /**
  * declare module './module2' {
  *  interface TSDocsDummy {

--- a/playground/ts/src/module1.ts
+++ b/playground/ts/src/module1.ts
@@ -15,7 +15,7 @@ declare module './module2' {
 }
 
 /**
- * declare namespace ExcludedModule {
+ * declare module './module2' {
  *  interface TSDocsDummy {
  *    field: string
  *  }
@@ -23,14 +23,14 @@ declare module './module2' {
  */
 
 /*
-  declare namespace ExcludedModule {
+  declare module './module2' {
    interface BlockCommentDummy {
      field: string
    }
   }
     */
 
-// declare namespace ExcludedModule {
+// declare module './module2' {
 //  interface CommentDummy {
 //    field: string
 //  }

--- a/playground/ts/src/module2.ts
+++ b/playground/ts/src/module2.ts
@@ -1,0 +1,6 @@
+/**
+ * @public
+ */
+export interface IncludedModuleDummy {
+  field: string
+}

--- a/playground/ts/src/not-imported.ts
+++ b/playground/ts/src/not-imported.ts
@@ -1,0 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+//@ts-expect-error unused
+import {IncludedModuleDummy} from './module2'
+
+//this should not appear in our final bundle
+declare module './module2' {
+  interface Excluded {
+    field: string
+  }
+}

--- a/src/node/_tasks/dts/_declareModuleFix.ts
+++ b/src/node/_tasks/dts/_declareModuleFix.ts
@@ -29,6 +29,7 @@ async function _extractModuleBlocksFromTypes(dirname: string): Promise<string[]>
     if (fileName.includes('.test.')) {
       continue
     }
+
     const content = await fs.readFile(path.resolve(dirname, fileName), {
       encoding: 'utf-8',
     })

--- a/src/node/_tasks/dts/_declareModuleFix.ts
+++ b/src/node/_tasks/dts/_declareModuleFix.ts
@@ -62,6 +62,8 @@ export function _extractModuleBlocks(fileContent: string): string[] {
     // This is just defensive code, just in case
     if (insideComment && line.includes('*/')) {
       insideComment = false
+    } else if (!insideComment && line.includes('/*') && line.includes('*/')) {
+      continue // it's a one-line comment
     } else if (!insideComment && line.includes('/*')) {
       insideComment = true
     }

--- a/src/node/_tasks/dts/_declareModuleFix.ts
+++ b/src/node/_tasks/dts/_declareModuleFix.ts
@@ -60,9 +60,9 @@ export function _extractModuleBlocks(fileContent: string): string[] {
   for (const line of lines) {
     // Note: Extractor already removes comment blocks, so fileContent is typically already comment free
     // This is just defensive code, just in case
-    if (insideComment && line.indexOf('*/') > 0) {
+    if (insideComment && line.includes('*/')) {
       insideComment = false
-    } else if (!insideComment && line.indexOf('/*') > 0) {
+    } else if (!insideComment && line.includes('/*')) {
       insideComment = true
     }
 

--- a/src/node/_tasks/dts/_doExtract.ts
+++ b/src/node/_tasks/dts/_doExtract.ts
@@ -48,13 +48,13 @@ export async function _doExtract(
     )
 
     const targetPath = path.resolve(cwd, entry.targetPath)
-
+    const filePath = path.relative(outDir, targetPath)
     const result = await _extractTypes({
       customTags: config?.extract?.customTags,
       cwd,
       exportPath,
       files,
-      filePath: path.relative(outDir, targetPath),
+      filePath: filePath,
       projectPath: cwd,
       rules: config?.extract?.rules,
       sourceTypesPath: sourceTypesPath,
@@ -64,6 +64,7 @@ export async function _doExtract(
 
     await _appendModuleBlocks({
       tsOutDir: tmpPath,
+      extractResult: result.extractorResult,
       extractTypesOutFile: path.resolve(outDir, targetPath),
     })
 

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -187,3 +187,30 @@ declare interface Plugin_2 {
 export {}
 "
 `;
+
+exports[`should build ts package 1`] = `
+"/**
+ * @internal
+ */
+export declare interface _Dummy {
+  field: string
+}
+
+/**
+ * @public
+ */
+export declare interface IncludedModuleDummy {
+  field: string
+}
+
+/** @public */
+export declare const VERSION = '1.0.0'
+
+export {}
+
+declare module './module2' {
+    interface IncludedModuleDummy {
+        addedField: string;
+    }
+}"
+`;

--- a/test/_extractModuleBlocks.test.ts
+++ b/test/_extractModuleBlocks.test.ts
@@ -26,6 +26,14 @@ test('extract module block', () => {
        *  }
        * }
        * /
+
+ /*
+     declare module 'BB' {
+      export interface BB {
+        a: string
+      }
+     }
+        * /
   `
   )
 

--- a/test/_extractModuleBlocks.test.ts
+++ b/test/_extractModuleBlocks.test.ts
@@ -19,6 +19,9 @@ test('extract module block', () => {
         }
       }
 
+/*declare module 'sanity' {}*/
+      /* declare module 'sanity' {} */
+
        /**
        * declare module 'sanity' {
        *  export interface StringOptions {

--- a/test/_extractModuleBlocks.test.ts
+++ b/test/_extractModuleBlocks.test.ts
@@ -19,6 +19,7 @@ test('extract module block', () => {
         }
       }
 
+      const a = 0; /*declare module 'sanity' {}*/ const b = 0;
 /*declare module 'sanity' {}*/
       /* declare module 'sanity' {} */
 

--- a/test/_extractModuleBlocks.test.ts
+++ b/test/_extractModuleBlocks.test.ts
@@ -18,8 +18,18 @@ test('extract module block', () => {
             x: string
         }
       }
+
+       /**
+       * declare module 'sanity' {
+       *  export interface StringOptions {
+       *    myCustomOption?: boolean
+       *  }
+       * }
+       * /
   `
   )
+
+  expect(blocks.length).toEqual(2)
 
   expect(blocks[0]).toEqual(outdent`
     declare module X {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -95,7 +95,7 @@ test('should build `multi-export` package', async () => {
   await project.remove()
 })
 
-test.only('should build ts package', async () => {
+test('should build ts package', async () => {
   const project = await _spawnProject('ts')
 
   await project.install()

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -95,7 +95,7 @@ test('should build `multi-export` package', async () => {
   await project.remove()
 })
 
-test('should build ts package', async () => {
+test.only('should build ts package', async () => {
   const project = await _spawnProject('ts')
 
   await project.install()

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -95,6 +95,20 @@ test('should build `multi-export` package', async () => {
   await project.remove()
 })
 
+test('should build ts package', async () => {
+  const project = await _spawnProject('ts')
+
+  await project.install()
+
+  const {stdout} = await project.run('build')
+
+  expect(stdout).toContain('./src/index.ts -> ./dist/src/index.d.ts')
+
+  expect(await project.readFile('dist/src/index.d.ts')).toMatchSnapshot()
+
+  await project.remove()
+})
+
 describe.skip('runtime: webpack v3', () => {
   test('import `dist/*.browser.js` from package', async () => {
     const exportsDummy = await _spawnProject('exports-dummy')


### PR DESCRIPTION
Espen discovered that the previous "fix" included `declare module` statements from test files as well as from TSDocs.

The code is not getting better with this, and we definitely should consider another approach, but dont have an TypeScript AST integration on hand right now unfortunatly.

**Update**
Files are now determined via `extractor.program.getSourceFiles()`: this is a bit better than glob for files ourself, and they already contain `text` without comments (but with TSDccs), so saves on readtime.

Added an integration test for ts to check that commented blocks and unused code are not included.