### PR TITLE
fix: require exported `package.json` behind `--strict` flag

### DIFF
--- a/playground/custom-dist/package.json
+++ b/playground/custom-dist/package.json
@@ -19,6 +19,6 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "rimraf lib && pkg build --tsconfig tsconfig.lib.json && pkg --tsconfig tsconfig.lib.json --strict"
+    "build": "rimraf lib && pkg build --strict --tsconfig tsconfig.lib.json && pkg --strict --tsconfig tsconfig.lib.json"
   }
 }

--- a/playground/exports-dummy/package.json
+++ b/playground/exports-dummy/package.json
@@ -51,6 +51,6 @@
     "extra.js"
   ],
   "scripts": {
-    "build": "rimraf dist extra.js && pkg build --tsconfig tsconfig.dist.json && pkg --tsconfig tsconfig.dist.json --strict"
+    "build": "rimraf dist extra.js && pkg build --strict --tsconfig tsconfig.dist.json && pkg --strict --tsconfig tsconfig.dist.json"
   }
 }

--- a/playground/extra-bundles/package.json
+++ b/playground/extra-bundles/package.json
@@ -8,6 +8,6 @@
   "module": "./dist/index.esm.js",
   "main": "./dist/index.js",
   "scripts": {
-    "build": "rimraf dist && pkg build && pkg --strict"
+    "build": "rimraf dist && pkg build --strict && pkg --strict"
   }
 }

--- a/playground/js/package.json
+++ b/playground/js/package.json
@@ -8,6 +8,6 @@
   "module": "./dist/index.esm.js",
   "main": "./dist/index.js",
   "scripts": {
-    "build": "rimraf dist && pkg build && pkg --strict"
+    "build": "rimraf dist && pkg build --strict && pkg --strict"
   }
 }

--- a/playground/multi-export/package.json
+++ b/playground/multi-export/package.json
@@ -33,6 +33,6 @@
     }
   },
   "scripts": {
-    "build": "rimraf dist plugin.js && pkg build --tsconfig tsconfig.dist.json && pkg --strict --tsconfig tsconfig.dist.json"
+    "build": "rimraf dist plugin.js && pkg build --strict --tsconfig tsconfig.dist.json && pkg --strict --tsconfig tsconfig.dist.json"
   }
 }

--- a/playground/ts/package.json
+++ b/playground/ts/package.json
@@ -19,6 +19,6 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "rimraf dist && pkg build --tsconfig tsconfig.dist.json && pkg --tsconfig tsconfig.dist.json --strict"
+    "build": "rimraf dist && pkg build --strict --tsconfig tsconfig.dist.json && pkg --strict --tsconfig tsconfig.dist.json"
   }
 }

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import {build} from '../src/node'
 
-build({cwd: path.resolve(__dirname, '..')}).catch((err) => {
+build({cwd: path.resolve(__dirname, '..'), strict: true}).catch((err) => {
   // eslint-disable-next-line no-console
   console.error(err.stack)
   process.exit(1)

--- a/src/node/_core/pkg/_parseExports.ts
+++ b/src/node/_core/pkg/_parseExports.ts
@@ -4,8 +4,11 @@ import {_PackageJSON} from './_types'
 import {_validateExports} from './_validateExports'
 
 /** @internal */
-export function _parseExports(options: {pkg: _PackageJSON}): (PkgExport & {_path: string})[] {
-  const {pkg} = options
+export function _parseExports(options: {
+  pkg: _PackageJSON
+  strict: boolean
+}): (PkgExport & {_path: string})[] {
+  const {pkg, strict} = options
 
   const rootExport: PkgExport & {_path: string} = {
     _exported: true,
@@ -27,7 +30,7 @@ export function _parseExports(options: {pkg: _PackageJSON}): (PkgExport & {_path
   const errors: string[] = []
 
   if (pkg.exports) {
-    if (!pkg.exports['./package.json']) {
+    if (strict && !pkg.exports['./package.json']) {
       errors.push('package.json: `exports["./package.json"] must be declared.')
     }
 

--- a/src/node/_printExtractMessages.ts
+++ b/src/node/_printExtractMessages.ts
@@ -16,6 +16,9 @@ export function _printExtractMessages(ctx: _BuildContext, messages: ExtractorMes
     const sourceFilePath = msg.sourceFilePath && path.relative(cwd, msg.sourceFilePath)
 
     if (msg.messageId === 'TS6307') {
+      // Ignore this warning:
+      // > TS6307: <filename> is not in project file list.
+      // > Projects must list all files or use an 'include' pattern.
       continue
     }
 

--- a/src/node/_resolveBuildContext.ts
+++ b/src/node/_resolveBuildContext.ts
@@ -67,7 +67,7 @@ export async function _resolveBuildContext(options: {
     node: nodeTarget,
   }
 
-  const parsedExports = _parseExports({pkg}).reduce<PkgExports>((acc, x) => {
+  const parsedExports = _parseExports({pkg, strict}).reduce<PkgExports>((acc, x) => {
     const {_path: exportPath, ...exportEntry} = x
 
     return {...acc, [exportPath]: exportEntry}

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -188,7 +188,7 @@ export {}
 "
 `;
 
-exports[`should build ts package 1`] = `
+exports[`should build \`ts\` package 1`] = `
 "/**
  * @internal
  */

--- a/test/_parseExports.test.ts
+++ b/test/_parseExports.test.ts
@@ -20,7 +20,7 @@ describe('_parseExports', () => {
       },
     }
 
-    const exports = _parseExports({pkg})
+    const exports = _parseExports({pkg, strict: true})
 
     expect(exports).toEqual([
       {
@@ -53,7 +53,7 @@ describe('_parseExports', () => {
       },
     }
 
-    expect(() => _parseExports({pkg})).toThrow(
+    expect(() => _parseExports({pkg, strict: true})).toThrow(
       '\n- package.json: `exports["./package.json"] must be declared.'
     )
   })
@@ -80,7 +80,7 @@ describe('_parseExports', () => {
       },
     }
 
-    const exports = _parseExports({pkg})
+    const exports = _parseExports({pkg, strict: true})
 
     expect(exports).toEqual([
       {
@@ -121,7 +121,7 @@ describe('_parseExports', () => {
       types: './lib/src/index.d.ts',
     }
 
-    expect(() => _parseExports({pkg})).toThrow(
+    expect(() => _parseExports({pkg, strict: true})).toThrow(
       '\n- package.json: mismatch between "main" and "exports.require". These must be equal.' +
         '\n- package.json: mismatch between "module" and "exports.import" These must be equal.' +
         '\n- package.json: `exports["./package.json"] must be "./package.json".' +

--- a/test/_parseTasks.test.ts
+++ b/test/_parseTasks.test.ts
@@ -15,11 +15,12 @@ test('should parse tasks', () => {
     },
   }
 
-  const exports = _parseExports({pkg})
+  const exports = _parseExports({pkg, strict: true})
 
   const ctx: _BuildContext = {
     cwd: '/test',
     distPath: '/test/dist',
+    emitDeclarationOnly: false,
     exports: Object.fromEntries(exports.map(({_path, ...entry}) => [_path, entry])),
     external: [],
     files: [],
@@ -37,6 +38,7 @@ test('should parse tasks', () => {
       browser: ['chrome102'],
       node: ['node14'],
     },
+    strict: true,
     ts: {},
   }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -95,7 +95,7 @@ test('should build `multi-export` package', async () => {
   await project.remove()
 })
 
-test('should build ts package', async () => {
+test('should build `ts` package', async () => {
   const project = await _spawnProject('ts')
 
   await project.install()


### PR DESCRIPTION
The fix to require exporting `./package.json` was a bit painful downstream, so this PR is to have this behavior behind the `--strict` flag.