### PR TITLE
fix: syntax error on multi-line declared modules

### DIFF
--- a/src/node/_tasks/dts/_declareModuleFix.ts
+++ b/src/node/_tasks/dts/_declareModuleFix.ts
@@ -62,6 +62,7 @@ export function _extractModuleBlocks(fileContent: string): string[] {
     // This is just defensive code, just in case
     if (insideComment && line.includes('*/')) {
       insideComment = false
+      continue
     } else if (!insideComment && line.includes('/*') && line.includes('*/')) {
       continue // it's a one-line comment
     } else if (!insideComment && line.includes('/*')) {

--- a/test/_extractModuleBlocks.test.ts
+++ b/test/_extractModuleBlocks.test.ts
@@ -8,14 +8,24 @@ test('extract module block', () => {
     interface A {}
 
     declare module X {
+      /**
+       * @beta
+       **/
       interface A {
           a: string
       }
     }
 
+      /** @public */
       declare module TT {
         interface X {
             x: string
+        }
+      }
+
+      declare module YY {
+        interface Y {
+            y: string
         }
       }
 
@@ -41,7 +51,7 @@ test('extract module block', () => {
   `
   )
 
-  expect(blocks.length).toEqual(2)
+  expect(blocks.length).toEqual(3)
 
   expect(blocks[0]).toEqual(outdent`
     declare module X {
@@ -54,6 +64,13 @@ test('extract module block', () => {
     declare module TT {
       interface X {
           x: string
+      }
+    }`)
+
+  expect(blocks[2]).toEqual(outdent`
+    declare module YY {
+      interface Y {
+          y: string
       }
     }`)
 })


### PR DESCRIPTION
Note: This is a temporary fix - I want to replace this approach with an AST-based approach instead.

When encountering multi-line comment blocks such as:
```
/**
 * @beta
 **/
```

The current code leaves the trailing ` **/`. The issue is that the logic sees that it is currently inside a comment and that the line includes the closing of the comment - which sets `insideComment` to false. This is correct for lines that _follow_ this one, but not _the current_ line. By adding a `continue`, we are telling it to now move on to the next line.

The real solution is to use an AST parser here, since there are plenty of pitfalls doing it the current way - lines that contain `*/` inside of a string but not a comment and similar, or that do not end with `*/` and has code directly following it etc.
