### PR TITLE
feat: use recast for extracting declared modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.19.0",
+    "@babel/types": "^7.19.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.18.9",
     "@babel/preset-env": "^7.19.0",
     "@microsoft/api-extractor": "^7.29.5",
@@ -77,6 +78,7 @@
     "pkg-up": "^3.1.0",
     "prettier": "^2.7.1",
     "pretty-bytes": "^5.6.0",
+    "recast": "^0.21.5",
     "rimraf": "^3.0.2",
     "rollup": "^2.78.1",
     "rollup-plugin-esbuild": "^4.9.3",

--- a/playground/ts/src/module1.ts
+++ b/playground/ts/src/module1.ts
@@ -16,14 +16,6 @@ declare module './module2' {
 
 // Note: dont remove these blocks, they test that we dont include them in the final bundle
 
-/**
- * declare module './module2' {
- *  interface TSDocsDummy {
- *    field: string
- *  }
- * }
- */
-
 /*
   declare module './module2' {
    interface BlockCommentDummy {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ importers:
       '@babel/core': ^7.19.0
       '@babel/plugin-proposal-object-rest-spread': ^7.18.9
       '@babel/preset-env': ^7.19.0
+      '@babel/types': ^7.19.0
       '@commitlint/cli': ^17.0.3
       '@commitlint/config-conventional': ^17.0.3
       '@microsoft/api-extractor': ^7.29.5
@@ -57,6 +58,7 @@ importers:
       pkg-up: ^3.1.0
       prettier: ^2.7.1
       pretty-bytes: ^5.6.0
+      recast: ^0.21.5
       rimraf: ^3.0.2
       rollup: ^2.78.1
       rollup-plugin-esbuild: ^4.9.3
@@ -71,13 +73,14 @@ importers:
       vitest: ^0.22.1
       zod: ^3.18.0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/plugin-proposal-object-rest-spread': 7.18.9_@babel+core@7.19.0
-      '@babel/preset-env': 7.19.0_@babel+core@7.19.0
+      '@babel/core': 7.20.2
+      '@babel/plugin-proposal-object-rest-spread': 7.20.2_@babel+core@7.20.2
+      '@babel/preset-env': 7.20.2_@babel+core@7.20.2
+      '@babel/types': 7.20.2
       '@microsoft/api-extractor': 7.29.5
       '@microsoft/tsdoc-config': 0.16.1
       '@rollup/plugin-alias': 3.1.9_rollup@2.78.1
-      '@rollup/plugin-babel': 5.3.1_yxkxvvbu4ixpw7pckvjfkqob6i
+      '@rollup/plugin-babel': 5.3.1_i5vxb67i64mnjmc4yzjkuahwuu
       '@rollup/plugin-commonjs': 22.0.2_rollup@2.78.1
       '@rollup/plugin-json': 4.1.0_rollup@2.78.1
       '@rollup/plugin-node-resolve': 13.3.0_rollup@2.78.1
@@ -95,6 +98,7 @@ importers:
       pkg-up: 3.1.0
       prettier: 2.7.1
       pretty-bytes: 5.6.0
+      recast: 0.21.5
       rimraf: 3.0.2
       rollup: 2.78.1
       rollup-plugin-esbuild: 4.9.3_75tz4fz3hdw34ihj4xz6ux6bmq
@@ -193,25 +197,25 @@ packages:
     dependencies:
       '@babel/highlight': 7.18.6
 
-  /@babel/compat-data/7.19.0:
-    resolution: {integrity: sha512-y5rqgTTPTmaF5e2nVhOxw+Ur9HDJLsWb6U/KpgUzRZEdPfE6VOubXBKLdbcUTijzRptednSBDQbYZBOSqJxpJw==}
+  /@babel/compat-data/7.20.1:
+    resolution: {integrity: sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==}
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/core/7.19.0:
-    resolution: {integrity: sha512-reM4+U7B9ss148rh2n1Qs9ASS+w94irYXga7c2jaQv9RVzpS7Mv1a9rnYYwuDa45G+DkORt9g6An2k/V4d9LbQ==}
+  /@babel/core/7.20.2:
+    resolution: {integrity: sha512-w7DbG8DtMrJcFOi4VrLm+8QM4az8Mo+PuLBKLp2zrYRCow8W/f9xiXm5sN53C8HksCyDQwCKha9JiDoIyPjT2g==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.19.0
-      '@babel/helper-compilation-targets': 7.19.0_@babel+core@7.19.0
-      '@babel/helper-module-transforms': 7.19.0
-      '@babel/helpers': 7.19.0
-      '@babel/parser': 7.19.0
+      '@babel/generator': 7.20.3
+      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.2
+      '@babel/helper-module-transforms': 7.20.2
+      '@babel/helpers': 7.20.1
+      '@babel/parser': 7.20.3
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.19.0
-      '@babel/types': 7.19.0
+      '@babel/traverse': 7.20.1
+      '@babel/types': 7.20.2
       convert-source-map: 1.8.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -221,11 +225,11 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/generator/7.19.0:
-    resolution: {integrity: sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==}
+  /@babel/generator/7.20.3:
+    resolution: {integrity: sha512-Wl5ilw2UD1+ZYprHVprxHZJCFeBWlzZYOovE4SDYLZnqCOD11j+0QzNeEWKLLTWM7nixrZEh7vNIyb76MyJg3A==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.20.2
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
     dev: false
@@ -234,7 +238,7 @@ packages:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.20.2
     dev: false
 
   /@babel/helper-builder-binary-assignment-operator-visitor/7.18.9:
@@ -242,59 +246,59 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.18.6
-      '@babel/types': 7.19.0
+      '@babel/types': 7.20.2
     dev: false
 
-  /@babel/helper-compilation-targets/7.19.0_@babel+core@7.19.0:
-    resolution: {integrity: sha512-Ai5bNWXIvwDvWM7njqsG3feMlL9hCVQsPYXodsZyLwshYkZVJt59Gftau4VrE8S9IT9asd2uSP1hG6wCNw+sXA==}
+  /@babel/helper-compilation-targets/7.20.0_@babel+core@7.20.2:
+    resolution: {integrity: sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.19.0
-      '@babel/core': 7.19.0
+      '@babel/compat-data': 7.20.1
+      '@babel/core': 7.20.2
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.3
       semver: 6.3.0
     dev: false
 
-  /@babel/helper-create-class-features-plugin/7.19.0_@babel+core@7.19.0:
+  /@babel/helper-create-class-features-plugin/7.19.0_@babel+core@7.20.2:
     resolution: {integrity: sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.19.0
+      '@babel/core': 7.20.2
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-member-expression-to-functions': 7.18.9
       '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.18.9
+      '@babel/helper-replace-supers': 7.19.1
       '@babel/helper-split-export-declaration': 7.18.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/helper-create-regexp-features-plugin/7.19.0_@babel+core@7.19.0:
+  /@babel/helper-create-regexp-features-plugin/7.19.0_@babel+core@7.20.2:
     resolution: {integrity: sha512-htnV+mHX32DF81amCDrwIDr8nrp1PTm+3wfBN9/v8QJOLEioOCOG7qNyq0nHeFiWbT3Eb7gsPwEmV64UCQ1jzw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.19.0
+      '@babel/core': 7.20.2
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.1.0
     dev: false
 
-  /@babel/helper-define-polyfill-provider/0.3.2_@babel+core@7.19.0:
-    resolution: {integrity: sha512-r9QJJ+uDWrd+94BSPcP6/de67ygLtvVy6cK4luE6MOuDsZIdoaPBnfSpbO/+LTifjPckbKXRuI9BB/Z2/y3iTg==}
+  /@babel/helper-define-polyfill-provider/0.3.3_@babel+core@7.20.2:
+    resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
     peerDependencies:
       '@babel/core': ^7.4.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-compilation-targets': 7.19.0_@babel+core@7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
       debug: 4.3.4
       lodash.debounce: 4.0.8
       resolve: 1.22.1
@@ -312,7 +316,7 @@ packages:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.20.2
     dev: false
 
   /@babel/helper-function-name/7.19.0:
@@ -320,42 +324,42 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.18.10
-      '@babel/types': 7.19.0
+      '@babel/types': 7.20.2
     dev: false
 
   /@babel/helper-hoist-variables/7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.20.2
     dev: false
 
   /@babel/helper-member-expression-to-functions/7.18.9:
     resolution: {integrity: sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.20.2
     dev: false
 
   /@babel/helper-module-imports/7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.20.2
     dev: false
 
-  /@babel/helper-module-transforms/7.19.0:
-    resolution: {integrity: sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==}
+  /@babel/helper-module-transforms/7.20.2:
+    resolution: {integrity: sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-simple-access': 7.18.6
+      '@babel/helper-simple-access': 7.20.2
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/helper-validator-identifier': 7.18.6
+      '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.19.0
-      '@babel/types': 7.19.0
+      '@babel/traverse': 7.20.1
+      '@babel/types': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -364,69 +368,69 @@ packages:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.20.2
     dev: false
 
-  /@babel/helper-plugin-utils/7.19.0:
-    resolution: {integrity: sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==}
+  /@babel/helper-plugin-utils/7.20.2:
+    resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/helper-remap-async-to-generator/7.18.9_@babel+core@7.19.0:
+  /@babel/helper-remap-async-to-generator/7.18.9_@babel+core@7.20.2:
     resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.19.0
+      '@babel/core': 7.20.2
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.19.0
-      '@babel/types': 7.19.0
+      '@babel/types': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/helper-replace-supers/7.18.9:
-    resolution: {integrity: sha512-dNsWibVI4lNT6HiuOIBr1oyxo40HvIVmbwPUm3XZ7wMh4k2WxrxTqZwSqw/eEmXDS9np0ey5M2bz9tBmO9c+YQ==}
+  /@babel/helper-replace-supers/7.19.1:
+    resolution: {integrity: sha512-T7ahH7wV0Hfs46SFh5Jz3s0B6+o8g3c+7TMxu7xKfmHikg7EAZ3I2Qk9LFhjxXq8sL7UkP5JflezNwoZa8WvWw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-member-expression-to-functions': 7.18.9
       '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/traverse': 7.19.0
-      '@babel/types': 7.19.0
+      '@babel/traverse': 7.20.1
+      '@babel/types': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/helper-simple-access/7.18.6:
-    resolution: {integrity: sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==}
+  /@babel/helper-simple-access/7.20.2:
+    resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.20.2
     dev: false
 
   /@babel/helper-skip-transparent-expression-wrappers/7.18.9:
     resolution: {integrity: sha512-imytd2gHi3cJPsybLRbmFrF7u5BIEuI2cNheyKi3/iOBC63kNn3q8Crn2xVuESli0aM4KYsyEqKyS7lFL8YVtw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.20.2
     dev: false
 
   /@babel/helper-split-export-declaration/7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.20.2
     dev: false
 
-  /@babel/helper-string-parser/7.18.10:
-    resolution: {integrity: sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==}
+  /@babel/helper-string-parser/7.19.4:
+    resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-validator-identifier/7.18.6:
-    resolution: {integrity: sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==}
+  /@babel/helper-validator-identifier/7.19.1:
+    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
     engines: {node: '>=6.9.0'}
 
   /@babel/helper-validator-option/7.18.6:
@@ -440,19 +444,19 @@ packages:
     dependencies:
       '@babel/helper-function-name': 7.19.0
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.19.0
-      '@babel/types': 7.19.0
+      '@babel/traverse': 7.20.1
+      '@babel/types': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/helpers/7.19.0:
-    resolution: {integrity: sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==}
+  /@babel/helpers/7.20.1:
+    resolution: {integrity: sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.19.0
-      '@babel/types': 7.19.0
+      '@babel/traverse': 7.20.1
+      '@babel/types': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -461,821 +465,818 @@ packages:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.18.6
+      '@babel/helper-validator-identifier': 7.19.1
       chalk: 2.4.2
       js-tokens: 4.0.0
 
-  /@babel/parser/7.19.0:
-    resolution: {integrity: sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw==}
+  /@babel/parser/7.20.3:
+    resolution: {integrity: sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.20.2
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.18.9_@babel+core@7.19.0:
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.18.9_@babel+core@7.20.2:
     resolution: {integrity: sha512-AHrP9jadvH7qlOj6PINbgSuphjQUAK7AOT7DPjBo9EHoLhQTnnK5u45e1Hd4DbSQEO9nqPWtQ89r+XEOWFScKg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
-      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.19.0
+      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.20.2
     dev: false
 
-  /@babel/plugin-proposal-async-generator-functions/7.19.0_@babel+core@7.19.0:
-    resolution: {integrity: sha512-nhEByMUTx3uZueJ/QkJuSlCfN4FGg+xy+vRsfGQGzSauq5ks2Deid2+05Q3KhfaUjvec1IGhw/Zm3cFm8JigTQ==}
+  /@babel/plugin-proposal-async-generator-functions/7.20.1_@babel+core@7.20.2:
+    resolution: {integrity: sha512-Gh5rchzSwE4kC+o/6T8waD0WHEQIsDmjltY8WnWRXHUdH8axZhuH86Ov9M72YhJfDrZseQwuuWaaIT/TmePp3g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
+      '@babel/core': 7.20.2
       '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/helper-remap-async-to-generator': 7.18.9_@babel+core@7.19.0
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.19.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-remap-async-to-generator': 7.18.9_@babel+core@7.20.2
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-proposal-class-properties/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-proposal-class-properties/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-proposal-class-static-block/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-proposal-class-static-block/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-+I3oIiNxrCpup3Gi8n5IGMwj0gOCAjcJUSQEcotNnCCPMEnixawOQ+KeJPlgfjzx+FKQ1QSyZOWe7wmoJp7vhw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-proposal-dynamic-import/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-proposal-dynamic-import/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.20.2
     dev: false
 
-  /@babel/plugin-proposal-export-namespace-from/7.18.9_@babel+core@7.19.0:
+  /@babel/plugin-proposal-export-namespace-from/7.18.9_@babel+core@7.20.2:
     resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.20.2
     dev: false
 
-  /@babel/plugin-proposal-json-strings/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-proposal-json-strings/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.20.2
     dev: false
 
-  /@babel/plugin-proposal-logical-assignment-operators/7.18.9_@babel+core@7.19.0:
+  /@babel/plugin-proposal-logical-assignment-operators/7.18.9_@babel+core@7.20.2:
     resolution: {integrity: sha512-128YbMpjCrP35IOExw2Fq+x55LMP42DzhOhX2aNNIdI9avSWl2PI0yuBWarr3RYpZBSPtabfadkH2yeRiMD61Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.20.2
     dev: false
 
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.20.2
     dev: false
 
-  /@babel/plugin-proposal-numeric-separator/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-proposal-numeric-separator/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.20.2
     dev: false
 
-  /@babel/plugin-proposal-object-rest-spread/7.18.9_@babel+core@7.19.0:
-    resolution: {integrity: sha512-kDDHQ5rflIeY5xl69CEqGEZ0KY369ehsCIEbTGb4siHG5BE9sga/T0r0OUwyZNLMmZE79E1kbsqAjwFCW4ds6Q==}
+  /@babel/plugin-proposal-object-rest-spread/7.20.2_@babel+core@7.20.2:
+    resolution: {integrity: sha512-Ks6uej9WFK+fvIMesSqbAto5dD8Dz4VuuFvGJFKgIGSkJuRGcrwGECPA1fDgQK3/DbExBJpEkTeYeB8geIFCSQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.19.0
-      '@babel/core': 7.19.0
-      '@babel/helper-compilation-targets': 7.19.0_@babel+core@7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.19.0
-      '@babel/plugin-transform-parameters': 7.18.8_@babel+core@7.19.0
+      '@babel/compat-data': 7.20.1
+      '@babel/core': 7.20.2
+      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.20.2
+      '@babel/plugin-transform-parameters': 7.20.3_@babel+core@7.20.2
     dev: false
 
-  /@babel/plugin-proposal-optional-catch-binding/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-proposal-optional-catch-binding/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.20.2
     dev: false
 
-  /@babel/plugin-proposal-optional-chaining/7.18.9_@babel+core@7.19.0:
+  /@babel/plugin-proposal-optional-chaining/7.18.9_@babel+core@7.20.2:
     resolution: {integrity: sha512-v5nwt4IqBXihxGsW2QmCWMDS3B3bzGIk/EQVZz2ei7f3NJl8NzAJVvUmpDW5q1CRNY+Beb/k58UAH1Km1N411w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.19.0
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.20.2
     dev: false
 
-  /@babel/plugin-proposal-private-methods/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-proposal-private-methods/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-proposal-private-property-in-object/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-proposal-private-property-in-object/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-9Rysx7FOctvT5ouj5JODjAFAkgGoudQuLPamZb0v1TGLpapdNaftzifU8NTWQm0IRjqoYypdrSmyWgkocDQ8Dw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
+      '@babel/core': 7.20.2
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.19.0
+      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-proposal-unicode-property-regex/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-proposal-unicode-property-regex/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
     engines: {node: '>=4'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.19.0:
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.20.2:
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.19.0:
+  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.20.2:
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.19.0:
+  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.20.2:
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.19.0:
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.20.2:
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.19.0:
+  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.20.2:
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-import-assertions/7.18.6_@babel+core@7.19.0:
-    resolution: {integrity: sha512-/DU3RXad9+bZwrgWJQKbr39gYbJpLJHezqEzRzi/BHRlJ9zsQb4CK2CA/5apllXNomwA1qHwzvHl+AdEmC5krQ==}
+  /@babel/plugin-syntax-import-assertions/7.20.0_@babel+core@7.20.2:
+    resolution: {integrity: sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.19.0:
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.20.2:
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.19.0:
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.20.2:
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.19.0:
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.20.2:
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.19.0:
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.20.2:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.19.0:
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.20.2:
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.19.0:
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.20.2:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.19.0:
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.20.2:
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.19.0:
+  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.20.2:
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.19.0:
+  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.20.2:
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-arrow-functions/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-transform-arrow-functions/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-9S9X9RUefzrsHZmKMbDXxweEH+YlE8JJEuat9FdvW9Qh1cw7W64jELCtWNkPBPX5En45uy28KGvA/AySqUh8CQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-async-to-generator/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-transform-async-to-generator/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-ARE5wZLKnTgPW7/1ftQmSi1CmkqqHo2DNmtztFhvgtOWSDfq0Cq9/9L+KnZNYSNrydBekhW3rwShduf59RoXag==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
+      '@babel/core': 7.20.2
       '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/helper-remap-async-to-generator': 7.18.9_@babel+core@7.19.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-remap-async-to-generator': 7.18.9_@babel+core@7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-block-scoped-functions/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-transform-block-scoped-functions/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-block-scoping/7.18.9_@babel+core@7.19.0:
-    resolution: {integrity: sha512-5sDIJRV1KtQVEbt/EIBwGy4T01uYIo4KRB3VUqzkhrAIOGx7AoctL9+Ux88btY0zXdDyPJ9mW+bg+v+XEkGmtw==}
+  /@babel/plugin-transform-block-scoping/7.20.2_@babel+core@7.20.2:
+    resolution: {integrity: sha512-y5V15+04ry69OV2wULmwhEA6jwSWXO1TwAtIwiPXcvHcoOQUqpyMVd2bDsQJMW8AurjulIyUV8kDqtjSwHy1uQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-classes/7.19.0_@babel+core@7.19.0:
-    resolution: {integrity: sha512-YfeEE9kCjqTS9IitkgfJuxjcEtLUHMqa8yUJ6zdz8vR7hKuo6mOy2C05P0F1tdMmDCeuyidKnlrw/iTppHcr2A==}
+  /@babel/plugin-transform-classes/7.20.2_@babel+core@7.20.2:
+    resolution: {integrity: sha512-9rbPp0lCVVoagvtEyQKSo5L8oo0nQS/iif+lwlAz29MccX2642vWDlSZK+2T2buxbopotId2ld7zZAzRfz9j1g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
+      '@babel/core': 7.20.2
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.19.0_@babel+core@7.19.0
+      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.2
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/helper-replace-supers': 7.18.9
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-replace-supers': 7.19.1
       '@babel/helper-split-export-declaration': 7.18.6
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-computed-properties/7.18.9_@babel+core@7.19.0:
+  /@babel/plugin-transform-computed-properties/7.18.9_@babel+core@7.20.2:
     resolution: {integrity: sha512-+i0ZU1bCDymKakLxn5srGHrsAPRELC2WIbzwjLhHW9SIE1cPYkLCL0NlnXMZaM1vhfgA2+M7hySk42VBvrkBRw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-destructuring/7.18.13_@babel+core@7.19.0:
-    resolution: {integrity: sha512-TodpQ29XekIsex2A+YJPj5ax2plkGa8YYY6mFjCohk/IG9IY42Rtuj1FuDeemfg2ipxIFLzPeA83SIBnlhSIow==}
+  /@babel/plugin-transform-destructuring/7.20.2_@babel+core@7.20.2:
+    resolution: {integrity: sha512-mENM+ZHrvEgxLTBXUiQ621rRXZes3KWUv6NdQlrnr1TkWVw+hUjQBZuP2X32qKlrlG2BzgR95gkuCRSkJl8vIw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-dotall-regex/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-transform-dotall-regex/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-duplicate-keys/7.18.9_@babel+core@7.19.0:
+  /@babel/plugin-transform-duplicate-keys/7.18.9_@babel+core@7.20.2:
     resolution: {integrity: sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-exponentiation-operator/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-transform-exponentiation-operator/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
+      '@babel/core': 7.20.2
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-for-of/7.18.8_@babel+core@7.19.0:
+  /@babel/plugin-transform-for-of/7.18.8_@babel+core@7.20.2:
     resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-function-name/7.18.9_@babel+core@7.19.0:
+  /@babel/plugin-transform-function-name/7.18.9_@babel+core@7.20.2:
     resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-compilation-targets': 7.19.0_@babel+core@7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.2
       '@babel/helper-function-name': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-literals/7.18.9_@babel+core@7.19.0:
+  /@babel/plugin-transform-literals/7.18.9_@babel+core@7.20.2:
     resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-member-expression-literals/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-transform-member-expression-literals/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-modules-amd/7.18.6_@babel+core@7.19.0:
-    resolution: {integrity: sha512-Pra5aXsmTsOnjM3IajS8rTaLCy++nGM4v3YR4esk5PCsyg9z8NA5oQLwxzMUtDBd8F+UmVza3VxoAaWCbzH1rg==}
+  /@babel/plugin-transform-modules-amd/7.19.6_@babel+core@7.20.2:
+    resolution: {integrity: sha512-uG3od2mXvAtIFQIh0xrpLH6r5fpSQN04gIVovl+ODLdUMANokxQLZnPBHcjmv3GxRjnqwLuHvppjjcelqUFZvg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-module-transforms': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
-      babel-plugin-dynamic-import-node: 2.3.3
+      '@babel/core': 7.20.2
+      '@babel/helper-module-transforms': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-modules-commonjs/7.18.6_@babel+core@7.19.0:
-    resolution: {integrity: sha512-Qfv2ZOWikpvmedXQJDSbxNqy7Xr/j2Y8/KfijM0iJyKkBTmWuvCA1yeH1yDM7NJhBW/2aXxeucLj6i80/LAJ/Q==}
+  /@babel/plugin-transform-modules-commonjs/7.19.6_@babel+core@7.20.2:
+    resolution: {integrity: sha512-8PIa1ym4XRTKuSsOUXqDG0YaOlEuTVvHMe5JCfgBMOtHvJKw/4NGovEGN33viISshG/rZNVrACiBmPQLvWN8xQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-module-transforms': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/helper-simple-access': 7.18.6
-      babel-plugin-dynamic-import-node: 2.3.3
+      '@babel/core': 7.20.2
+      '@babel/helper-module-transforms': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-simple-access': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-modules-systemjs/7.19.0_@babel+core@7.19.0:
-    resolution: {integrity: sha512-x9aiR0WXAWmOWsqcsnrzGR+ieaTMVyGyffPVA7F8cXAGt/UxefYv6uSHZLkAFChN5M5Iy1+wjE+xJuPt22H39A==}
+  /@babel/plugin-transform-modules-systemjs/7.19.6_@babel+core@7.20.2:
+    resolution: {integrity: sha512-fqGLBepcc3kErfR9R3DnVpURmckXP7gj7bAlrTQyBxrigFqszZCkFkcoxzCp2v32XmwXLvbw+8Yq9/b+QqksjQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
+      '@babel/core': 7.20.2
       '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-module-transforms': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/helper-validator-identifier': 7.18.6
-      babel-plugin-dynamic-import-node: 2.3.3
+      '@babel/helper-module-transforms': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-identifier': 7.19.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-modules-umd/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-transform-modules-umd/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-module-transforms': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-module-transforms': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-named-capturing-groups-regex/7.19.0_@babel+core@7.19.0:
-    resolution: {integrity: sha512-HDSuqOQzkU//kfGdiHBt71/hkDTApw4U/cMVgKgX7PqfB3LOaK+2GtCEsBu1dL9CkswDm0Gwehht1dCr421ULQ==}
+  /@babel/plugin-transform-named-capturing-groups-regex/7.19.1_@babel+core@7.20.2:
+    resolution: {integrity: sha512-oWk9l9WItWBQYS4FgXD4Uyy5kq898lvkXpXQxoJEY1RnvPk4R/Dvu2ebXU9q8lP+rlMwUQTFf2Ok6d78ODa0kw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-new-target/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-transform-new-target/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-object-super/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-transform-object-super/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/helper-replace-supers': 7.18.9
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-replace-supers': 7.19.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-parameters/7.18.8_@babel+core@7.19.0:
-    resolution: {integrity: sha512-ivfbE3X2Ss+Fj8nnXvKJS6sjRG4gzwPMsP+taZC+ZzEGjAYlvENixmt1sZ5Ca6tWls+BlKSGKPJ6OOXvXCbkFg==}
+  /@babel/plugin-transform-parameters/7.20.3_@babel+core@7.20.2:
+    resolution: {integrity: sha512-oZg/Fpx0YDrj13KsLyO8I/CX3Zdw7z0O9qOd95SqcoIzuqy/WTGWvePeHAnZCN54SfdyjHcb1S30gc8zlzlHcA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-property-literals/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-transform-property-literals/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-regenerator/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-transform-regenerator/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-poqRI2+qiSdeldcz4wTSTXBRryoq3Gc70ye7m7UD5Ww0nE29IXqMl6r7Nd15WBgRd74vloEMlShtH6CKxVzfmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
       regenerator-transform: 0.15.0
     dev: false
 
-  /@babel/plugin-transform-reserved-words/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-transform-reserved-words/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-shorthand-properties/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-transform-shorthand-properties/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-spread/7.19.0_@babel+core@7.19.0:
+  /@babel/plugin-transform-spread/7.19.0_@babel+core@7.20.2:
     resolution: {integrity: sha512-RsuMk7j6n+r752EtzyScnWkQyuJdli6LdO5Klv8Yx0OfPVTcQkIUfS8clx5e9yHXzlnhOZF3CbQ8C2uP5j074w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
     dev: false
 
-  /@babel/plugin-transform-sticky-regex/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-transform-sticky-regex/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-template-literals/7.18.9_@babel+core@7.19.0:
+  /@babel/plugin-transform-template-literals/7.18.9_@babel+core@7.20.2:
     resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-typeof-symbol/7.18.9_@babel+core@7.19.0:
+  /@babel/plugin-transform-typeof-symbol/7.18.9_@babel+core@7.20.2:
     resolution: {integrity: sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-unicode-escapes/7.18.10_@babel+core@7.19.0:
+  /@babel/plugin-transform-unicode-escapes/7.18.10_@babel+core@7.20.2:
     resolution: {integrity: sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-unicode-regex/7.18.6_@babel+core@7.19.0:
+  /@babel/plugin-transform-unicode-regex/7.18.6_@babel+core@7.20.2:
     resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/preset-env/7.19.0_@babel+core@7.19.0:
-    resolution: {integrity: sha512-1YUju1TAFuzjIQqNM9WsF4U6VbD/8t3wEAlw3LFYuuEr+ywqLRcSXxFKz4DCEj+sN94l/XTDiUXYRrsvMpz9WQ==}
+  /@babel/preset-env/7.20.2_@babel+core@7.20.2:
+    resolution: {integrity: sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.19.0
-      '@babel/core': 7.19.0
-      '@babel/helper-compilation-targets': 7.19.0_@babel+core@7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/compat-data': 7.20.1
+      '@babel/core': 7.20.2
+      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-validator-option': 7.18.6
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.18.9_@babel+core@7.19.0
-      '@babel/plugin-proposal-async-generator-functions': 7.19.0_@babel+core@7.19.0
-      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-proposal-class-static-block': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-proposal-dynamic-import': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-proposal-export-namespace-from': 7.18.9_@babel+core@7.19.0
-      '@babel/plugin-proposal-json-strings': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-proposal-logical-assignment-operators': 7.18.9_@babel+core@7.19.0
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-proposal-object-rest-spread': 7.18.9_@babel+core@7.19.0
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.19.0
-      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-proposal-private-property-in-object': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.19.0
-      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.19.0
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.19.0
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.19.0
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.19.0
-      '@babel/plugin-syntax-import-assertions': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.19.0
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.19.0
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.19.0
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.19.0
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.19.0
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.19.0
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.19.0
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.19.0
-      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.19.0
-      '@babel/plugin-transform-arrow-functions': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-async-to-generator': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-block-scoping': 7.18.9_@babel+core@7.19.0
-      '@babel/plugin-transform-classes': 7.19.0_@babel+core@7.19.0
-      '@babel/plugin-transform-computed-properties': 7.18.9_@babel+core@7.19.0
-      '@babel/plugin-transform-destructuring': 7.18.13_@babel+core@7.19.0
-      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-duplicate-keys': 7.18.9_@babel+core@7.19.0
-      '@babel/plugin-transform-exponentiation-operator': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-for-of': 7.18.8_@babel+core@7.19.0
-      '@babel/plugin-transform-function-name': 7.18.9_@babel+core@7.19.0
-      '@babel/plugin-transform-literals': 7.18.9_@babel+core@7.19.0
-      '@babel/plugin-transform-member-expression-literals': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-modules-amd': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-modules-commonjs': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-modules-systemjs': 7.19.0_@babel+core@7.19.0
-      '@babel/plugin-transform-modules-umd': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.19.0_@babel+core@7.19.0
-      '@babel/plugin-transform-new-target': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-object-super': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-parameters': 7.18.8_@babel+core@7.19.0
-      '@babel/plugin-transform-property-literals': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-regenerator': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-reserved-words': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-spread': 7.19.0_@babel+core@7.19.0
-      '@babel/plugin-transform-sticky-regex': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.19.0
-      '@babel/plugin-transform-typeof-symbol': 7.18.9_@babel+core@7.19.0
-      '@babel/plugin-transform-unicode-escapes': 7.18.10_@babel+core@7.19.0
-      '@babel/plugin-transform-unicode-regex': 7.18.6_@babel+core@7.19.0
-      '@babel/preset-modules': 0.1.5_@babel+core@7.19.0
-      '@babel/types': 7.19.0
-      babel-plugin-polyfill-corejs2: 0.3.2_@babel+core@7.19.0
-      babel-plugin-polyfill-corejs3: 0.5.3_@babel+core@7.19.0
-      babel-plugin-polyfill-regenerator: 0.4.0_@babel+core@7.19.0
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.18.9_@babel+core@7.20.2
+      '@babel/plugin-proposal-async-generator-functions': 7.20.1_@babel+core@7.20.2
+      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-proposal-class-static-block': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-proposal-dynamic-import': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-proposal-export-namespace-from': 7.18.9_@babel+core@7.20.2
+      '@babel/plugin-proposal-json-strings': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-proposal-logical-assignment-operators': 7.18.9_@babel+core@7.20.2
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-proposal-object-rest-spread': 7.20.2_@babel+core@7.20.2
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.20.2
+      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-proposal-private-property-in-object': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.20.2
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.20.2
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.20.2
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.20.2
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.20.2
+      '@babel/plugin-syntax-import-assertions': 7.20.0_@babel+core@7.20.2
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.20.2
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.20.2
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.20.2
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.20.2
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.20.2
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.20.2
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.20.2
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.20.2
+      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.20.2
+      '@babel/plugin-transform-arrow-functions': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-transform-async-to-generator': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-transform-block-scoping': 7.20.2_@babel+core@7.20.2
+      '@babel/plugin-transform-classes': 7.20.2_@babel+core@7.20.2
+      '@babel/plugin-transform-computed-properties': 7.18.9_@babel+core@7.20.2
+      '@babel/plugin-transform-destructuring': 7.20.2_@babel+core@7.20.2
+      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-transform-duplicate-keys': 7.18.9_@babel+core@7.20.2
+      '@babel/plugin-transform-exponentiation-operator': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-transform-for-of': 7.18.8_@babel+core@7.20.2
+      '@babel/plugin-transform-function-name': 7.18.9_@babel+core@7.20.2
+      '@babel/plugin-transform-literals': 7.18.9_@babel+core@7.20.2
+      '@babel/plugin-transform-member-expression-literals': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-transform-modules-amd': 7.19.6_@babel+core@7.20.2
+      '@babel/plugin-transform-modules-commonjs': 7.19.6_@babel+core@7.20.2
+      '@babel/plugin-transform-modules-systemjs': 7.19.6_@babel+core@7.20.2
+      '@babel/plugin-transform-modules-umd': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.19.1_@babel+core@7.20.2
+      '@babel/plugin-transform-new-target': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-transform-object-super': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-transform-parameters': 7.20.3_@babel+core@7.20.2
+      '@babel/plugin-transform-property-literals': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-transform-regenerator': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-transform-reserved-words': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-transform-spread': 7.19.0_@babel+core@7.20.2
+      '@babel/plugin-transform-sticky-regex': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.20.2
+      '@babel/plugin-transform-typeof-symbol': 7.18.9_@babel+core@7.20.2
+      '@babel/plugin-transform-unicode-escapes': 7.18.10_@babel+core@7.20.2
+      '@babel/plugin-transform-unicode-regex': 7.18.6_@babel+core@7.20.2
+      '@babel/preset-modules': 0.1.5_@babel+core@7.20.2
+      '@babel/types': 7.20.2
+      babel-plugin-polyfill-corejs2: 0.3.3_@babel+core@7.20.2
+      babel-plugin-polyfill-corejs3: 0.6.0_@babel+core@7.20.2
+      babel-plugin-polyfill-regenerator: 0.4.1_@babel+core@7.20.2
       core-js-compat: 3.25.1
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/preset-modules/0.1.5_@babel+core@7.19.0:
+  /@babel/preset-modules/0.1.5_@babel+core@7.20.2:
     resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.19.0
-      '@babel/types': 7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.20.2
+      '@babel/types': 7.20.2
       esutils: 2.0.3
     dev: false
 
@@ -1291,34 +1292,34 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.19.0
-      '@babel/types': 7.19.0
+      '@babel/parser': 7.20.3
+      '@babel/types': 7.20.2
     dev: false
 
-  /@babel/traverse/7.19.0:
-    resolution: {integrity: sha512-4pKpFRDh+utd2mbRC8JLnlsMUii3PMHjpL6a0SZ4NMZy7YFP9aXORxEhdMVOc9CpWtDF09IkciQLEhK7Ml7gRA==}
+  /@babel/traverse/7.20.1:
+    resolution: {integrity: sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.19.0
+      '@babel/generator': 7.20.3
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.19.0
-      '@babel/types': 7.19.0
+      '@babel/parser': 7.20.3
+      '@babel/types': 7.20.2
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/types/7.19.0:
-    resolution: {integrity: sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==}
+  /@babel/types/7.20.2:
+    resolution: {integrity: sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-string-parser': 7.18.10
-      '@babel/helper-validator-identifier': 7.18.6
+      '@babel/helper-string-parser': 7.19.4
+      '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
 
   /@colors/colors/1.5.0:
@@ -1900,7 +1901,7 @@ packages:
       slash: 3.0.0
     dev: false
 
-  /@rollup/plugin-babel/5.3.1_yxkxvvbu4ixpw7pckvjfkqob6i:
+  /@rollup/plugin-babel/5.3.1_i5vxb67i64mnjmc4yzjkuahwuu:
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -1911,7 +1912,7 @@ packages:
       '@types/babel__core':
         optional: true
     dependencies:
-      '@babel/core': 7.19.0
+      '@babel/core': 7.20.2
       '@babel/helper-module-imports': 7.18.6
       '@rollup/pluginutils': 3.1.0_rollup@2.78.1
       '@types/babel__core': 7.1.19
@@ -2209,8 +2210,8 @@ packages:
   /@types/babel__core/7.1.19:
     resolution: {integrity: sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==}
     dependencies:
-      '@babel/parser': 7.19.0
-      '@babel/types': 7.19.0
+      '@babel/parser': 7.20.3
+      '@babel/types': 7.20.2
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.18.1
@@ -2218,18 +2219,18 @@ packages:
   /@types/babel__generator/7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.20.2
 
   /@types/babel__template/7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.19.0
-      '@babel/types': 7.19.0
+      '@babel/parser': 7.20.3
+      '@babel/types': 7.20.2
 
   /@types/babel__traverse/7.18.1:
     resolution: {integrity: sha512-FSdLaZh2UxaMuLp9lixWaHq/golWTRWOnRsAXzDTDSDOQLuZb1nsdCt6pJSPWSEQt2eFZ2YVk3oYhn+1kLMeMA==}
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.20.2
 
   /@types/chai-subset/1.3.3:
     resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
@@ -2763,6 +2764,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /ast-types/0.15.2:
+    resolution: {integrity: sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==}
+    engines: {node: '>=4'}
+    dependencies:
+      tslib: 2.4.0
+    dev: false
+
   /astral-regex/2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
@@ -2789,44 +2797,38 @@ packages:
     hasBin: true
     dev: true
 
-  /babel-plugin-dynamic-import-node/2.3.3:
-    resolution: {integrity: sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==}
-    dependencies:
-      object.assign: 4.1.4
-    dev: false
-
-  /babel-plugin-polyfill-corejs2/0.3.2_@babel+core@7.19.0:
-    resolution: {integrity: sha512-LPnodUl3lS0/4wN3Rb+m+UK8s7lj2jcLRrjho4gLw+OJs+I4bvGXshINesY5xx/apM+biTnQ9reDI8yj+0M5+Q==}
+  /babel-plugin-polyfill-corejs2/0.3.3_@babel+core@7.20.2:
+    resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.19.0
-      '@babel/core': 7.19.0
-      '@babel/helper-define-polyfill-provider': 0.3.2_@babel+core@7.19.0
+      '@babel/compat-data': 7.20.1
+      '@babel/core': 7.20.2
+      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.2
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /babel-plugin-polyfill-corejs3/0.5.3_@babel+core@7.19.0:
-    resolution: {integrity: sha512-zKsXDh0XjnrUEW0mxIHLfjBfnXSMr5Q/goMe/fxpQnLm07mcOZiIZHBNWCMx60HmdvjxfXcalac0tfFg0wqxyw==}
+  /babel-plugin-polyfill-corejs3/0.6.0_@babel+core@7.20.2:
+    resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-define-polyfill-provider': 0.3.2_@babel+core@7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.2
       core-js-compat: 3.25.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /babel-plugin-polyfill-regenerator/0.4.0_@babel+core@7.19.0:
-    resolution: {integrity: sha512-RW1cnryiADFeHmfLS+WW/G431p1PsW5qdRdz0SDRi7TKcUgc7Oh/uXkT7MZ/+tGsT1BkczEAmD5XjUyJ5SWDTw==}
+  /babel-plugin-polyfill-regenerator/0.4.1_@babel+core@7.20.2:
+    resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.19.0
-      '@babel/helper-define-polyfill-provider': 0.3.2_@babel+core@7.19.0
+      '@babel/core': 7.20.2
+      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -3092,6 +3094,7 @@ packages:
     dependencies:
       function-bind: 1.1.1
       get-intrinsic: 1.1.2
+    dev: true
 
   /callsites/3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -3819,6 +3822,7 @@ packages:
     dependencies:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
+    dev: true
 
   /define-property/0.2.5:
     resolution: {integrity: sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==}
@@ -4743,7 +4747,6 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /esquery/1.4.0:
     resolution: {integrity: sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==}
@@ -5243,6 +5246,7 @@ packages:
       function-bind: 1.1.1
       has: 1.0.3
       has-symbols: 1.0.3
+    dev: true
 
   /get-stream/3.0.0:
     resolution: {integrity: sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==}
@@ -5438,10 +5442,12 @@ packages:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
     dependencies:
       get-intrinsic: 1.1.2
+    dev: true
 
   /has-symbols/1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
     engines: {node: '>= 0.4'}
+    dev: true
 
   /has-tostringtag/1.0.0:
     resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
@@ -7047,6 +7053,7 @@ packages:
   /object-keys/1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
+    dev: true
 
   /object-visit/1.0.1:
     resolution: {integrity: sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==}
@@ -7063,6 +7070,7 @@ packages:
       define-properties: 1.1.4
       has-symbols: 1.0.3
       object-keys: 1.1.1
+    dev: true
 
   /object.omit/2.0.1:
     resolution: {integrity: sha512-UiAM5mhmIuKLsOvrL+B0U2d1hXHF3bFYWIuH1LMpuV2EJEHG1Ntz06PgLEHjm6VFd87NpH8rastvPoyv6UW2fA==}
@@ -7701,6 +7709,16 @@ packages:
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.1
+
+  /recast/0.21.5:
+    resolution: {integrity: sha512-hjMmLaUXAm1hIuTqOdeYObMslq/q+Xff6QE3Y2P+uoHAg2nmVlLBps2hzh1UJDdMtDTMXOFewK6ky51JQIeECg==}
+    engines: {node: '>= 4'}
+    dependencies:
+      ast-types: 0.15.2
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tslib: 2.4.0
+    dev: false
 
   /redent/3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}

--- a/src/node/_tasks/dts/_doExtract.ts
+++ b/src/node/_tasks/dts/_doExtract.ts
@@ -4,7 +4,6 @@ import {ExtractorMessage} from '@microsoft/api-extractor'
 import rimrafCallback from 'rimraf'
 import {_BuildContext} from '../../_core'
 import {_buildTypes} from './_buildTypes'
-import {_appendModuleBlocks} from './_declareModuleFix'
 import {_DtsError} from './_DtsError'
 import {_extractTypes} from './_extractTypes'
 import {_DtsResult, _DtsTask, _DtsWatchTask} from './_types'
@@ -52,20 +51,15 @@ export async function _doExtract(
     const result = await _extractTypes({
       customTags: config?.extract?.customTags,
       cwd,
+      distPath: outDir,
       exportPath,
       files,
       filePath: filePath,
       projectPath: cwd,
       rules: config?.extract?.rules,
       sourceTypesPath: sourceTypesPath,
+      tmpPath,
       tsconfigPath: path.resolve(cwd, ts.configPath || 'tsconfig.json'),
-      distPath: outDir,
-    })
-
-    await _appendModuleBlocks({
-      tsOutDir: tmpPath,
-      extractResult: result.extractorResult,
-      extractTypesOutFile: path.resolve(outDir, targetPath),
     })
 
     messages.push(...result.messages)

--- a/src/node/_tasks/dts/_extractModuleBlocks.ts
+++ b/src/node/_tasks/dts/_extractModuleBlocks.ts
@@ -1,4 +1,3 @@
-import fs from 'fs/promises'
 import type {File} from '@babel/types'
 import {ExtractorResult} from '@microsoft/api-extractor'
 import {parse, print} from 'recast'
@@ -6,35 +5,18 @@ import typeScriptParser from 'recast/parsers/typescript'
 import {Program} from 'typescript'
 
 /**
- * '@microsoft/api-extractor' omits declare module blocks
- * This is a workaround that finds all module blocks in ts files and appends them to the result
- */
-export async function _appendModuleBlocks({
-  tsOutDir,
-  extractResult,
-  extractTypesOutFile,
-}: {
-  tsOutDir: string
-  extractResult: ExtractorResult
-  extractTypesOutFile: string
-}): Promise<void> {
-  const moduleBlocks = await _extractModuleBlocksFromTypes({tsOutDir, extractResult})
-
-  if (moduleBlocks.length) {
-    await fs.appendFile(extractTypesOutFile, '\n' + moduleBlocks.join('\n\n'))
-  }
-}
-
-async function _extractModuleBlocksFromTypes({
+ * A workaround to find all module blocks in extract TS files.
+ * @internal
+ * */
+export async function _extractModuleBlocksFromTypes({
   tsOutDir,
   extractResult,
 }: {
   tsOutDir: string
   extractResult: ExtractorResult
 }): Promise<string[]> {
-  const moduleBlocks: string[] = []
-
   const program = extractResult.compilerState.program as Program
+  const moduleBlocks: string[] = []
 
   // all program files, including node_modules
   const allProgramFiles = [...program.getSourceFiles()]
@@ -51,6 +33,7 @@ async function _extractModuleBlocksFromTypes({
   return moduleBlocks
 }
 
+/** @internal */
 export function _extractModuleBlocks(fileContent: string): string[] {
   const ast = parse(fileContent, {
     parser: typeScriptParser,

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -199,9 +199,10 @@ export declare const VERSION = '1.0.0'
 export {}
 
 declare module './module2' {
-    interface IncludedModuleDummy {
-        addedField: string;
-    }
+  interface IncludedModuleDummy {
+    addedField: string
+  }
 }
-//# sourceMappingURL=module1.d.ts.map"
+//# sourceMappingURL=module1.d.ts.map
+"
 `;

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -90,15 +90,12 @@ exports[`should build \`multi-export\` package 1`] = `
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-
 function defineConfig(options) {
   return options;
 }
-
 function definePlugin(plugin) {
   return plugin;
 }
-
 exports.defineConfig = defineConfig;
 exports.definePlugin = definePlugin;
 //# sourceMappingURL=index.cjs.map
@@ -109,11 +106,9 @@ exports[`should build \`multi-export\` package 2`] = `
 "function defineConfig(options) {
   return options;
 }
-
 function definePlugin(plugin) {
   return plugin;
 }
-
 export { defineConfig, definePlugin };
 //# sourceMappingURL=index.js.map
 "
@@ -147,15 +142,12 @@ exports[`should build \`multi-export\` package 4`] = `
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-
 var multiExport = require('multi-export');
-
 function plugin() {
   return multiExport.definePlugin({
     name: \\"plugin\\"
   });
 }
-
 exports.plugin = plugin;
 //# sourceMappingURL=plugin.cjs.map
 "
@@ -163,13 +155,11 @@ exports.plugin = plugin;
 
 exports[`should build \`multi-export\` package 5`] = `
 "import { definePlugin } from 'multi-export';
-
 function plugin() {
   return definePlugin({
     name: \\"plugin\\"
   });
 }
-
 export { plugin };
 //# sourceMappingURL=plugin.js.map
 "
@@ -212,5 +202,6 @@ declare module './module2' {
     interface IncludedModuleDummy {
         addedField: string;
     }
-}"
+}
+//# sourceMappingURL=module1.d.ts.map"
 `;

--- a/test/_extractModuleBlocks.test.ts
+++ b/test/_extractModuleBlocks.test.ts
@@ -1,6 +1,6 @@
 import outdent from 'outdent'
 import {expect, test} from 'vitest'
-import {_extractModuleBlocks} from '../src/node/_tasks/dts/_declareModuleFix'
+import {_extractModuleBlocks} from '../src/node/_tasks/dts/_extractModuleBlocks'
 
 test('extract module block', () => {
   const blocks = _extractModuleBlocks(

--- a/test/_extractModuleBlocks.test.ts
+++ b/test/_extractModuleBlocks.test.ts
@@ -4,7 +4,7 @@ import {_extractModuleBlocks} from '../src/node/_tasks/dts/_declareModuleFix'
 
 test('extract module block', () => {
   const blocks = _extractModuleBlocks(
-    outdent`
+    `
     interface A {}
 
     declare module X {
@@ -18,12 +18,14 @@ test('extract module block', () => {
 
       /** @public */
       declare module TT {
+        /** @public */
         interface X {
             x: string
         }
       }
 
       declare module YY {
+        /** @internal */
         interface Y {
             y: string
         }
@@ -47,7 +49,7 @@ test('extract module block', () => {
         a: string
       }
      }
-        * /
+        */
   `
   )
 
@@ -55,13 +57,18 @@ test('extract module block', () => {
 
   expect(blocks[0]).toEqual(outdent`
     declare module X {
+      /**
+       * @beta
+       **/
       interface A {
           a: string
       }
     }`)
 
   expect(blocks[1]).toEqual(outdent`
+    /** @public */
     declare module TT {
+      /** @public */
       interface X {
           x: string
       }
@@ -69,6 +76,7 @@ test('extract module block', () => {
 
   expect(blocks[2]).toEqual(outdent`
     declare module YY {
+      /** @internal */
       interface Y {
           y: string
       }


### PR DESCRIPTION
This PR replaces the manual line-by-line approach of extracting declared modules with one that does so by parsing the file to an AST and extracting the found ts module definitions.

Also has the added bonus of including any TSDoc that might be in the declaration.
  
- There are some spacing changes. I am not 100% sure why, but don't see this as a big deal personally
- There was a test to see if `declare module` inside of comments were being included - this failed now because the extractor will keep those types of comments, and we don't strip them anymore. I think this is more in line with what you would expect.
- The source map url was not included previously - an unintended side effect as I see it. It doesn't point to a valid URL, but that is the case regardless of the extraction process.

