### PR TITLE
fix: support the `use client` directive

### DIFF
--- a/src/node/tasks/rollup/resolveRollupConfig.ts
+++ b/src/node/tasks/rollup/resolveRollupConfig.ts
@@ -110,6 +110,10 @@ export function resolveRollupConfig(
     }),
     minify &&
       terser({
+        compress: {
+          // Needed until https://github.com/terser/terser/issues/1320 is fixed
+          directives: false,
+        },
         output: {
           comments: (_node, comment) => {
             const text = comment.value


### PR DESCRIPTION
Related to https://github.com/terser/terser/issues/1320

Terser removes any unknown directives. `@sanity/preview-kit` and `next-sanity` needs this before they can start shipping minified code