### PR TITLE
fix: allow `dynamicImportInCjs` in rollup v3

### DIFF
--- a/src/node/tasks/rollup/resolveRollupConfig.ts
+++ b/src/node/tasks/rollup/resolveRollupConfig.ts
@@ -106,7 +106,12 @@ export function resolveRollupConfig(
     getBabelOutputPlugin({
       babelrc: false,
       plugins: ['@babel/plugin-proposal-object-rest-spread'],
-      presets: [['@babel/preset-env', {targets: pkg.browserslist || DEFAULT_BROWSERSLIST_QUERY}]],
+      presets: [
+        [
+          '@babel/preset-env',
+          {targets: pkg.browserslist || DEFAULT_BROWSERSLIST_QUERY, modules: false},
+        ],
+      ],
     }),
     minify &&
       terser({


### PR DESCRIPTION
Rollup v3 introduces a great new option called [`dynamicImportInCjs`](https://rollupjs.org/guide/en/#dynamic-import-in-commonjs-output).
Since we target Node 14 as our baseline we can safely use code like this:

```js
const pkg = await import('pkg')
```
And if `pkg` is ESM-only (no CJS exports) it'll work the same in both ESM and CJS in NodeJS environments.

However since we use `@babel/preset-env` this new option doesn't work as babel is transforming the dynamic `import()` calls to `require()`.

This PR fixes that by turning module transformation off in babel.