### PR TITLE
fix: disable transitive imports hoisting

### DIFF
--- a/src/node/tasks/rollup/resolveRollupConfig.ts
+++ b/src/node/tasks/rollup/resolveRollupConfig.ts
@@ -210,6 +210,7 @@ export function resolveRollupConfig(
       interop: 'compat',
       minifyInternalExports: minify,
       sourcemap: config?.sourcemap ?? true,
+      hoistTransitiveImports: false,
     },
   }
 }


### PR DESCRIPTION
As packages consumed by `pkg-utils` are typically consumed by other bundlers this optimization is a bit counter-intuitive.

For example look at: https://unpkg.com/browse/next-sanity@3.1.8/dist/studio/index.js
And line 17-18:
```js
import '@sanity/icons';
import '@sanity/ui';
```
This happens because the file that uses `@sanity/icons` and `@sanity/ui` is `NextStudioLoading`. And `NextStudioLoading` is used by `dist/studio/index.js` and [`dist/studio/loading.js`](https://unpkg.com/browse/next-sanity@3.1.8/dist/studio/loading.js).

[More info.](https://rollupjs.org/guide/en/#why-do-additional-imports-turn-up-in-my-entry-chunks-when-code-splitting)
