### PR TITLE
chore: remove rollup defaults

### DIFF
--- a/src/node/tasks/rollup/resolveRollupConfig.ts
+++ b/src/node/tasks/rollup/resolveRollupConfig.ts
@@ -88,12 +88,7 @@ export function resolveRollupConfig(
       extensions: ['.cjs', '.mjs', '.js', '.jsx', '.json', '.node'],
       preferBuiltins: true, // runtime === 'node',
     }),
-    commonjs({
-      esmExternals: false,
-      extensions: ['.js'],
-      // include: /\/node_modules\//,
-      // requireReturnsDefault: 'namespace',
-    }),
+    commonjs(),
     json(),
     esbuild({
       jsx: config?.jsx ?? 'automatic',


### PR DESCRIPTION
Removing options that match defaults makes the codebase a little easier to maintain.