### PR TITLE
fix: optional package type

### DIFF
--- a/playground/dummy-commonjs/package.config.ts
+++ b/playground/dummy-commonjs/package.config.ts
@@ -1,6 +1,6 @@
 import {defineConfig} from '@sanity/pkg-utils'
 
 export default defineConfig({
-  legacyExports: true,
+  legacyExports: false,
   tsconfig: 'tsconfig.dist.json',
 })

--- a/playground/dummy-commonjs/package.json
+++ b/playground/dummy-commonjs/package.json
@@ -1,6 +1,5 @@
 {
   "private": true,
-  "type": "commonjs",
   "name": "dummy-commonjs",
   "version": "1.0.0",
   "license": "MIT",

--- a/src/node/core/pkg/loadPkgWithReporting.ts
+++ b/src/node/core/pkg/loadPkgWithReporting.ts
@@ -12,7 +12,13 @@ export async function loadPkgWithReporting(options: {
   const {cwd, logger} = options
 
   try {
-    return await loadPkg({cwd})
+    const pkg = await loadPkg({cwd})
+
+    if (pkg.type === undefined) {
+      logger.warn('no "type" field in package.json, defaulting to "commonjs"')
+    }
+
+    return pkg
   } catch (err) {
     if (err instanceof ZodError) {
       for (const issue of err.issues) {

--- a/src/node/core/pkg/types.ts
+++ b/src/node/core/pkg/types.ts
@@ -1,6 +1,6 @@
 /** @internal */
 export interface PackageJSON {
-  type: 'commonjs' | 'module'
+  type?: 'commonjs' | 'module'
   version: string
   private?: boolean
   name: string

--- a/src/node/core/pkg/validateExports.ts
+++ b/src/node/core/pkg/validateExports.ts
@@ -7,7 +7,7 @@ export function validateExports(
   options: {extMap: PkgExtMap; pkg: PackageJSON}
 ): string[] {
   const {extMap, pkg} = options
-  const ext = extMap[pkg.type]
+  const ext = extMap[pkg.type || 'commonjs']
 
   const errors: string[] = []
 

--- a/src/node/core/pkg/validatePkg.ts
+++ b/src/node/core/pkg/validatePkg.ts
@@ -2,7 +2,7 @@ import {z} from 'zod'
 import {PackageJSON} from './types'
 
 const pkgSchema = z.object({
-  type: z.enum(['commonjs', 'module']),
+  type: z.optional(z.enum(['commonjs', 'module'])),
   name: z.string(),
   version: z.string(),
   license: z.string(),
@@ -47,7 +47,5 @@ const pkgSchema = z.object({
 })
 
 export function validatePkg(input: unknown): PackageJSON {
-  const pkg = pkgSchema.parse(input)
-
-  return {...pkg, type: pkg.type || 'commonjs'}
+  return pkgSchema.parse(input)
 }

--- a/src/node/tasks/rollup/resolveRollupConfig.ts
+++ b/src/node/tasks/rollup/resolveRollupConfig.ts
@@ -23,7 +23,7 @@ export function resolveRollupConfig(
 ): RollupConfig {
   const {format, runtime, target} = buildTask
   const {config, cwd, exports: _exports, extMap, external, distPath, logger, pkg, ts} = ctx
-  const outputExt = extMap[pkg.type][format]
+  const outputExt = extMap[pkg.type || 'commonjs'][format]
   const minify = config?.minify ?? false
   const outDir = path.relative(cwd, distPath)
 


### PR DESCRIPTION
In `@sanity/pkg-utils@2` we introduced a required `type` property in `package.json`. This causes issues in Next.js, where it does not interpret `type: "commonjs"` (which is the same as `type: undefined`) the same way as Node and Vite.