### PR TITLE
feat: add `use client` module directive support

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "rimraf": "^4.4.1",
     "rollup": "^3.27.2",
     "rollup-plugin-esbuild": "^5.0.0",
+    "rollup-plugin-preserve-directives": "^0.2.0",
     "rxjs": "^7.8.1",
     "treeify": "^1.1.0",
     "uuid": "^9.0.0",

--- a/playground/runtime-next-js/app/app-router/leaf.tsx
+++ b/playground/runtime-next-js/app/app-router/leaf.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+// Teeny tiny component in its own file, demonstrating how small client component
+// leafs can be in an RSC tree, and how little the impact of using `React.createContext` can be
+
+import {useResult} from 'use-client-directive'
+
+export default function Leaf() {
+  const result = useResult()
+  return <div>useContext={result}</div>
+}

--- a/playground/runtime-next-js/app/app-router/page.tsx
+++ b/playground/runtime-next-js/app/app-router/page.tsx
@@ -1,0 +1,18 @@
+import * as index from 'dummy-module'
+import * as extra from 'dummy-module/extra'
+
+import Leaf from './leaf'
+
+export default function IndexPage() {
+  return (
+    <div>
+      <div>
+        path={index.path}, format={index.format}, runtime={index.runtime}
+      </div>
+      <div>
+        path={extra.path}, format={extra.format}, runtime={extra.runtime}
+      </div>
+      <Leaf />
+    </div>
+  )
+}

--- a/playground/runtime-next-js/app/layout.tsx
+++ b/playground/runtime-next-js/app/layout.tsx
@@ -1,0 +1,12 @@
+import {Provider} from 'use-client-directive'
+
+export default function RootLayout({children}: {children: React.ReactNode}) {
+  return (
+    <html lang="en">
+      <head />
+      <body>
+        <Provider>{children}</Provider>
+      </body>
+    </html>
+  )
+}

--- a/playground/runtime-next-js/next-env.d.ts
+++ b/playground/runtime-next-js/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/playground/runtime-next-js/package.json
+++ b/playground/runtime-next-js/package.json
@@ -12,7 +12,8 @@
     "dummy-module": "workspace:*",
     "next": "^13.4.13",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "use-client-directive": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "^18.2.18"

--- a/playground/runtime-next-js/tsconfig.json
+++ b/playground/runtime-next-js/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.settings",
-  "include": ["./next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["./next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["./node_modules"],
   "compilerOptions": {
     "noEmit": true,
@@ -11,6 +11,8 @@
     "module": "esnext",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "plugins": [{"name": "next"}],
+    "strictNullChecks": true
   }
 }

--- a/playground/use-client-directive/package.config.ts
+++ b/playground/use-client-directive/package.config.ts
@@ -1,0 +1,6 @@
+import {defineConfig} from '@sanity/pkg-utils'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  preserveModuleDirectives: true,
+})

--- a/playground/use-client-directive/package.json
+++ b/playground/use-client-directive/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "use-client-directive",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "source": "./src/index.ts",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "run-s clean && pkg build --strict && pkg check --strict",
+    "clean": "rimraf dist"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.18",
+    "react": "^18.2.0"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0"
+  }
+}

--- a/playground/use-client-directive/src/_exports.tsx
+++ b/playground/use-client-directive/src/_exports.tsx
@@ -1,0 +1,10 @@
+import {createContext, useContext} from 'react'
+
+const Context = createContext<'success' | 'failure'>('failure')
+
+/** @public */
+export const Provider = ({children}: {children: React.ReactNode}) => (
+  <Context.Provider value="success">{children}</Context.Provider>
+)
+/** @public */
+export const useResult = () => useContext(Context)

--- a/playground/use-client-directive/src/index.ts
+++ b/playground/use-client-directive/src/index.ts
@@ -1,0 +1,3 @@
+'use client'
+
+export * from './_exports'

--- a/playground/use-client-directive/tsconfig.dist.json
+++ b/playground/use-client-directive/tsconfig.dist.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["./src"],
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist",
+    "emitDeclarationOnly": true
+  }
+}

--- a/playground/use-client-directive/tsconfig.json
+++ b/playground/use-client-directive/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["./package.config.ts", "./src"],
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  }
+}

--- a/playground/use-client-directive/tsconfig.settings.json
+++ b/playground/use-client-directive/tsconfig.settings.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "jsx": "preserve",
+
+    // Strict type-checking
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+
+    // Additional checks
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+
+    // Module resolution
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       rollup-plugin-esbuild:
         specifier: ^5.0.0
         version: 5.0.0(esbuild@0.18.19)(rollup@3.27.2)
+      rollup-plugin-preserve-directives:
+        specifier: ^0.2.0
+        version: 0.2.0(rollup@3.27.2)
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
@@ -282,6 +285,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      use-client-directive:
+        specifier: workspace:*
+        version: link:../use-client-directive
     devDependencies:
       '@types/react':
         specifier: ^18.2.18
@@ -335,6 +341,15 @@ importers:
   playground/ts-bundler: {}
 
   playground/ts-node16: {}
+
+  playground/use-client-directive:
+    devDependencies:
+      '@types/react':
+        specifier: ^18.2.18
+        version: 18.2.18
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
 
 packages:
 
@@ -7635,7 +7650,6 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
-    dev: false
 
   /loupe@2.3.6:
     resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
@@ -9498,7 +9512,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
-    dev: false
 
   /read-pkg-up@10.0.0:
     resolution: {integrity: sha512-jgmKiS//w2Zs+YbX039CorlkOp8FIVbSAN8r8GJHDsGlmNPXo+VeHkqAwCiQVTTx5/LwLZTcEw59z3DvcLbr0g==}
@@ -9984,6 +9997,15 @@ packages:
       rollup: 3.27.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /rollup-plugin-preserve-directives@0.2.0(rollup@3.27.2):
+    resolution: {integrity: sha512-KUwbBaFvD1zFIDNnOkR+u64sSod3m0l6q46/SzTOa4GTQ6hp6w0FRr2u7x99YkY9qhlna5panmTmuLWeJ/2KWw==}
+    peerDependencies:
+      rollup: 2.x || 3.x
+    dependencies:
+      magic-string: 0.30.2
+      rollup: 3.27.2
     dev: false
 
   /rollup-plugin-visualizer@5.9.2(rollup@3.27.2):

--- a/src/node/core/config/types.ts
+++ b/src/node/core/config/types.ts
@@ -114,6 +114,11 @@ export interface PkgConfigOptions {
    * Build package with support for legacy exports (writes root `<export>.js` files)
    */
   legacyExports?: boolean
+  /**
+   * Preserves module directives, such as `'use client'`
+   * @alpha
+   */
+  preserveModuleDirectives?: boolean
   minify?: boolean
   /** @alpha */
   rollup?: {

--- a/src/node/tasks/rollup/rollupTask.ts
+++ b/src/node/tasks/rollup/rollupTask.ts
@@ -114,6 +114,26 @@ async function execPromise(ctx: BuildContext, task: RollupTask) {
     const bundle = await rollup({
       ...inputOptions,
       onwarn(warning) {
+        if (
+          // Ignore the directive warning until the preserveDirectives plugin does it automatically: https://github.com/Ephem/rollup-plugin-preserve-directives#rollup-plugin-preserve-directives-warning
+          warning.message.includes(
+            'Module level directives cause errors when bundled, "use client" in',
+          )
+        ) {
+          // If the preserve option isn't enabled, then extend the message with a note about how to enable
+          if (!ctx.config?.preserveModuleDirectives) {
+            consoleSpy.messages.push({
+              type: 'warn',
+              code: warning.code,
+              args: [
+                `${warning.message} You can preserve it by setting "preserveModuleDirectives: true" in your "package.config.ts"`,
+              ],
+            })
+          }
+
+          return
+        }
+
         consoleSpy.messages.push({
           type: 'warn',
           code: warning.code,


### PR DESCRIPTION
To enable out-of-the-box support for React Server Components.