### PR TITLE
fix: make "node.require" optional when re-exporting CJS

### DIFF
--- a/playground/default-export/package.json
+++ b/playground/default-export/package.json
@@ -9,8 +9,7 @@
       "source": "./src/index.js",
       "require": "./dist/index.cjs",
       "node": {
-        "import": "./dist/index.cjs.js",
-        "require": "./dist/index.cjs"
+        "import": "./dist/index.cjs.js"
       },
       "import": "./dist/index.js",
       "default": "./dist/index.js"

--- a/playground/multi-export/package.json
+++ b/playground/multi-export/package.json
@@ -10,8 +10,7 @@
       "source": "./src/index.ts",
       "require": "./dist/index.cjs",
       "node": {
-        "import": "./dist/index.cjs.js",
-        "require": "./dist/index.cjs"
+        "import": "./dist/index.cjs.js"
       },
       "import": "./dist/index.js",
       "default": "./dist/index.js"
@@ -21,8 +20,7 @@
       "source": "./src/plugin.ts",
       "require": "./dist/plugin.cjs",
       "node": {
-        "import": "./dist/plugin.cjs.js",
-        "require": "./dist/plugin.cjs"
+        "import": "./dist/plugin.cjs.js"
       },
       "import": "./dist/plugin.js",
       "default": "./dist/plugin.js"

--- a/playground/multi-exports-commonjs/package.json
+++ b/playground/multi-exports-commonjs/package.json
@@ -10,8 +10,7 @@
       "source": "./src/index.ts",
       "require": "./dist/index.js",
       "node": {
-        "import": "./dist/index.cjs.mjs",
-        "require": "./dist/index.js"
+        "import": "./dist/index.cjs.mjs"
       },
       "import": "./dist/index.esm.js",
       "default": "./dist/index.esm.js"
@@ -21,8 +20,7 @@
       "source": "./src/plugin.ts",
       "require": "./dist/plugin.js",
       "node": {
-        "import": "./dist/plugin.cjs.mjs",
-        "require": "./dist/plugin.js"
+        "import": "./dist/plugin.cjs.mjs"
       },
       "import": "./dist/plugin.esm.js",
       "default": "./dist/plugin.esm.js"

--- a/playground/ts-bundler/package.json
+++ b/playground/ts-bundler/package.json
@@ -10,8 +10,7 @@
       "source": "./src/index.ts",
       "require": "./dist/index.cjs",
       "node": {
-        "import": "./dist/index.cjs.js",
-        "require": "./dist/index.cjs"
+        "import": "./dist/index.cjs.js"
       },
       "import": "./dist/index.js",
       "default": "./dist/index.js"

--- a/playground/ts-node16/package.json
+++ b/playground/ts-node16/package.json
@@ -10,8 +10,7 @@
       "source": "./src/index.ts",
       "require": "./dist/index.cjs",
       "node": {
-        "import": "./dist/index.cjs.js",
-        "require": "./dist/index.cjs"
+        "import": "./dist/index.cjs.js"
       },
       "import": "./dist/index.js",
       "default": "./dist/index.js"

--- a/playground/ts/package.json
+++ b/playground/ts/package.json
@@ -10,8 +10,7 @@
       "source": "./src/index.ts",
       "require": "./dist/index.cjs",
       "node": {
-        "import": "./dist/index.cjs.js",
-        "require": "./dist/index.cjs"
+        "import": "./dist/index.cjs.js"
       },
       "import": "./dist/index.js",
       "default": "./dist/index.js"

--- a/src/node/resolveBuildTasks.ts
+++ b/src/node/resolveBuildTasks.ts
@@ -164,7 +164,7 @@ export function resolveBuildTasks(ctx: BuildContext): BuildTask[] {
       exp.node &&
       !exp.node.source &&
       exp.node.import &&
-      exp.node.require &&
+      (exp.node.require || exp.require) &&
       (exp.node.import.endsWith('.cjs.js') || exp.node.import.endsWith('.cjs.mjs'))
     ) {
       const importId = path.join(pkg.name, exp._path)
@@ -172,7 +172,7 @@ export function resolveBuildTasks(ctx: BuildContext): BuildTask[] {
       nodeReexportCjsEntries.push({
         importId,
         import: exp.node.import,
-        require: exp.node.require,
+        require: (exp.node.require || exp.require)!,
       })
     }
   }


### PR DESCRIPTION
Currently this is required for re-exports can be used:
```json
{
  ".": {
    "source": "./src/index.js",
    "require": "./dist/index.cjs",
    "node": {
      "import": "./dist/index.cjs.js",
      "require": "./dist/index.cjs"
    },
    "import": "./dist/index.js",
    "default": "./dist/index.js"
  }
}
```
In this case, the "node.require" condition is **never used** because "require" comes first.
And so it can safely be removed, allowing us to simplify the package json's a little bit.

This PR enables `@sanity/pkg-utils` to build the CJS wrappers when this is done:
```json
{
  ".": {
    "source": "./src/index.js",
    "require": "./dist/index.cjs",
    "node": {
      "import": "./dist/index.cjs.js"
    },
    "import": "./dist/index.js",
    "default": "./dist/index.js"
  }
}
```