### PR TITLE
fix: improve astro compatibilty

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "source": "./src/node/index.ts",
-      "require": "./dist/index.cjs",
       "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json"

--- a/playground/babel-plugin/package.json
+++ b/playground/babel-plugin/package.json
@@ -8,8 +8,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
-      "require": "./dist/index.cjs",
       "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json"

--- a/playground/custom-dist/package.json
+++ b/playground/custom-dist/package.json
@@ -8,8 +8,8 @@
     ".": {
       "types": "./lib/src/index.d.ts",
       "source": "./src/index.ts",
-      "require": "./lib/index.cjs",
       "import": "./lib/index.js",
+      "require": "./lib/index.cjs",
       "default": "./lib/index.js"
     },
     "./package.json": "./package.json"

--- a/playground/default-export/package.json
+++ b/playground/default-export/package.json
@@ -9,6 +9,7 @@
       "source": "./src/index.js",
       "require": "./dist/index.cjs",
       "node": {
+        "module": "./dist/index.js",
         "import": "./dist/index.cjs.js"
       },
       "import": "./dist/index.js",

--- a/playground/dummy-commonjs/package.json
+++ b/playground/dummy-commonjs/package.json
@@ -10,16 +10,16 @@
       "source": "./src/index.ts",
       "browser": {
         "source": "./src/index.ts",
-        "require": "./dist/index.browser.js",
-        "import": "./dist/index.browser.mjs"
+        "import": "./dist/index.browser.mjs",
+        "require": "./dist/index.browser.js"
       },
-      "module": "./dist/index.mjs",
-      "require": "./dist/index.js",
       "node": {
+        "module": "./dist/index.mjs",
         "import": "./node/index.mjs",
         "require": "./node/index.js"
       },
       "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
       "default": "./dist/index.mjs"
     },
     "./extra": {
@@ -27,15 +27,16 @@
       "source": "./src/extra.ts",
       "browser": {
         "source": "./src/extra.ts",
-        "require": "./dist/extra.browser.js",
-        "import": "./dist/extra.browser.mjs"
+        "import": "./dist/extra.browser.mjs",
+        "require": "./dist/extra.browser.js"
       },
-      "require": "./dist/extra.js",
       "node": {
+        "module": "./dist/extra.mjs",
         "import": "./node/extra.mjs",
         "require": "./node/extra.js"
       },
       "import": "./dist/extra.mjs",
+      "require": "./dist/extra.js",
       "default": "./dist/extra.mjs"
     },
     "./package.json": "./package.json"

--- a/playground/dummy-module/package.json
+++ b/playground/dummy-module/package.json
@@ -10,15 +10,16 @@
       "source": "./src/index.ts",
       "browser": {
         "source": "./src/index.ts",
-        "require": "./dist/index.browser.cjs",
-        "import": "./dist/index.browser.js"
+        "import": "./dist/index.browser.js",
+        "require": "./dist/index.browser.cjs"
       },
-      "require": "./dist/index.cjs",
       "node": {
+        "module": "./dist/index.js",
         "import": "./node/index.js",
         "require": "./node/index.cjs"
       },
       "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
       "default": "./dist/index.js"
     },
     "./extra": {
@@ -26,15 +27,16 @@
       "source": "./src/extra.ts",
       "browser": {
         "source": "./src/extra.ts",
-        "require": "./dist/extra.browser.cjs",
-        "import": "./dist/extra.browser.js"
+        "import": "./dist/extra.browser.js",
+        "require": "./dist/extra.browser.cjs"
       },
-      "require": "./dist/extra.cjs",
       "node": {
+        "module": "./dist/extra.js",
         "import": "./node/extra.js",
         "require": "./node/extra.cjs"
       },
       "import": "./dist/extra.js",
+      "require": "./dist/extra.cjs",
       "default": "./dist/extra.js"
     },
     "./package.json": "./package.json"

--- a/playground/multi-export/package.json
+++ b/playground/multi-export/package.json
@@ -10,6 +10,7 @@
       "source": "./src/index.ts",
       "require": "./dist/index.cjs",
       "node": {
+        "module": "./dist/index.js",
         "import": "./dist/index.cjs.js"
       },
       "import": "./dist/index.js",
@@ -20,6 +21,7 @@
       "source": "./src/plugin.ts",
       "require": "./dist/plugin.cjs",
       "node": {
+        "module": "./dist/plugin.js",
         "import": "./dist/plugin.cjs.js"
       },
       "import": "./dist/plugin.js",

--- a/playground/multi-exports-commonjs/package.json
+++ b/playground/multi-exports-commonjs/package.json
@@ -10,6 +10,7 @@
       "source": "./src/index.ts",
       "require": "./dist/index.js",
       "node": {
+        "module": "./dist/index.esm.js",
         "import": "./dist/index.cjs.mjs"
       },
       "import": "./dist/index.esm.js",
@@ -20,6 +21,7 @@
       "source": "./src/plugin.ts",
       "require": "./dist/plugin.js",
       "node": {
+        "module": "./dist/plugin.esm.js",
         "import": "./dist/plugin.cjs.mjs"
       },
       "import": "./dist/plugin.esm.js",

--- a/playground/ts-bundler/package.json
+++ b/playground/ts-bundler/package.json
@@ -10,6 +10,7 @@
       "source": "./src/index.ts",
       "require": "./dist/index.cjs",
       "node": {
+        "module": "./dist/index.js",
         "import": "./dist/index.cjs.js"
       },
       "import": "./dist/index.js",

--- a/playground/ts-node16/package.json
+++ b/playground/ts-node16/package.json
@@ -10,6 +10,7 @@
       "source": "./src/index.ts",
       "require": "./dist/index.cjs",
       "node": {
+        "module": "./dist/index.js",
         "import": "./dist/index.cjs.js"
       },
       "import": "./dist/index.js",

--- a/playground/ts/package.json
+++ b/playground/ts/package.json
@@ -10,6 +10,7 @@
       "source": "./src/index.ts",
       "require": "./dist/index.cjs",
       "node": {
+        "module": "./dist/index.js",
         "import": "./dist/index.cjs.js"
       },
       "import": "./dist/index.js",

--- a/src/node/core/pkg/types.ts
+++ b/src/node/core/pkg/types.ts
@@ -19,14 +19,16 @@ export interface PackageJSON {
         types?: string
         browser?: {
           source: string
-          require?: string
           import?: string
+          require?: string
         }
         node?: {
           source?: string
-          require?: string
+          module?: string
           import?: string
+          require?: string
         }
+        module?: string
         import?: string
         require?: string
         default: string

--- a/src/node/core/pkg/validatePkg.ts
+++ b/src/node/core/pkg/validatePkg.ts
@@ -23,22 +23,24 @@ const pkgSchema = z.object({
         z.object({
           types: z.optional(z.string()),
           source: z.string(),
-          require: z.optional(z.string()),
           browser: z.optional(
             z.object({
               source: z.string(),
-              require: z.optional(z.string()),
               import: z.optional(z.string()),
+              require: z.optional(z.string()),
             }),
           ),
           node: z.optional(
             z.object({
               source: z.optional(z.string()),
-              require: z.optional(z.string()),
+              module: z.optional(z.string()),
               import: z.optional(z.string()),
+              require: z.optional(z.string()),
             }),
           ),
+          module: z.optional(z.string()),
           import: z.optional(z.string()),
+          require: z.optional(z.string()),
           default: z.string(),
         }),
       ]),


### PR DESCRIPTION
When this pattern is used:
```json
{
  ".": {
    "source": "./src/index.js",
    "require": "./dist/index.cjs",
    "node": {
      "import": "./dist/index.cjs.js"
    },
    "import": "./dist/index.js",
    "default": "./dist/index.js"
  }
}
```

astro throws an error as it will use the `node.import` condition and isn't prepared to handle a re-export of CJS:
```bash
error   "default" is not exported by "../dummy-commonjs/dist/index.js", imported by "../dummy-commonjs/node/index.mjs".
  File:
    /Users/cody/Developer/GitHub/pkg-utils/playground/dummy-commonjs/node/index.mjs:1:7
  Code:
    1: import cjs from '../dist/index.js'
              ^
    2: 
    3: export const format = cjs.format
  Stacktrace:
RollupError: "default" is not exported by "../dummy-commonjs/dist/index.js", imported by "../dummy-commonjs/node/index.mjs".
```

The solution is to add a `node.module` condition before `node.import`, that has the same value as `import`:
```json
{
  ".": {
    "source": "./src/index.js",
    "require": "./dist/index.cjs",
    "node": {
      "module": "./dist/index.js",
      "import": "./dist/index.cjs.js"
    },
    "import": "./dist/index.js",
    "default": "./dist/index.js"
  }
}
```

This PR adds validation that ensures this pattern, and other `pkg.exports` ordering best practices, are used. And it will throw errors on common mistakes.