### PR TITLE
fix: throw DtsError with errors only

### DIFF
--- a/src/node/tasks/dts/doExtract.ts
+++ b/src/node/tasks/dts/doExtract.ts
@@ -62,10 +62,10 @@ export async function doExtract(
 
     messages.push(...result.messages)
 
-    if (result.messages.some((msg) => msg.logLevel === 'error')) {
+    const errors = result.messages.filter((msg) => msg.logLevel === 'error')
+    if (errors.length > 0) {
       await rimraf(tmpPath)
-
-      throw new DtsError('encountered errors when extracting types', result.messages)
+      throw new DtsError(`encountered ${errors.length} errors when extracting types`, errors)
     }
 
     results.push({sourcePath: path.resolve(cwd, entry.sourcePath), filePath: targetPath})


### PR DESCRIPTION
Currently, if `doExtract` fails it throws an error including every message received during build, including warnings that are ignored by the current loglevel/package config. Combined with another issue that does't render error messages properly (not exactly sure where this happens, didn't dig into it), but rather console.logs the array of messages, the actual errors gets obscured by other messages (info, warnings, etc.) which in turn makes it hard to track down exactly what failed. This fixes this particular issue by making sure only _errors_ are attached to the thrown exception.