### PR TITLE
feat: Chokidar use polling on rollup watch

### DIFF
--- a/src/node/tasks/rollup/resolveRollupConfig.ts
+++ b/src/node/tasks/rollup/resolveRollupConfig.ts
@@ -184,6 +184,12 @@ export function resolveRollupConfig(
         return {...acc, [entry.name]: entry.source}
       }, {}),
 
+      watch: {
+        chokidar: {
+          usePolling: true
+        }
+      },
+
       plugins,
 
       treeshake: {


### PR DESCRIPTION
I had some issues where npm run watch would only register changes once on WSL/NVIM, turns out there is something called safe-write that some editors implement. Either way it could be turned off in nvim with `:set backupcopy=yes`, or setting a usePolling property on the chokidar watch config, which is what rollup watch uses when available. How you want to implement this or if you want to is ofcourse up to you. Maybe detecting safe-write is possible. There is some discussion on this thread: https://github.com/parcel-bundler/parcel/issues/221#issuecomment-350883702