### PR TITLE
fix: ensure no "Masquerading as ESM|CJS" dts errors

### DIFF
--- a/package.config.ts
+++ b/package.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   bundles: [
     {
       source: './src/cli/index.ts',
-      require: './dist/cli.js',
+      require: './dist/cli.cjs',
     },
   ],
   extract: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/pkg-utils",
-  "version": "5.1.0",
+  "version": "5.1.1-canary.0",
   "description": "Simple utilities for modern npm packages.",
   "keywords": [
     "sanity-io",
@@ -25,7 +25,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "source": "./src/node/index.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",

--- a/playground/babel-plugin/package.json
+++ b/playground/babel-plugin/package.json
@@ -7,7 +7,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",

--- a/playground/custom-dist/package.json
+++ b/playground/custom-dist/package.json
@@ -7,7 +7,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./lib/src/index.d.ts",
       "source": "./src/index.ts",
       "import": "./lib/index.js",
       "require": "./lib/index.cjs",
@@ -18,7 +17,7 @@
   "main": "./lib/index.cjs",
   "module": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/src/index.d.ts",
+  "types": "./lib/index.d.ts",
   "scripts": {
     "build": "run-s clean && pkg build --strict && pkg check --strict",
     "clean": "rimraf lib"

--- a/playground/dummy-commonjs/package.json
+++ b/playground/dummy-commonjs/package.json
@@ -7,7 +7,6 @@
   "type": "commonjs",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
       "browser": {
         "source": "./src/index.ts",
@@ -19,7 +18,6 @@
       "default": "./dist/index.mjs"
     },
     "./extra": {
-      "types": "./dist/extra.d.ts",
       "source": "./src/extra.ts",
       "browser": {
         "source": "./src/extra.ts",

--- a/playground/dummy-module/package.json
+++ b/playground/dummy-module/package.json
@@ -7,7 +7,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
       "browser": {
         "source": "./src/index.ts",
@@ -19,7 +18,6 @@
       "default": "./dist/index.js"
     },
     "./extra": {
-      "types": "./dist/extra.d.ts",
       "source": "./src/extra.ts",
       "browser": {
         "source": "./src/extra.ts",

--- a/playground/dummy-side-effects/package.json
+++ b/playground/dummy-side-effects/package.json
@@ -9,12 +9,10 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./index.d.ts",
       "require": "./index.cjs",
       "default": "./index.js"
     },
     "./side-effect": {
-      "types": "./side-effect.d.ts",
       "require": "./side-effect.cjs",
       "default": "./side-effect.js"
     },

--- a/playground/multi-export/package.json
+++ b/playground/multi-export/package.json
@@ -9,28 +9,24 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",
       "default": "./dist/index.js"
     },
     "./plugin": {
-      "types": "./dist/plugin.d.ts",
       "source": "./src/plugin.ts",
       "import": "./dist/plugin.js",
       "require": "./dist/plugin.cjs",
       "default": "./dist/plugin.js"
     },
     "./pure": {
-      "types": "./dist/pure.d.ts",
       "source": "./src/pure.ts",
       "import": "./dist/pure.js",
       "require": "./dist/pure.cjs",
       "default": "./dist/pure.js"
     },
     "./side-effect": {
-      "types": "./dist/side-effect.d.ts",
       "source": "./src/side-effect.ts",
       "import": "./dist/side-effect.js",
       "require": "./dist/side-effect.cjs",
@@ -41,7 +37,6 @@
       "svelte": "./dist-svelte/index.js"
     },
     "./no-side-effect": {
-      "types": "./dist/no-side-effect.d.ts",
       "source": "./src/no-side-effect.ts",
       "import": "./dist/no-side-effect.js",
       "require": "./dist/no-side-effect.cjs",

--- a/playground/multi-exports-commonjs/package.json
+++ b/playground/multi-exports-commonjs/package.json
@@ -7,14 +7,12 @@
   "type": "commonjs",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
       "import": "./dist/index.esm.js",
       "require": "./dist/index.js",
       "default": "./dist/index.esm.js"
     },
     "./plugin": {
-      "types": "./dist/plugin.d.ts",
       "source": "./src/plugin.ts",
       "import": "./dist/plugin.esm.js",
       "require": "./dist/plugin.js",

--- a/playground/ts-bundler/package.json
+++ b/playground/ts-bundler/package.json
@@ -7,7 +7,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",

--- a/playground/ts-node16/package.json
+++ b/playground/ts-node16/package.json
@@ -7,7 +7,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",

--- a/playground/ts/package.json
+++ b/playground/ts/package.json
@@ -7,7 +7,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",

--- a/playground/use-client-directive/package.json
+++ b/playground/use-client-directive/package.json
@@ -7,7 +7,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
       "react-server": "./lib/index.js",
       "import": "./dist/index.js",

--- a/src/node/check.ts
+++ b/src/node/check.ts
@@ -41,14 +41,14 @@ export async function check(options: {
       if (exp.import && !fileExists(path.resolve(cwd, exp.import))) {
         missingFiles.push(exp.import)
       }
+    }
 
-      if (exp.types && !fileExists(path.resolve(cwd, exp.types))) {
-        missingFiles.push(exp.types)
-      }
+    if (ctx.pkg.types && !fileExists(path.resolve(cwd, ctx.pkg.types))) {
+      missingFiles.push(ctx.pkg.types)
     }
 
     if (missingFiles.length) {
-      logger.error('missing files')
+      logger.error(`missing files: ${missingFiles.join(', ')}`)
       process.exit(1)
     }
 

--- a/src/node/core/pkg/loadPkgWithReporting.ts
+++ b/src/node/core/pkg/loadPkgWithReporting.ts
@@ -1,8 +1,8 @@
 import chalk from 'chalk'
 import {ZodError} from 'zod'
 
-import {assertFirst, assertLast, assertOrder} from './helpers'
 import type {Logger} from '../../logger'
+import {assertLast, assertOrder} from './helpers'
 import {loadPkg} from './loadPkg'
 import type {PackageJSON} from './types'
 
@@ -28,9 +28,11 @@ export async function loadPkgWithReporting(options: {
 
         const keys = Object.keys(exp)
 
-        if (!assertFirst('types', keys)) {
+        if (exp.types) {
           shouldError = true
-          logger.error(`exports["${expPath}"]: the \`types\` property should be the first property`)
+          logger.error(
+            `exports["${expPath}"]: the \`types\` condition shouldn't be used as dts files are generated in such a way that both CJS and ESM is supported`,
+          )
         }
 
         if (exp.module) {

--- a/src/node/core/pkg/parseExports.ts
+++ b/src/node/core/pkg/parseExports.ts
@@ -15,7 +15,6 @@ export function parseExports(options: {
   const rootExport: PkgExport & {_path: string} = {
     _exported: true,
     _path: '.',
-    types: pkg.types,
     source: pkg.source || '',
     browser: pkg.browser && {
       source: pkg.source || '',
@@ -30,6 +29,16 @@ export function parseExports(options: {
   const extraExports: (PkgExport & {_path: string})[] = []
 
   const errors: string[] = []
+
+  if (strict && !pkg.types && pkg.source?.endsWith('.ts')) {
+    errors.push(
+      'package.json: `types` must be declared for the npm listing to show as a TypeScript module.',
+    )
+  }
+
+  if (strict && 'typings' in pkg) {
+    errors.push('package.json: `typings` should be `types`')
+  }
 
   if (pkg.exports) {
     if (strict && !pkg.exports['./package.json']) {
@@ -60,12 +69,6 @@ export function parseExports(options: {
           if (exportEntry.import && rootExport.import && exportEntry.import !== rootExport.import) {
             errors.push(
               'package.json: mismatch between "module" and "exports.import" These must be equal.',
-            )
-          }
-
-          if (exportEntry.types && rootExport.types && exportEntry.types !== rootExport.types) {
-            errors.push(
-              'package.json: mismatch between "types" and "exports.types". These must be equal.',
             )
           }
 

--- a/src/node/printPackageTree.ts
+++ b/src/node/printPackageTree.ts
@@ -49,19 +49,12 @@ export function printPackageTree(ctx: BuildContext): void {
       .filter(([, entry]) => entry._exported)
       .map(([exportPath, entry]) => {
         const exp: Omit<PkgExport, '_exported'> = {
-          types: undefined,
           source: fileInfo(entry.source),
           browser: undefined,
           require: undefined,
           node: undefined,
           import: undefined,
           default: fileInfo(entry.default),
-        }
-
-        if (entry.types) {
-          exp.types = fileInfo(entry.types)
-        } else {
-          delete exp.types
         }
 
         if (entry.browser) {

--- a/src/node/resolveWatchTasks.ts
+++ b/src/node/resolveWatchTasks.ts
@@ -1,8 +1,9 @@
 import fs from 'fs'
 import path from 'path'
 
-import {BuildContext, PkgExport, PkgFormat, PkgRuntime} from './core'
-import {DtsWatchTask, RollupTaskEntry, RollupWatchTask, WatchTask} from './tasks'
+import type {BuildContext, PkgExport, PkgFormat, PkgRuntime} from './core'
+import type {DtsWatchTask, RollupTaskEntry, RollupWatchTask, WatchTask} from './tasks'
+import {getTargetPaths} from './tasks/dts/getTargetPaths'
 
 /** @internal */
 export function resolveWatchTasks(ctx: BuildContext): WatchTask[] {
@@ -41,12 +42,30 @@ export function resolveWatchTasks(ctx: BuildContext): WatchTask[] {
   for (const exp of exports) {
     const importId = path.join(pkg.name, exp._path)
 
-    if (exp.types) {
+    if (exp.source?.endsWith('.ts')) {
       dtsTask.entries.push({
         importId,
         exportPath: exp._path,
         sourcePath: exp.source,
-        targetPath: exp.types,
+        targetPaths: getTargetPaths(pkg.type, exp),
+      })
+    }
+
+    if (exp.browser?.source?.endsWith('.ts')) {
+      dtsTask.entries.push({
+        importId,
+        exportPath: exp._path,
+        sourcePath: exp.browser.source,
+        targetPaths: getTargetPaths(pkg.type, exp.browser),
+      })
+    }
+
+    if (exp.node?.source?.endsWith('.ts')) {
+      dtsTask.entries.push({
+        importId,
+        exportPath: exp._path,
+        sourcePath: exp.node.source,
+        targetPaths: getTargetPaths(pkg.type, exp.node),
       })
     }
   }

--- a/src/node/tasks/dts/doExtract.ts
+++ b/src/node/tasks/dts/doExtract.ts
@@ -34,7 +34,7 @@ export async function doExtract(
   await buildTypes({cwd, logger, outDir: tmpPath, strict, tsconfig: ts.config})
   const messages: ExtractorMessage[] = []
 
-  const results: {sourcePath: string; filePath: string}[] = []
+  const results: {sourcePath: string; filePaths: string[]}[] = []
 
   for (const entry of task.entries) {
     const exportPath = entry.exportPath === '.' ? './index' : entry.exportPath
@@ -44,8 +44,8 @@ export async function doExtract(
       path.relative(rootDir, path.resolve(cwd, entry.sourcePath)).replace(/\.ts$/, '.d.ts'),
     )
 
-    const targetPath = path.resolve(cwd, entry.targetPath)
-    const filePath = path.relative(outDir, targetPath)
+    const targetPaths = entry.targetPaths.map((targetPath) => path.resolve(cwd, targetPath))
+    const filePaths = targetPaths.map((targetPath) => path.relative(outDir, targetPath))
     const result = await extractTypes({
       bundledPackages: config?.extract?.bundledPackages || [],
       customTags: config?.extract?.customTags,
@@ -53,7 +53,7 @@ export async function doExtract(
       distPath: outDir,
       exportPath,
       files,
-      filePath: filePath,
+      filePaths,
       projectPath: cwd,
       rules: config?.extract?.rules,
       sourceTypesPath: sourceTypesPath,
@@ -71,7 +71,7 @@ export async function doExtract(
       throw new DtsError(`encountered ${errors.length} errors when extracting types`, errors)
     }
 
-    results.push({sourcePath: path.resolve(cwd, entry.sourcePath), filePath: targetPath})
+    results.push({sourcePath: path.resolve(cwd, entry.sourcePath), filePaths: targetPaths})
   }
 
   await rimraf(tmpPath)

--- a/src/node/tasks/dts/dtsTask.ts
+++ b/src/node/tasks/dts/dtsTask.ts
@@ -13,12 +13,16 @@ export const dtsTask: TaskHandler<DtsTask, DtsResult> = {
     [
       'Build type definitions...',
       '  entries:',
-      ...task.entries.map((entry) =>
-        [
-          `    - ${chalk.cyan(entry.importId)}: `,
-          `${chalk.yellow(entry.sourcePath)} ${chalk.gray('→')} ${chalk.yellow(entry.targetPath)}`,
-        ].join(''),
-      ),
+      ...task.entries.map((entry) => {
+        return entry.targetPaths
+          .map((targetPath) => {
+            return [
+              `    - ${chalk.cyan(entry.importId)}: `,
+              `${chalk.yellow(entry.sourcePath)} ${chalk.gray('→')} ${chalk.yellow(targetPath)}`,
+            ].join('')
+          })
+          .join('\n')
+      }),
     ].join('\n'),
   exec: (ctx, task) => {
     return new Observable((observer) => {

--- a/src/node/tasks/dts/dtsWatchTask.ts
+++ b/src/node/tasks/dts/dtsWatchTask.ts
@@ -2,20 +2,24 @@ import chalk from 'chalk'
 import {Observable} from 'rxjs'
 
 import {printExtractMessages} from '../../printExtractMessages'
-import {TaskHandler} from '../types'
+import type {TaskHandler} from '../types'
 import {doExtract} from './doExtract'
 import {DtsError} from './DtsError'
-import {DtsResult, DtsWatchTask} from './types'
+import type {DtsResult, DtsWatchTask} from './types'
 
 /** @internal */
 export const dtsWatchTask: TaskHandler<DtsWatchTask, DtsResult> = {
   name: (_ctx, task) =>
     [
       `build type definitions`,
-      ...task.entries.map(
-        (entry) =>
-          `       ${chalk.blue(entry.importId)}: ${entry.sourcePath} -> ${entry.targetPath}`,
-      ),
+      ...task.entries.map((entry) => {
+        return entry.targetPaths.map((targetPath) => {
+          return [
+            `    - ${chalk.cyan(entry.importId)}: `,
+            `${chalk.yellow(entry.sourcePath)} ${chalk.gray('→')} ${chalk.yellow(targetPath)}`,
+          ].join('')
+        })
+      }),
     ].join('\n'),
   exec: (ctx, task) => {
     return new Observable((observer) => {

--- a/src/node/tasks/dts/getTargetPaths.ts
+++ b/src/node/tasks/dts/getTargetPaths.ts
@@ -1,0 +1,64 @@
+import type {PackageJSON, PkgBundle, PkgExport} from '../../core'
+
+const fileEnding = /\.[mc]?js$/
+const dtsEnding = '.d.ts'
+const mtsEnding = '.d.mts'
+const ctsEnding = '.d.cts'
+
+/** @internal */
+export function getTargetPaths(
+  _type: PackageJSON['type'],
+  expOrBundle: PkgExport | PkgExport['browser'] | PkgExport['node'] | PkgBundle,
+): string[] {
+  const type = (_type === 'module' ? 'module' : 'commonjs') satisfies PackageJSON['type']
+
+  const set = new Set<string>()
+
+  if (expOrBundle?.import) {
+    set.add(expOrBundle.import.replace(fileEnding, type === 'module' ? dtsEnding : mtsEnding))
+  }
+
+  if (expOrBundle?.require) {
+    set.add(expOrBundle.require.replace(fileEnding, type === 'commonjs' ? dtsEnding : ctsEnding))
+  }
+
+  if (isPkgExport(expOrBundle)) {
+    if (!expOrBundle.browser?.source) {
+      if (expOrBundle.browser?.import) {
+        set.add(
+          expOrBundle.browser.import.replace(fileEnding, type === 'module' ? dtsEnding : mtsEnding),
+        )
+      }
+
+      if (expOrBundle.browser?.require) {
+        set.add(
+          expOrBundle.browser.require.replace(
+            fileEnding,
+            type === 'commonjs' ? dtsEnding : ctsEnding,
+          ),
+        )
+      }
+    }
+
+    if (!expOrBundle.node?.source) {
+      if (expOrBundle.node?.import) {
+        set.add(
+          expOrBundle.node.import.replace(fileEnding, type === 'module' ? dtsEnding : mtsEnding),
+        )
+      }
+
+      if (expOrBundle.node?.require) {
+        set.add(
+          expOrBundle.node.require.replace(fileEnding, type === 'commonjs' ? dtsEnding : ctsEnding),
+        )
+      }
+    }
+  }
+
+  return Array.from(set)
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isPkgExport(exp: any): exp is PkgExport {
+  return exp?.browser || exp?.node || exp?.default
+}

--- a/src/node/tasks/dts/types.ts
+++ b/src/node/tasks/dts/types.ts
@@ -1,4 +1,4 @@
-import {ExtractorMessage} from '@microsoft/api-extractor'
+import type {ExtractorMessage} from '@microsoft/api-extractor'
 
 /** @internal */
 export interface DtsWatchTask {
@@ -7,7 +7,7 @@ export interface DtsWatchTask {
     exportPath: string
     importId: string
     sourcePath: string
-    targetPath: string
+    targetPaths: string[]
   }[]
 }
 
@@ -18,7 +18,7 @@ export interface DtsTask {
     exportPath: string
     importId: string
     sourcePath: string
-    targetPath: string
+    targetPaths: string[]
   }[]
 }
 
@@ -26,5 +26,5 @@ export interface DtsTask {
 export interface DtsResult {
   type: 'dts'
   messages: ExtractorMessage[]
-  results: {sourcePath: string; filePath: string}[]
+  results: {sourcePath: string; filePaths: string[]}[]
 }

--- a/src/node/templates/default/template.ts
+++ b/src/node/templates/default/template.ts
@@ -278,12 +278,6 @@ export const defaultTemplate: PkgTemplate = async ({cwd, logger, packagePath}) =
       if (features.typescript) {
         pkgJson.types = './dist/index.d.ts'
 
-        const mainExport = pkgJson.exports?.['.']
-
-        if (isRecord(mainExport)) {
-          mainExport.types = './dist/index.d.ts'
-        }
-
         pkgJson.scripts = {
           ...pkgJson.scripts,
           ['ts:check']: 'tsc --build',

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -83,11 +83,11 @@ test.skipIf(isWindows)('should build `custom-dist` package', async () => {
 
   expect(stdout).toContain('./src/index.ts → ./lib/index.cjs')
   expect(stdout).toContain('./src/index.ts → ./lib/index.js')
-  expect(stdout).toContain('./src/index.ts → ./lib/src/index.d.ts')
+  expect(stdout).toContain('./src/index.ts → ./lib/index.d.ts')
 
   expect(await project.readFile('lib/index.cjs')).toMatchSnapshot()
   expect(await project.readFile('lib/index.js')).toMatchSnapshot()
-  expect(await project.readFile('lib/src/index.d.ts')).toMatchSnapshot()
+  expect(await project.readFile('lib/index.d.ts')).toMatchSnapshot()
 
   await project.remove()
 })

--- a/test/parseExports.test.ts
+++ b/test/parseExports.test.ts
@@ -13,6 +13,7 @@ describe('parseExports', () => {
       bin: {test: './dist/cli.js'},
       source: './src/index.ts',
       main: './dist/index.js',
+      types: './dist/index.d.ts',
       exports: {
         '.': {
           source: './src/index.ts',
@@ -231,28 +232,10 @@ describe('parseExports', () => {
       [
         {
           source: './src/index.ts',
-          types: './dist/index.d.ts',
-          require: './dist/index.cjs',
-          default: './dist/index.js',
-        },
-        `"types" should be first`,
-      ],
-      [
-        {
-          source: './src/index.ts',
           default: './dist/index.js',
           require: './dist/index.cjs',
         },
         `"default" should be last`,
-      ],
-      [
-        {
-          types: './dist/index.d.ts',
-          require: './dist/index.cjs',
-          source: './src/index.ts',
-          default: './dist/index.js',
-        },
-        `"source" should be after "types"`,
       ],
       [
         {

--- a/test/parseTasks.test.ts
+++ b/test/parseTasks.test.ts
@@ -12,6 +12,7 @@ test('should parse tasks (type: module)', () => {
     source: './src/index.ts',
     main: './dist/index.cjs',
     module: './dist/index.js',
+    types: './dist/index.d.ts',
     browser: {
       './dist/index.cjs': './dist/index.browser.cjs',
       './dist/index.js': './dist/index.browser.js',
@@ -49,6 +50,23 @@ test('should parse tasks (type: module)', () => {
   const tasks = resolveBuildTasks(ctx)
 
   expect(tasks).toEqual([
+    {
+      entries: [
+        {
+          exportPath: '.',
+          importId: 'test',
+          sourcePath: './src/index.ts',
+          targetPaths: ['./dist/index.d.ts', './dist/index.d.cts'],
+        },
+        {
+          exportPath: '.',
+          importId: 'test',
+          sourcePath: './src/index.ts',
+          targetPaths: ['./dist/index.browser.d.ts', './dist/index.browser.d.cts'],
+        },
+      ],
+      type: 'build:dts',
+    },
     {
       type: 'build:js',
       buildId: 'commonjs:*',
@@ -118,6 +136,7 @@ test('should parse tasks (type: commonjs, legacyExports: true)', () => {
     source: './src/index.ts',
     main: './dist/index.js',
     module: './dist/index.esm.js',
+    types: './dist/index.d.ts',
     browser: {
       './dist/index.js': './dist/index.browser.js',
       './dist/index.esm.js': './dist/index.browser.esm.js',
@@ -155,6 +174,23 @@ test('should parse tasks (type: commonjs, legacyExports: true)', () => {
   const tasks = resolveBuildTasks(ctx)
 
   expect(tasks).toEqual([
+    {
+      type: 'build:dts',
+      entries: [
+        {
+          exportPath: '.',
+          importId: 'test',
+          sourcePath: './src/index.ts',
+          targetPaths: ['./dist/index.esm.d.mts', './dist/index.d.ts'],
+        },
+        {
+          exportPath: '.',
+          importId: 'test',
+          sourcePath: './src/index.ts',
+          targetPaths: ['./dist/index.browser.esm.d.mts', './dist/index.browser.d.ts'],
+        },
+      ],
+    },
     {
       type: 'build:js',
       buildId: 'commonjs:*',


### PR DESCRIPTION
Fixes errors such as ["👺 Masquerading as ESM"](https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseESM.md) on:
- https://arethetypeswrong.github.io/?p=%40sanity%2Fpkg-utils%405.1
- https://publint.dev/@sanity/pkg-utils@5.1.0