### PR TITLE
fix: emit valid ESM in CJS modules when `legacyExports: true`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 etc
 dist
 node_modules
+.swc

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The name of the library from which to import JSX factory and fragment names.
 - Default: `false`
 
 Build package with support for legacy exports (writes root `<export>.js` files). Use this if you
-need to support older Node.js versions or older bundlers.
+need to support older bundlers.
 
 #### `minify`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/pkg-utils",
-  "version": "5.1.2",
+  "version": "5.1.3-canary.0",
   "description": "Simple utilities for modern npm packages.",
   "keywords": [
     "sanity-io",

--- a/playground/custom-dist/package.json
+++ b/playground/custom-dist/package.json
@@ -15,7 +15,7 @@
     "./package.json": "./package.json"
   },
   "main": "./lib/index.cjs",
-  "module": "./lib/index.js",
+  "module": "./lib/index.esm.js",
   "source": "./src/index.ts",
   "types": "./lib/index.d.ts",
   "scripts": {

--- a/playground/dummy-module/package.json
+++ b/playground/dummy-module/package.json
@@ -31,11 +31,11 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "module": "./dist/index.browser.esm.js",
   "source": "./src/index.ts",
   "browser": {
-    "./dist/index.cjs": "./dist/index.browser.cjs",
-    "./dist/index.js": "./dist/index.browser.js"
+    "./dist/index.cjs": "./dist/index.browser.esm.js",
+    "./dist/index.js": "./dist/index.browser.esm.js"
   },
   "types": "./dist/index.d.ts",
   "typesVersions": {

--- a/playground/multi-exports-commonjs/package.json
+++ b/playground/multi-exports-commonjs/package.json
@@ -8,15 +8,15 @@
   "exports": {
     ".": {
       "source": "./src/index.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js",
-      "default": "./dist/index.esm.js"
+      "default": "./dist/index.js"
     },
     "./plugin": {
       "source": "./src/plugin.ts",
-      "import": "./dist/plugin.esm.js",
+      "import": "./dist/plugin.mjs",
       "require": "./dist/plugin.js",
-      "default": "./dist/plugin.esm.js"
+      "default": "./dist/plugin.js"
     },
     "./package.json": "./package.json"
   },

--- a/playground/multi-exports-commonjs/src/index.ts
+++ b/playground/multi-exports-commonjs/src/index.ts
@@ -1,3 +1,4 @@
 export * from './defineConfig'
 export * from './definePlugin'
+export * from './shared'
 export * from './types'

--- a/playground/multi-exports-commonjs/src/plugin.ts
+++ b/playground/multi-exports-commonjs/src/plugin.ts
@@ -6,3 +6,5 @@ export function plugin(): Plugin {
     name: 'plugin',
   })
 }
+
+export * from './shared'

--- a/playground/multi-exports-commonjs/src/shared.ts
+++ b/playground/multi-exports-commonjs/src/shared.ts
@@ -1,0 +1,5 @@
+/**
+ * Exported from both entry-points to trigger chunking
+ * @public
+ */
+export const shared = 'shared'

--- a/playground/styled-components-module/.swcrc
+++ b/playground/styled-components-module/.swcrc
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/swcrc",
+  "jsc": {
+    "experimental": {
+      "plugins": [
+        [
+          "@swc/plugin-styled-components",
+          {
+
+            "pure": true,
+          }
+        ]
+      ]
+    }
+  },
+  "minify": false
+}

--- a/playground/styled-components-module/package.config.ts
+++ b/playground/styled-components-module/package.config.ts
@@ -1,0 +1,17 @@
+import swc from '@rollup/plugin-swc'
+import {defineConfig} from '@sanity/pkg-utils'
+
+export default defineConfig({
+  extract: {
+    rules: {
+      'ae-forgotten-export': 'off',
+    },
+  },
+  tsconfig: 'tsconfig.dist.json',
+  rollup: {
+    plugins: [swc()],
+  },
+  babel: {
+    // plugins: ['babel-plugin-styled-components'],
+  },
+})

--- a/playground/styled-components-module/package.json
+++ b/playground/styled-components-module/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "styled-components-module",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "source": "./src/index.ts",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "run-s clean && pkg build --strict && pkg check --strict",
+    "test": "node test.mjs",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@rollup/plugin-commonjs": "^25.0.7",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-swc": "^0.3.0",
+    "@swc/plugin-styled-components": "^1.5.119",
+    "@types/react": "^18.2.67",
+    "babel-plugin-styled-components": "^2.1.4",
+    "react": "^18.2.0",
+    "rollup": "^4.13.0",
+    "rollup-plugin-esbuild": "^6.1.1",
+    "styled-components": "^6.1.8"
+  }
+}

--- a/playground/styled-components-module/rollup.config.mjs
+++ b/playground/styled-components-module/rollup.config.mjs
@@ -1,0 +1,38 @@
+import commonjs from '@rollup/plugin-commonjs'
+import resolve from '@rollup/plugin-node-resolve'
+
+export default {
+  logLevel: 'debug',
+  input: ['src/index2.js'],
+  output: {
+    entryFileNames: '[name].js',
+    dir: 'dist',
+    format: 'esm',
+    exports: 'named',
+    interop: 'auto',
+  },
+  plugins: [
+    resolve({
+      extensions: ['.cjs', '.mjs', '.js', '.jsx', '.json', '.node'],
+      preferBuiltins: true,
+      // allowExportsFolderMapping: false,
+      // exportConditions: ['node'],
+      // resolveOnly: (mod) => {
+      //   return mod !== 'styled-components'
+      // },
+
+      // Intentionally not using 'module' as it has problems with styled-components and Node in ESM mode
+      // mainFields: ['main'],
+      // modulesOnly: true,
+    }),
+    // /*
+    commonjs({
+      esmExternals: true,
+      // defaultIsModuleExports: true,
+      // requireReturnsDefault: false,
+    }),
+    // */
+    // cjsDetectionPlugin(),
+  ],
+  external: ['react', 'react/jsx-runtime'],
+}

--- a/playground/styled-components-module/src/Card.tsx
+++ b/playground/styled-components-module/src/Card.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components'
+
+const Box = styled.div`
+  display: block;
+`
+
+/** @public */
+export function Card({children}: React.PropsWithChildren) {
+  return <Box>{children}</Box>
+}

--- a/playground/styled-components-module/src/index.ts
+++ b/playground/styled-components-module/src/index.ts
@@ -1,0 +1,1 @@
+export * from './Card'

--- a/playground/styled-components-module/test.mjs
+++ b/playground/styled-components-module/test.mjs
@@ -1,0 +1,10 @@
+// the default import is not supported
+// import styled from 'styled-components'
+import {styled} from 'styled-components'
+
+// import {Card} from 'styled-components-module'
+import {Card as CardCjs} from './dist/index.cjs'
+import {Card as CardEsm} from './dist/index.js'
+
+// console.log({Card})
+console.log(CardCjs === CardEsm, CardCjs({}), CardEsm({}), styled.div)

--- a/playground/styled-components-module/tsconfig.dist.json
+++ b/playground/styled-components-module/tsconfig.dist.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["./src"],
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  }
+}

--- a/playground/styled-components-module/tsconfig.json
+++ b/playground/styled-components-module/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["./src"],
+  "compilerOptions": {
+    "noEmit": true,
+  }
+}

--- a/playground/styled-components-module/tsconfig.settings.json
+++ b/playground/styled-components-module/tsconfig.settings.json
@@ -4,6 +4,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "jsx": "preserve",
 
     // Strict type-checking
     "strict": true,
@@ -24,6 +25,6 @@
     // Module resolution
     "module": "Preserve",
     "moduleDetection": "force",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": false
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -443,6 +443,39 @@ importers:
         specifier: ^3.12.0
         version: 3.12.0
 
+  playground/styled-components-module:
+    dependencies:
+      '@rollup/plugin-commonjs':
+        specifier: ^25.0.7
+        version: 25.0.7(rollup@4.13.0)
+      '@rollup/plugin-node-resolve':
+        specifier: ^15.2.3
+        version: 15.2.3(rollup@4.13.0)
+      '@rollup/plugin-swc':
+        specifier: ^0.3.0
+        version: 0.3.0(@swc/core@1.4.8)(rollup@4.13.0)
+      '@swc/plugin-styled-components':
+        specifier: ^1.5.119
+        version: 1.5.119
+      '@types/react':
+        specifier: ^18.2.67
+        version: 18.2.67
+      babel-plugin-styled-components:
+        specifier: ^2.1.4
+        version: 2.1.4(@babel/core@7.24.1)(styled-components@6.1.8)
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      rollup:
+        specifier: ^4.13.0
+        version: 4.13.0
+      rollup-plugin-esbuild:
+        specifier: ^6.1.1
+        version: 6.1.1(esbuild@0.20.2)(rollup@4.13.0)
+      styled-components:
+        specifier: ^6.1.8
+        version: 6.1.8(react-dom@18.2.0)(react@18.2.0)
+
   playground/ts: {}
 
   playground/ts-bundler: {}
@@ -588,7 +621,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.24.0
-    dev: true
 
   /@babel/helper-compilation-targets@7.23.6:
     resolution: {integrity: sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==}
@@ -639,7 +671,6 @@ packages:
   /@babel/helper-plugin-utils@7.24.0:
     resolution: {integrity: sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-simple-access@7.22.5:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
@@ -714,7 +745,6 @@ packages:
     dependencies:
       '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-    dev: true
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.24.1):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
@@ -954,6 +984,20 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
+
+  /@emotion/is-prop-valid@1.2.1:
+    resolution: {integrity: sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==}
+    dependencies:
+      '@emotion/memoize': 0.8.1
+    dev: false
+
+  /@emotion/memoize@0.8.1:
+    resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
+    dev: false
+
+  /@emotion/unitless@0.8.0:
+    resolution: {integrity: sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==}
+    dev: false
 
   /@esbuild/aix-ppc64@0.19.12:
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -1757,6 +1801,22 @@ packages:
       rollup: 4.13.0
     dev: false
 
+  /@rollup/plugin-swc@0.3.0(@swc/core@1.4.8)(rollup@4.13.0):
+    resolution: {integrity: sha512-PC1c1FFAwGoasYUesGCMtJ3DggJl1l9ydvufze5esUwdIFjg2BmKeM6j0JA6WHTJjx6C4x9RjF4LNHEIknKPgA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@swc/core': ^1.3.0
+      rollup: ^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.13.0)
+      '@swc/core': 1.4.8
+      rollup: 4.13.0
+      smob: 1.4.1
+    dev: false
+
   /@rollup/plugin-terser@0.4.4(rollup@4.13.0):
     resolution: {integrity: sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==}
     engines: {node: '>=14.0.0'}
@@ -2098,11 +2158,142 @@ packages:
       - supports-color
     dev: true
 
+  /@swc/core-darwin-arm64@1.4.8:
+    resolution: {integrity: sha512-hhQCffRTgzpTIbngSnC30vV6IJVTI9FFBF954WEsshsecVoCGFiMwazBbrkLG+RwXENTrMhgeREEFh6R3KRgKQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-darwin-x64@1.4.8:
+    resolution: {integrity: sha512-P3ZBw8Jr8rKhY/J8d+6WqWriqngGTgHwtFeJ8MIakQJTbdYbFgXSZxcvDiERg3psbGeFXaUaPI0GO6BXv9k/OQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-linux-arm-gnueabihf@1.4.8:
+    resolution: {integrity: sha512-PP9JIJt19bUWhAGcQW6qMwTjZOcMyzkvZa0/LWSlDm0ORYVLmDXUoeQbGD3e0Zju9UiZxyulnpjEN0ZihJgPTA==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-linux-arm64-gnu@1.4.8:
+    resolution: {integrity: sha512-HvEWnwKHkoVUr5iftWirTApFJ13hGzhAY2CMw4lz9lur2m+zhPviRRED0FCI6T95Knpv7+8eUOr98Z7ctrG6DQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-linux-arm64-musl@1.4.8:
+    resolution: {integrity: sha512-kY8+qa7k/dEeBq9p0Hrta18QnJPpsiJvDQSLNaTIFpdM3aEM9zbkshWz8gaX5VVGUEALowCBUWqmzO4VaqM+2w==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-linux-x64-gnu@1.4.8:
+    resolution: {integrity: sha512-0WWyIw432wpO/zeGblwq4f2YWam4pn8Z/Ig4KzHMgthR/KmiLU3f0Z7eo45eVmq5vcU7Os1zi/Zb65OOt09q/w==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-linux-x64-musl@1.4.8:
+    resolution: {integrity: sha512-p4yxvVS05rBNCrBaSTa20KK88vOwtg8ifTW7ec/yoab0bD5EwzzB8KbDmLLxE6uziFa0sdjF0dfRDwSZPex37Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-win32-arm64-msvc@1.4.8:
+    resolution: {integrity: sha512-jKuXihxAaqUnbFfvPxtmxjdJfs87F1GdBf33il+VUmSyWCP4BE6vW+/ReDAe8sRNsKyrZ3UH1vI5q1n64csBUA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-win32-ia32-msvc@1.4.8:
+    resolution: {integrity: sha512-O0wT4AGHrX8aBeH6c2ADMHgagAJc5Kf6W48U5moyYDAkkVnKvtSc4kGhjWhe1Yl0sI0cpYh2In2FxvYsb44eWw==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-win32-x64-msvc@1.4.8:
+    resolution: {integrity: sha512-C2AYc3A2o+ECciqsJWRgIpp83Vk5EaRzHe7ed/xOWzVd0MsWR+fweEsyOjlmzHfpUxJSi46Ak3/BIZJlhZbXbg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core@1.4.8:
+    resolution: {integrity: sha512-uY2RSJcFPgNOEg12RQZL197LZX+MunGiKxsbxmh22VfVxrOYGRvh4mPANFlrD1yb38CgmW1wI6YgIi8LkIwmWg==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    peerDependencies:
+      '@swc/helpers': ^0.5.0
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.6
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.4.8
+      '@swc/core-darwin-x64': 1.4.8
+      '@swc/core-linux-arm-gnueabihf': 1.4.8
+      '@swc/core-linux-arm64-gnu': 1.4.8
+      '@swc/core-linux-arm64-musl': 1.4.8
+      '@swc/core-linux-x64-gnu': 1.4.8
+      '@swc/core-linux-x64-musl': 1.4.8
+      '@swc/core-win32-arm64-msvc': 1.4.8
+      '@swc/core-win32-ia32-msvc': 1.4.8
+      '@swc/core-win32-x64-msvc': 1.4.8
+    dev: false
+
+  /@swc/counter@0.1.3:
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+    dev: false
+
   /@swc/helpers@0.5.2:
     resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
     dependencies:
       tslib: 2.6.2
     dev: true
+
+  /@swc/plugin-styled-components@1.5.119:
+    resolution: {integrity: sha512-rlKh9t+BszPW+CkY119A8f3XygxA+F/4k8gF/rFLU1Q00r0LmxMrzUr7bz7UcBjPXIhKZPKt2XKQms9CkG2oQg==}
+    dependencies:
+      '@swc/counter': 0.1.3
+    dev: false
+
+  /@swc/types@0.1.6:
+    resolution: {integrity: sha512-/JLo/l2JsT/LRd80C3HfbmVpxOAJ11FO2RCEslFrgzLltoP9j8XIbsyDcfCt2WWyX+CM96rBoNM+IToAkFOugg==}
+    dependencies:
+      '@swc/counter': 0.1.3
+    dev: false
 
   /@tsconfig/node-lts@20.1.1:
     resolution: {integrity: sha512-V7wHydi1dv8I8xiOX3pJ0lhC+MlOakznvLks94J6y/TqQK6DBcbdD1G4jEq8yU+s6lBASPn4e1Ci636fDqeyvQ==}
@@ -2260,7 +2451,6 @@ packages:
 
   /@types/prop-types@15.7.11:
     resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
-    dev: true
 
   /@types/pug@2.0.10:
     resolution: {integrity: sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==}
@@ -2272,7 +2462,6 @@ packages:
       '@types/prop-types': 15.7.11
       '@types/scheduler': 0.16.8
       csstype: 3.1.3
-    dev: true
 
   /@types/resolve@1.20.2:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -2287,11 +2476,14 @@ packages:
 
   /@types/scheduler@0.16.8:
     resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
-    dev: true
 
   /@types/semver@7.5.8:
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
     dev: true
+
+  /@types/stylis@4.2.0:
+    resolution: {integrity: sha512-n4sx2bqL0mW1tvDf/loQ+aMX7GQD3lc3fkCMC55VFNDu/vBOabO+LTIeXKM14xK0ppk5TUGcWRjiSpIlUpghKw==}
+    dev: false
 
   /@types/treeify@1.0.3:
     resolution: {integrity: sha512-hx0o7zWEUU4R2Amn+pjCBQQt23Khy/Dk56gQU5xi5jtPL1h83ACJCeFaB2M/+WO1AntvWrSoVnnCAfI1AQH4Cg==}
@@ -2938,6 +3130,21 @@ packages:
     dev: true
     optional: true
 
+  /babel-plugin-styled-components@2.1.4(@babel/core@7.24.1)(styled-components@6.1.8):
+    resolution: {integrity: sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==}
+    peerDependencies:
+      styled-components: '>= 2'
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.24.1)
+      lodash: 4.17.21
+      picomatch: 2.3.1
+      styled-components: 6.1.8(react-dom@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+    dev: false
+
   /babel-runtime@6.26.0:
     resolution: {integrity: sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==}
     dependencies:
@@ -3294,6 +3501,10 @@ packages:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
     engines: {node: '>=14.16'}
     dev: true
+
+  /camelize@1.0.1:
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
+    dev: false
 
   /caniuse-lite@1.0.30001599:
     resolution: {integrity: sha512-LRAQHZ4yT1+f9LemSMeqdMpMxZcc4RMWdj4tiFe3G8tNkWK+E58g+/tzotb5cU6TbcVJLr4fySiAW7XmxQvZQA==}
@@ -3844,6 +4055,19 @@ packages:
       randomfill: 1.0.4
     dev: true
 
+  /css-color-keywords@1.0.0:
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /css-to-react-native@3.2.0:
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
+    dependencies:
+      camelize: 1.0.1
+      css-color-keywords: 1.0.0
+      postcss-value-parser: 4.2.0
+    dev: false
+
   /css-tree@2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -3858,9 +4082,12 @@ packages:
     hasBin: true
     dev: true
 
+  /csstype@3.1.2:
+    resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
+    dev: false
+
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
-    dev: true
 
   /cz-conventional-changelog@3.3.0(@types/node@20.11.29)(typescript@5.4.2):
     resolution: {integrity: sha512-U466fIzU5U22eES5lTNiNbZ+d8dfcHcssH4o7QsdWaCcRs/feIPCxKYSWkYBNs5mny7MvEfwpTLWjvbm94hecw==}
@@ -6818,7 +7045,6 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
-    dev: true
 
   /loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
@@ -7545,7 +7771,6 @@ packages:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: true
 
   /nanomatch@1.2.13(supports-color@4.5.0):
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
@@ -8321,6 +8546,10 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
+  /postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+    dev: false
+
   /postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -8328,7 +8557,6 @@ packages:
       nanoid: 3.3.7
       picocolors: 1.0.0
       source-map-js: 1.1.0
-    dev: true
 
   /postcss@8.4.36:
     resolution: {integrity: sha512-/n7eumA6ZjFHAsbX30yhHup/IMkOmlmvtEi7P+6RMYf+bGJSUHc3geH4a0NSZxAz/RJfiS9tooCTs9LAVYUZKw==}
@@ -8562,7 +8790,6 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
-    dev: true
 
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
@@ -8573,7 +8800,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
-    dev: true
 
   /read-package-json-fast@3.0.2:
     resolution: {integrity: sha512-0J+Msgym3vrLOUB3hzQCuZHII0xkNGCtz/HJH9xZshwv9DbDwkw1KaE3gx/e2J5rpEY5rtOy6cyhKOPrkP7FZw==}
@@ -9073,7 +9299,6 @@ packages:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
     dependencies:
       loose-envify: 1.4.0
-    dev: true
 
   /scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
@@ -9170,6 +9395,10 @@ packages:
       inherits: 2.0.4
       safe-buffer: 5.2.1
     dev: true
+
+  /shallowequal@1.1.0:
+    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
+    dev: false
 
   /sharp@0.32.6:
     resolution: {integrity: sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==}
@@ -9375,7 +9604,6 @@ packages:
   /source-map-js@1.1.0:
     resolution: {integrity: sha512-9vC2SfsJzlej6MAaMPLu8HiBSHGdRAJ9hVFYN1ibZoNkeanmDmLUcIrj6G9DGL7XMJ54AKg/G75akXl1/izTOw==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /source-map-resolve@0.5.3:
     resolution: {integrity: sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==}
@@ -9690,6 +9918,26 @@ packages:
       js-tokens: 8.0.3
     dev: true
 
+  /styled-components@6.1.8(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-PQ6Dn+QxlWyEGCKDS71NGsXoVLKfE1c3vApkvDYS5KAK+V8fNWGhbSUEo9Gg2iaID2tjLXegEW3bZDUGpofRWw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      react: '>= 16.8.0'
+      react-dom: '>= 16.8.0'
+    dependencies:
+      '@emotion/is-prop-valid': 1.2.1
+      '@emotion/unitless': 0.8.0
+      '@types/stylis': 4.2.0
+      css-to-react-native: 3.2.0
+      csstype: 3.1.2
+      postcss: 8.4.31
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      shallowequal: 1.1.0
+      stylis: 4.3.1
+      tslib: 2.5.0
+    dev: false
+
   /styled-jsx@5.1.1(@babel/core@7.24.1)(react@18.2.0):
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
     engines: {node: '>= 12.0.0'}
@@ -9707,6 +9955,10 @@ packages:
       client-only: 0.0.1
       react: 18.2.0
     dev: true
+
+  /stylis@4.3.1:
+    resolution: {integrity: sha512-EQepAV+wMsIaGVGX1RECzgrcqRRU/0sYOHkeLsZ3fzHaHXZy4DaOOX0vOlGQdlsjkh3mFHAIlVimpwAs4dslyQ==}
+    dev: false
 
   /subarg@1.0.0:
     resolution: {integrity: sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==}
@@ -10133,6 +10385,10 @@ packages:
       minimist: 1.2.8
       strip-bom: 3.0.0
     dev: true
+
+  /tslib@2.5.0:
+    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
+    dev: false
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -1,4 +1,4 @@
-import {getPkgExtMap, loadConfig, loadPkgWithReporting} from './core'
+import {loadConfig, loadPkgWithReporting} from './core'
 import {createLogger} from './logger'
 import {resolveBuildContext} from './resolveBuildContext'
 import {resolveBuildTasks} from './resolveBuildTasks'
@@ -36,14 +36,12 @@ export async function build(options: {
   const pkg = await loadPkgWithReporting({cwd, logger, strict})
 
   const config = await loadConfig({cwd})
-  const extMap = getPkgExtMap({legacyExports: config?.legacyExports ?? false})
   const tsconfig = tsconfigOption || config?.tsconfig || 'tsconfig.json'
 
   const ctx = await resolveBuildContext({
     config,
     cwd,
     emitDeclarationOnly,
-    extMap,
     logger,
     pkg,
     strict,

--- a/src/node/check.ts
+++ b/src/node/check.ts
@@ -2,7 +2,7 @@ import esbuild, {type BuildFailure} from 'esbuild'
 import path from 'path'
 
 import {createConsoleSpy} from './consoleSpy'
-import {getPkgExtMap, loadConfig, loadPkgWithReporting} from './core'
+import {loadConfig, loadPkgWithReporting} from './core'
 import {fileExists} from './fileExists'
 import {createLogger, type Logger} from './logger'
 import {printPackageTree} from './printPackageTree'
@@ -19,9 +19,8 @@ export async function check(options: {
 
   const pkg = await loadPkgWithReporting({cwd, logger, strict})
   const config = await loadConfig({cwd})
-  const extMap = getPkgExtMap({legacyExports: config?.legacyExports ?? false})
   const tsconfig = tsconfigOption || config?.tsconfig || 'tsconfig.json'
-  const ctx = await resolveBuildContext({config, cwd, extMap, logger, pkg, strict, tsconfig})
+  const ctx = await resolveBuildContext({config, cwd, logger, pkg, strict, tsconfig})
 
   printPackageTree(ctx)
 

--- a/src/node/core/contexts/buildContext.ts
+++ b/src/node/core/contexts/buildContext.ts
@@ -1,8 +1,8 @@
-import ts from 'typescript'
+import type ts from 'typescript'
 
-import {Logger} from '../../logger'
-import {PkgConfigOptions, PkgExports, PkgRuntime} from '../config'
-import {PackageJSON, PkgExtMap} from '../pkg'
+import type {Logger} from '../../logger'
+import type {PkgConfigOptions, PkgExports, PkgRuntime} from '../config'
+import type {PackageJSON} from '../pkg'
 
 /** @internal */
 export interface BuildFile {
@@ -17,7 +17,6 @@ export interface BuildContext {
   distPath: string
   emitDeclarationOnly: boolean
   exports: PkgExports | undefined
-  extMap: PkgExtMap
   external: string[]
   files: BuildFile[]
   logger: Logger

--- a/src/node/core/pkg/pkgExt.ts
+++ b/src/node/core/pkg/pkgExt.ts
@@ -1,11 +1,14 @@
+import {legacyEnding} from '../../tasks/dts/getTargetPaths'
+
 /** @internal */
 export interface PkgExtMap {
   commonjs: {commonjs: string; esm: string}
   module: {commonjs: string; esm: string}
+  legacy: string
 }
 
 /** @internal */
-export const DEFAULT_PKG_EXT_MAP: PkgExtMap = {
+export const pkgExtMap: PkgExtMap = {
   // pkg.type: "commonjs"
   commonjs: {
     commonjs: '.js',
@@ -17,22 +20,6 @@ export const DEFAULT_PKG_EXT_MAP: PkgExtMap = {
     commonjs: '.cjs',
     esm: '.js',
   },
-}
-
-/** @internal */
-export function getPkgExtMap(options: {legacyExports: boolean}): PkgExtMap {
-  const {legacyExports} = options
-
-  const ret = {...DEFAULT_PKG_EXT_MAP}
-
-  // Fall back to legacy file extensions for package.json with `"type": "commonjs"`
-  // NOTE: Not supported by Node 14+ and will be removed in a future version
-  if (legacyExports) {
-    ret['commonjs'] = {
-      commonjs: '.js',
-      esm: '.esm.js',
-    }
-  }
-
-  return ret
+  // package.config.legacyExports: true
+  legacy: legacyEnding,
 }

--- a/src/node/core/pkg/validateExports.ts
+++ b/src/node/core/pkg/validateExports.ts
@@ -1,16 +1,17 @@
-import {PkgExport} from '../config'
-import {PkgExtMap} from './pkgExt'
-import {PackageJSON} from './types'
+import type {PkgExport} from '../config'
+import {pkgExtMap as extMap} from './pkgExt'
+import type {PackageJSON} from './types'
 
 export function validateExports(
   _exports: (PkgExport & {_path: string})[],
-  options: {extMap: PkgExtMap; pkg: PackageJSON},
+  options: {pkg: PackageJSON},
 ): string[] {
-  const {extMap, pkg} = options
+  const {pkg} = options
   const ext = extMap[pkg.type || 'commonjs']
 
   const errors: string[] = []
 
+  // @TODO validate that no exports declare the legacy exports
   for (const exp of _exports) {
     if (exp.require && !exp.require.endsWith(ext.commonjs)) {
       errors.push(

--- a/src/node/resolveBuildContext.ts
+++ b/src/node/resolveBuildContext.ts
@@ -2,19 +2,18 @@ import browserslistToEsbuild from 'browserslist-to-esbuild'
 import path from 'path'
 
 import {
-  BuildContext,
+  type BuildContext,
   DEFAULT_BROWSERSLIST_QUERY,
   loadTSConfig,
-  PackageJSON,
+  type PackageJSON,
   parseExports,
-  PkgConfigOptions,
-  PkgExports,
-  PkgExtMap,
-  PkgRuntime,
+  type PkgConfigOptions,
+  type PkgExports,
+  type PkgRuntime,
   resolveConfigProperty,
 } from './core'
 import {findCommonDirPath, pathContains} from './core/findCommonPath'
-import {Logger} from './logger'
+import type {Logger} from './logger'
 import {resolveBrowserTarget} from './resolveBrowserTarget'
 import {resolveNodeTarget} from './resolveNodeTarget'
 
@@ -22,7 +21,6 @@ export async function resolveBuildContext(options: {
   config?: PkgConfigOptions
   cwd: string
   emitDeclarationOnly?: boolean
-  extMap: PkgExtMap
   logger: Logger
   pkg: PackageJSON
   strict: boolean
@@ -32,7 +30,6 @@ export async function resolveBuildContext(options: {
     config,
     cwd,
     emitDeclarationOnly = false,
-    extMap,
     logger,
     pkg,
     strict,
@@ -76,7 +73,11 @@ export async function resolveBuildContext(options: {
     'node': nodeTarget,
   }
 
-  const parsedExports = parseExports({extMap, pkg, strict}).reduce<PkgExports>((acc, x) => {
+  const parsedExports = parseExports({
+    pkg,
+    strict,
+    legacyExports: config?.legacyExports ?? false,
+  }).reduce<PkgExports>((acc, x) => {
     const {_path: exportPath, ...exportEntry} = x
 
     return {...acc, [exportPath]: exportEntry}
@@ -146,7 +147,6 @@ export async function resolveBuildContext(options: {
     emitDeclarationOnly,
     exports,
     external,
-    extMap,
     files: [],
     logger,
     pkg,

--- a/src/node/tasks/dts/buildTypes.ts
+++ b/src/node/tasks/dts/buildTypes.ts
@@ -40,7 +40,11 @@ export async function buildTypes(options: {
   const allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics)
 
   for (const diagnostic of allDiagnostics) {
-    printDiagnostic({cwd, logger, diagnostic})
+    // @TODO match the import with known export paths
+    // Ignore TS2307 errors as they'll be captured elsewhere if they're actually a problem
+    if (diagnostic.code !== 2307) {
+      printDiagnostic({cwd, logger, diagnostic})
+    }
   }
 
   if (emitResult.emitSkipped) {

--- a/src/node/tasks/dts/getTargetPaths.ts
+++ b/src/node/tasks/dts/getTargetPaths.ts
@@ -1,7 +1,11 @@
 import type {PackageJSON, PkgBundle, PkgExport} from '../../core'
 
-const fileEnding = /\.[mc]?js$/
-const dtsEnding = '.d.ts'
+/** @internal */
+export const fileEnding = /\.[mc]?js$/
+/** @internal */
+export const dtsEnding = '.d.ts'
+/** @internal */
+export const legacyEnding = '.esm.js'
 const mtsEnding = '.d.mts'
 const ctsEnding = '.d.cts'
 

--- a/src/node/tasks/index.ts
+++ b/src/node/tasks/index.ts
@@ -1,6 +1,6 @@
 import {dtsTask, dtsWatchTask} from './dts'
-import {rollupTask, rollupWatchTask} from './rollup'
-import {BuildTaskHandlers, WatchTaskHandlers} from './types'
+import {rollupLegacyTask, rollupTask, rollupWatchTask} from './rollup'
+import type {BuildTaskHandlers, WatchTaskHandlers} from './types'
 
 export * from './dts'
 export * from './rollup'
@@ -10,6 +10,7 @@ export * from './types'
 export const buildTaskHandlers: BuildTaskHandlers = {
   'build:dts': dtsTask,
   'build:js': rollupTask,
+  'build:legacy': rollupLegacyTask,
 }
 
 /** @internal */

--- a/src/node/tasks/rollup/index.ts
+++ b/src/node/tasks/rollup/index.ts
@@ -1,2 +1,3 @@
+export * from './rollupLegacyTask'
 export * from './rollupTask'
 export * from './rollupWatchTask'

--- a/src/node/tasks/rollup/rollupLegacyTask.ts
+++ b/src/node/tasks/rollup/rollupLegacyTask.ts
@@ -5,29 +5,16 @@ import {Observable} from 'rxjs'
 
 import {createConsoleSpy} from '../../consoleSpy'
 import type {BuildContext} from '../../core'
-import type {RollupTask, TaskHandler} from '../types'
+import type {RollupLegacyTask, TaskHandler} from '../types'
 import {resolveRollupConfig} from './resolveRollupConfig'
 
 /** @internal */
-export const rollupTask: TaskHandler<RollupTask> = {
+export const rollupLegacyTask: TaskHandler<RollupLegacyTask> = {
   name: (ctx, task) => {
-    const bundleEntries = task.entries.filter((e) => e.path.includes('__$$bundle_'))
     const entries = task.entries.filter((e) => !e.path.includes('__$$bundle_'))
 
     const targetLines = task.target.length
-      ? [`  target:`, ...task.target.map((t) => `    - ${chalk.yellow(t)}`)]
-      : []
-
-    const bundlesLines = bundleEntries.length
-      ? [
-          '  bundles:',
-          ...bundleEntries.map((e) =>
-            [
-              `    - `,
-              `${chalk.yellow(e.source)} ${chalk.gray('→')} ${chalk.yellow(e.output)}`,
-            ].join(''),
-          ),
-        ]
+      ? ['  target:', ...task.target.map((t) => `    - ${chalk.yellow(t)}`)]
       : []
 
     const entriesLines = entries.length
@@ -35,7 +22,7 @@ export const rollupTask: TaskHandler<RollupTask> = {
           '  entries:',
           ...entries.map((e) =>
             [
-              `    - `,
+              '    - ',
               `${chalk.cyan(path.join(ctx.pkg.name, e.path))}: `,
               `${chalk.yellow(e.source)} ${chalk.gray('→')} ${chalk.yellow(e.output)}`,
             ].join(''),
@@ -43,11 +30,12 @@ export const rollupTask: TaskHandler<RollupTask> = {
         ]
       : []
 
+    // @TODO list out the root level files that are generated
+
     return [
-      `Build javascript files...`,
+      'Build legacy exports...',
       `  format: ${chalk.yellow(task.format)}`,
       ...targetLines,
-      ...bundlesLines,
       ...entriesLines,
     ].join('\n')
   },
@@ -70,7 +58,7 @@ export const rollupTask: TaskHandler<RollupTask> = {
   },
 }
 
-async function execPromise(ctx: BuildContext, task: RollupTask) {
+async function execPromise(ctx: BuildContext, task: RollupLegacyTask) {
   const {distPath, files, logger} = ctx
   const outDir = path.relative(ctx.cwd, distPath)
 

--- a/src/node/tasks/types.ts
+++ b/src/node/tasks/types.ts
@@ -1,8 +1,8 @@
-import {RollupWatcherEvent} from 'rollup'
-import {Observable} from 'rxjs'
+import type {RollupWatcherEvent} from 'rollup'
+import type {Observable} from 'rxjs'
 
-import {BuildContext, PkgRuntime} from '../core'
-import {DtsResult, DtsTask, DtsWatchTask} from './dts'
+import type {BuildContext, PkgRuntime} from '../core'
+import type {DtsResult, DtsTask, DtsWatchTask} from './dts'
 
 /** @internal */
 export interface RollupTaskEntry {
@@ -22,6 +22,16 @@ export interface RollupTask {
 }
 
 /** @internal */
+export interface RollupLegacyTask {
+  type: 'build:legacy'
+  buildId: string
+  entries: RollupTaskEntry[]
+  runtime: PkgRuntime
+  format: 'esm'
+  target: string[]
+}
+
+/** @internal */
 export interface RollupWatchTask {
   type: 'watch:js'
   buildId: string
@@ -32,7 +42,7 @@ export interface RollupWatchTask {
 }
 
 /** @internal */
-export type BuildTask = DtsTask | RollupTask
+export type BuildTask = DtsTask | RollupTask | RollupLegacyTask
 
 /** @internal */
 export type WatchTask = DtsWatchTask | RollupWatchTask
@@ -49,6 +59,7 @@ export type TaskHandler<Task, Result = void> = {
 export interface BuildTaskHandlers {
   'build:dts': TaskHandler<DtsTask, DtsResult>
   'build:js': TaskHandler<RollupTask>
+  'build:legacy': TaskHandler<RollupLegacyTask>
 }
 
 /** @internal */

--- a/src/node/watch.ts
+++ b/src/node/watch.ts
@@ -1,11 +1,11 @@
 import path from 'path'
 import {switchMap} from 'rxjs'
 
-import {getPkgExtMap, loadConfig, loadPkgWithReporting} from './core'
+import {loadConfig, loadPkgWithReporting} from './core'
 import {createLogger} from './logger'
 import {resolveBuildContext} from './resolveBuildContext'
 import {resolveWatchTasks} from './resolveWatchTasks'
-import {TaskHandler, WatchTask, watchTaskHandlers} from './tasks'
+import {type TaskHandler, type WatchTask, watchTaskHandlers} from './tasks'
 import {watchConfigFiles} from './watchConfigFiles'
 
 /** @public */
@@ -32,10 +32,9 @@ export async function watch(options: {
 
       const pkg = await loadPkgWithReporting({cwd, logger, strict})
       const config = await loadConfig({cwd})
-      const extMap = getPkgExtMap({legacyExports: config?.legacyExports ?? false})
       const tsconfig = tsconfigOption || config?.tsconfig || 'tsconfig.json'
 
-      return resolveBuildContext({config, cwd, extMap, logger, pkg, strict, tsconfig})
+      return resolveBuildContext({config, cwd, logger, pkg, strict, tsconfig})
     }),
   )
 

--- a/test/parseExports.test.ts
+++ b/test/parseExports.test.ts
@@ -1,11 +1,9 @@
 import {describe, expect, test} from 'vitest'
 
-import {getPkgExtMap, PackageJSON, parseExports} from '../src/node'
+import {type PackageJSON, parseExports} from '../src/node'
 
 describe('parseExports', () => {
   test('parse basic package.json', () => {
-    const extMap = getPkgExtMap({legacyExports: false})
-
     const pkg: PackageJSON = {
       type: 'commonjs',
       name: 'test',
@@ -24,7 +22,7 @@ describe('parseExports', () => {
       },
     }
 
-    const exports = parseExports({pkg, extMap, strict: true})
+    const exports = parseExports({pkg, strict: true, legacyExports: false})
 
     expect(exports).toEqual([
       {
@@ -41,8 +39,6 @@ describe('parseExports', () => {
   })
 
   test('should throw if `package.json` is missing from the exports', () => {
-    const extMap = getPkgExtMap({legacyExports: false})
-
     const pkg: PackageJSON = {
       type: 'commonjs',
       name: 'test',
@@ -59,14 +55,12 @@ describe('parseExports', () => {
       },
     }
 
-    expect(() => parseExports({extMap, pkg, strict: true})).toThrow(
+    expect(() => parseExports({pkg, strict: true, legacyExports: false})).toThrow(
       '\n- package.json: `exports["./package.json"] must be declared.',
     )
   })
 
   test('parse package.json with browser files', () => {
-    const extMap = getPkgExtMap({legacyExports: false})
-
     const pkg: PackageJSON = {
       type: 'module',
       name: 'test',
@@ -88,7 +82,7 @@ describe('parseExports', () => {
       },
     }
 
-    const exports = parseExports({extMap, pkg, strict: true})
+    const exports = parseExports({pkg, strict: true, legacyExports: false})
 
     expect(exports).toEqual([
       {
@@ -109,8 +103,6 @@ describe('parseExports', () => {
   })
 
   test('package.json with multiple exports errors', () => {
-    const extMap = getPkgExtMap({legacyExports: false})
-
     const pkg: PackageJSON = {
       type: 'commonjs',
       name: 'test',
@@ -131,7 +123,7 @@ describe('parseExports', () => {
       types: './lib/src/index.d.ts',
     }
 
-    expect(() => parseExports({extMap, pkg, strict: true})).toThrow(
+    expect(() => parseExports({pkg, strict: true, legacyExports: false})).toThrow(
       '\n- package.json: mismatch between "main" and "exports.require". These must be equal.' +
         '\n- package.json: mismatch between "module" and "exports.import" These must be equal.' +
         '\n- package.json: `exports["./package.json"] must be "./package.json".' +
@@ -194,8 +186,6 @@ describe('parseExports', () => {
         `"node" can output both a "import" and "require" condition`,
       ],
     ])('%o', (json, msg) => {
-      const extMap = getPkgExtMap({legacyExports: false})
-
       const pkg = {
         type: 'module',
         name: 'test',
@@ -211,7 +201,7 @@ describe('parseExports', () => {
         },
       } satisfies PackageJSON
 
-      expect(() => parseExports({extMap, pkg, strict: true}), msg).not.toThrow()
+      expect(() => parseExports({pkg, strict: true, legacyExports: false}), msg).not.toThrow()
     })
   })
 
@@ -321,8 +311,6 @@ describe('parseExports', () => {
         `"node.import" must be before "import"`,
       ],
     ])('%o throws because %s', (json, msg) => {
-      const extMap = getPkgExtMap({legacyExports: false})
-
       const pkg = {
         type: 'module',
         name: 'test',
@@ -334,8 +322,11 @@ describe('parseExports', () => {
         },
       } satisfies PackageJSON
 
-      // @ts-expect-error -- a lot of the examples are intentionally invalid
-      expect(() => parseExports({extMap, pkg, strict: true}), msg).toThrowErrorMatchingSnapshot()
+      expect(
+        // @ts-expect-error -- a lot of the examples are intentionally invalid
+        () => parseExports({pkg, strict: true, legacyExports: false}),
+        msg,
+      ).toThrowErrorMatchingSnapshot()
     })
   })
 })

--- a/test/parseTasks.test.ts
+++ b/test/parseTasks.test.ts
@@ -1,10 +1,8 @@
 import {expect, test, vi} from 'vitest'
 
-import {BuildContext, getPkgExtMap, PackageJSON, parseExports, resolveBuildTasks} from '../src/node'
+import {type BuildContext, type PackageJSON, parseExports, resolveBuildTasks} from '../src/node'
 
 test('should parse tasks (type: module)', () => {
-  const extMap = getPkgExtMap({legacyExports: false})
-
   const pkg: PackageJSON = {
     type: 'module',
     name: 'test',
@@ -19,14 +17,13 @@ test('should parse tasks (type: module)', () => {
     },
   }
 
-  const exports = parseExports({extMap, pkg, strict: true})
+  const exports = parseExports({pkg, strict: true, legacyExports: false})
 
   const ctx: BuildContext = {
     cwd: '/test',
     distPath: '/test/dist',
     emitDeclarationOnly: false,
     exports: Object.fromEntries(exports.map(({_path, ...entry}) => [_path, entry])),
-    extMap,
     external: [],
     files: [],
     logger: {
@@ -127,30 +124,27 @@ test('should parse tasks (type: module)', () => {
 })
 
 test('should parse tasks (type: commonjs, legacyExports: true)', () => {
-  const extMap = getPkgExtMap({legacyExports: true})
-
   const pkg: PackageJSON = {
     type: 'commonjs',
     name: 'test',
     version: '1.0.0',
     source: './src/index.ts',
     main: './dist/index.js',
-    module: './dist/index.esm.js',
+    module: './dist/index.mjs',
     types: './dist/index.d.ts',
     browser: {
       './dist/index.js': './dist/index.browser.js',
-      './dist/index.esm.js': './dist/index.browser.esm.js',
+      './dist/index.mjs': './dist/index.browser.mjs',
     },
   }
 
-  const exports = parseExports({extMap, pkg, strict: true})
+  const exports = parseExports({pkg, strict: true, legacyExports: true})
 
   const ctx: BuildContext = {
     cwd: '/test',
     distPath: '/test/dist',
     emitDeclarationOnly: false,
     exports: Object.fromEntries(exports.map(({_path, ...entry}) => [_path, entry])),
-    extMap,
     external: [],
     files: [],
     logger: {
@@ -181,13 +175,13 @@ test('should parse tasks (type: commonjs, legacyExports: true)', () => {
           exportPath: '.',
           importId: 'test',
           sourcePath: './src/index.ts',
-          targetPaths: ['./dist/index.esm.d.mts', './dist/index.d.ts'],
+          targetPaths: ['./dist/index.d.mts', './dist/index.d.ts'],
         },
         {
           exportPath: '.',
           importId: 'test',
           sourcePath: './src/index.ts',
-          targetPaths: ['./dist/index.browser.esm.d.mts', './dist/index.browser.d.ts'],
+          targetPaths: ['./dist/index.browser.d.mts', './dist/index.browser.d.ts'],
         },
       ],
     },
@@ -212,7 +206,7 @@ test('should parse tasks (type: commonjs, legacyExports: true)', () => {
         {
           path: '.',
           source: './src/index.ts',
-          output: './dist/index.esm.js',
+          output: './dist/index.mjs',
         },
       ],
       runtime: '*',
@@ -240,7 +234,7 @@ test('should parse tasks (type: commonjs, legacyExports: true)', () => {
         {
           path: '.',
           source: './src/index.ts',
-          output: './dist/index.browser.esm.js',
+          output: './dist/index.browser.mjs',
         },
       ],
       runtime: 'browser',


### PR DESCRIPTION
When a module has `type: commonjs` and `legacyExports: true` we stop emitting ESM with `.mjs` endings. This is causing `@sanity/ui` to ship typings that are invalid in stricter runtimes, and also creates problems at runtimes in scenarios like NodeJS in ESM mode, or test runners like Jest.

- https://arethetypeswrong.github.io/?p=%40sanity%2Fui%402.0.10
- https://publint.dev/@sanity/ui@2.0.10