### PR TITLE
fix: only require `type: commonjs` when `legacyExports: false`

### DIFF
--- a/.github/workflows/browserslist.yml
+++ b/.github/workflows/browserslist.yml
@@ -22,11 +22,11 @@ jobs:
       - run: corepack enable && pnpm --version
       - run: pnpm install --ignore-scripts
       - run: npx update-browserslist-db@latest
-      - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
-        id: generate-token
+      - uses: actions/create-github-app-token@v1
+        id: app-token
         with:
-          app_id: ${{ secrets.ECOSPARK_APP_ID }}
-          private_key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       - uses: peter-evans/create-pull-request@70a41aba780001da0a30141984ae2a0c95d8704e # v6
         with:
           body: I ran `npx update-browserslist-db@latest` 🧑‍💻
@@ -34,4 +34,4 @@ jobs:
           commit-message: "chore: update browserslist db"
           labels: 🤖 bot
           title: "chore: update browserslist db"
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/format-if-needed.yml
+++ b/.github/workflows/format-if-needed.yml
@@ -28,11 +28,11 @@ jobs:
       - run: pnpm install --ignore-scripts
       - run: pnpm format
       - run: git restore .github/workflows CHANGELOG.md
-      - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
-        id: generate-token
+      - uses: actions/create-github-app-token@v1
+        id: app-token
         with:
-          app_id: ${{ secrets.ECOSPARK_APP_ID }}
-          private_key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       - uses: peter-evans/create-pull-request@70a41aba780001da0a30141984ae2a0c95d8704e # v6
         with:
           body: I ran `pnpm format` 🧑‍💻
@@ -40,4 +40,4 @@ jobs:
           commit-message: "chore(format): 🤖 ✨"
           labels: 🤖 bot
           title: "chore(format): 🤖 ✨"
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,17 +23,17 @@ jobs:
       # permissions for pushing commits and opening PRs are handled by the `generate-token` step
     runs-on: ubuntu-latest
     steps:
-      - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
-        id: generate-token
+      - uses: actions/create-github-app-token@v1
+        id: app-token
         with:
-          app_id: ${{ secrets.ECOSPARK_APP_ID }}
-          private_key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       # This action will create a release PR when regular conventional commits are pushed to main, it'll also detect if a release PR is merged and npm publish should happen
       - uses: google-github-actions/release-please-action@v4
         id: release
         with:
           release-type: node
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
 
       # Publish to NPM on new releases
       - uses: actions/checkout@v4

--- a/playground/multi-exports-commonjs/package.json
+++ b/playground/multi-exports-commonjs/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "license": "MIT",
   "sideEffects": false,
-  "type": "commonjs",
   "exports": {
     ".": {
       "source": "./src/index.ts",

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -33,9 +33,10 @@ export async function build(options: {
   const {cwd, emitDeclarationOnly, strict = false, tsconfig: tsconfigOption} = options
   const logger = createLogger()
 
-  const pkg = await loadPkgWithReporting({cwd, logger, strict})
-
   const config = await loadConfig({cwd})
+  const legacyExports = config?.legacyExports ?? false
+  const pkg = await loadPkgWithReporting({cwd, logger, strict, legacyExports})
+
   const tsconfig = tsconfigOption || config?.tsconfig || 'tsconfig.json'
 
   const ctx = await resolveBuildContext({

--- a/src/node/check.ts
+++ b/src/node/check.ts
@@ -17,8 +17,9 @@ export async function check(options: {
   const {cwd, strict = false, tsconfig: tsconfigOption} = options
   const logger = createLogger()
 
-  const pkg = await loadPkgWithReporting({cwd, logger, strict})
   const config = await loadConfig({cwd})
+  const legacyExports = config?.legacyExports ?? false
+  const pkg = await loadPkgWithReporting({cwd, logger, strict, legacyExports})
   const tsconfig = tsconfigOption || config?.tsconfig || 'tsconfig.json'
   const ctx = await resolveBuildContext({config, cwd, logger, pkg, strict, tsconfig})
 

--- a/src/node/core/pkg/loadPkgWithReporting.ts
+++ b/src/node/core/pkg/loadPkgWithReporting.ts
@@ -11,18 +11,28 @@ export async function loadPkgWithReporting(options: {
   cwd: string
   logger: Logger
   strict: boolean
+  legacyExports: boolean
 }): Promise<PackageJSON> {
-  const {cwd, logger, strict} = options
+  const {cwd, logger, strict, legacyExports} = options
 
   try {
     const pkg = await loadPkg({cwd})
     let shouldError = false
 
-    if (strict && !pkg.type) {
-      shouldError = true
-      logger.error(
-        `the \`type\` field in \`./package.json\` must be either "module" or "commonjs")`,
-      )
+    if (strict) {
+      if (legacyExports && pkg.type === 'commonjs') {
+        shouldError = true
+        logger.error(
+          `the \`type\` field in \`./package.json\` shouldn't be "commonjs" when \`legacyExports\` is set to true)`,
+        )
+      }
+
+      if (!legacyExports && !pkg.type) {
+        shouldError = true
+        logger.error(
+          `the \`type\` field in \`./package.json\` must be either "module" or "commonjs")`,
+        )
+      }
     }
 
     // validate exports

--- a/src/node/watch.ts
+++ b/src/node/watch.ts
@@ -30,8 +30,9 @@ export async function watch(options: {
         throw new Error('missing package.json')
       }
 
-      const pkg = await loadPkgWithReporting({cwd, logger, strict})
       const config = await loadConfig({cwd})
+      const legacyExports = config?.legacyExports ?? false
+      const pkg = await loadPkgWithReporting({cwd, logger, strict, legacyExports})
       const tsconfig = tsconfigOption || config?.tsconfig || 'tsconfig.json'
 
       return resolveBuildContext({config, cwd, logger, pkg, strict, tsconfig})


### PR DESCRIPTION
More details in the original report https://github.com/sanity-io/ui/issues/1246 by @spencerbeggs.
This PR changes `@sanity/pkg-utils` so that it no longer requires specifying `type` when `legacyExports: true`. It's only when generating legacy exports that we deal with files that end in `.js` that are ESM and that are not declared in `pkg.exports`.
It also ensures that if `legacyExports: true` then we do not allow `type: commonjs` to ensure packages don't fall into this regression.

This PR is blocking https://github.com/sanity-io/ui/pull/1247