### PR TITLE
fix: widen `typescript` peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "vitest-github-actions-reporter": "^0.11.1"
   },
   "peerDependencies": {
-    "typescript": "5.4.2"
+    "typescript": "^5.4.2"
   },
   "packageManager": "pnpm@8.15.6",
   "engines": {


### PR DESCRIPTION
Fixes #669 