### PR TITLE
fix: allow wider `typescript` semver range

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "@types/parse-git-config": "^3.0.4",
     "@types/prompts": "^2.4.9",
     "@types/rimraf": "^3.0.2",
+    "@types/semver": "^7.5.8",
     "@types/treeify": "^1.0.3",
     "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^7.6.0",
@@ -148,13 +149,14 @@
     "outdent": "^0.8.0",
     "recast": "^0.23.6",
     "rollup-plugin-visualizer": "^5.12.0",
+    "semver": "^7.6.0",
     "ts-node": "^10.9.2",
     "typescript": "5.4.2",
     "vitest": "^1.4.0",
     "vitest-github-actions-reporter": "^0.11.1"
   },
   "peerDependencies": {
-    "typescript": "5.4.2"
+    "typescript": "5.4.x"
   },
   "packageManager": "pnpm@8.15.6",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       '@types/rimraf':
         specifier: ^3.0.2
         version: 3.0.2
+      '@types/semver':
+        specifier: ^7.5.8
+        version: 7.5.8
       '@types/treeify':
         specifier: ^1.0.3
         version: 1.0.3
@@ -216,6 +219,9 @@ importers:
       rollup-plugin-visualizer:
         specifier: ^5.12.0
         version: 5.12.0(rollup@4.14.1)
+      semver:
+        specifier: ^7.6.0
+        version: 7.6.0
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.12.4)(typescript@5.4.2)

--- a/test/verifyTypeScriptVersion.test.ts
+++ b/test/verifyTypeScriptVersion.test.ts
@@ -1,19 +1,10 @@
 import apiExtractorJson from '@microsoft/api-extractor/package.json' assert {type: 'json'}
 import pkgUtilsJson from '@sanity/pkg-utils/package.json' assert {type: 'json'}
+import {satisfies} from 'semver'
 import {expect, test} from 'vitest'
 
-/**
- * Why are we requiring the same version of TypeScript as @microsoft/api-extractor?
- * @microsoft/api-extractor is shipping with `typescript` in its `dependencies`.
- * We have it as a peer dependency in @sanity/pkg-utils.
- * As long as everything results in the same version of `typescript`, we're good.
- * But if they're different then weird issues can happen, that can be incredibly hard to debug in userland.
- * To avoid all this we're requiring the same version of `typescript` as @microsoft/api-extractor at all times,
- * while it's still possible to override it, as adhering to `peerDependencies` largely depends on which package
- * manager is being used and how it's configured, you'll still at least get helpful warnings if there's a mismatch.
- */
-
-test('verify that @sanity/pkg-utils requires the same typescript version as @microsoft/api-extractor', () => {
-  expect(pkgUtilsJson.devDependencies.typescript).toBe(apiExtractorJson.dependencies.typescript)
-  expect(pkgUtilsJson.peerDependencies.typescript).toBe(apiExtractorJson.dependencies.typescript)
+test('verify that @sanity/pkg-utils requires the same typescript minor as @microsoft/api-extractor', () => {
+  expect(
+    satisfies(apiExtractorJson.dependencies.typescript, pkgUtilsJson.peerDependencies.typescript),
+  ).toBe(true)
 })


### PR DESCRIPTION
Replaces #670, fixes #669