### PR TITLE
feat: improve `exports` validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .DS_Store
 .eslintcache
 .idea
-.vscode
 etc
 dist
 node_modules

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "vitest.commandLine": "pnpx vitest --"
+}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
-  "source": "./src/node/index.ts",
   "types": "./dist/index.d.ts",
   "bin": {
     "pkg": "./bin/pkg-utils.cjs",
@@ -44,7 +43,8 @@
     "bin",
     "dist",
     "!dist/stats.html",
-    "src"
+    "src",
+    "!src/**/*.test.ts"
   ],
   "scripts": {
     "build": "run-s clean build:pkg check:pkg",
@@ -59,9 +59,9 @@
     "playground:build": "pnpm --filter './playground/**' build",
     "playground:clean": "pnpm --filter './playground/**' --silent clean",
     "prepublishOnly": "pnpm run build",
-    "test": "run-s playground:clean test:clean vitest:run",
-    "test:clean": "rimraf test/env/__tmp__",
-    "vitest:run": "vitest run",
+    "pretest": "run-s playground:clean",
+    "test": "vitest",
+    "test:update-snapshots": "pnpm test run -- --update",
     "watch": "node -r esbuild-register scripts/watch"
   },
   "commitlint": {

--- a/playground/babel-plugin/package.json
+++ b/playground/babel-plugin/package.json
@@ -15,8 +15,6 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "run-s clean && pkg build --strict && pkg check --strict",

--- a/playground/browser-bundle/package.json
+++ b/playground/browser-bundle/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "MIT",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "source": "./src/index.js",
@@ -14,8 +15,6 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "source": "./src/index.js",
   "scripts": {
     "build": "run-s clean && pkg build --strict && pkg check --strict",
     "clean": "rimraf dist"

--- a/playground/custom-dist/package.json
+++ b/playground/custom-dist/package.json
@@ -16,7 +16,6 @@
   },
   "main": "./lib/index.cjs",
   "module": "./lib/index.esm.js",
-  "source": "./src/index.ts",
   "types": "./lib/index.d.ts",
   "scripts": {
     "build": "run-s clean && pkg build --strict && pkg check --strict",

--- a/playground/default-export/package.json
+++ b/playground/default-export/package.json
@@ -15,8 +15,6 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "source": "./src/index.js",
   "scripts": {
     "build": "run-s clean && pkg build --strict && pkg check --strict",
     "clean": "rimraf dist"

--- a/playground/dummy-commonjs/package.json
+++ b/playground/dummy-commonjs/package.json
@@ -31,12 +31,6 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "source": "./src/index.ts",
-  "browser": {
-    "./dist/index.js": "./dist/index.browser.js",
-    "./dist/index.mjs": "./dist/index.browser.mjs"
-  },
   "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {

--- a/playground/dummy-lodash-es/package.json
+++ b/playground/dummy-lodash-es/package.json
@@ -16,7 +16,6 @@
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",
-  "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",

--- a/playground/dummy-lodash/package.json
+++ b/playground/dummy-lodash/package.json
@@ -16,7 +16,6 @@
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",
-  "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",

--- a/playground/dummy-module/package.json
+++ b/playground/dummy-module/package.json
@@ -31,11 +31,12 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.browser.esm.js",
-  "source": "./src/index.ts",
+  "module": "./dist/index.esm.js",
   "browser": {
-    "./dist/index.cjs": "./dist/index.browser.esm.js",
-    "./dist/index.js": "./dist/index.browser.esm.js"
+    "./dist/index.cjs": "./dist/index.browser.cjs",
+    "./dist/index.js": "./dist/index.browser.esm.js",
+    "./dist/extra.cjs": "./dist/extra.browser.cjs",
+    "./dist/extra.js": "./dist/extra.browser.esm.js"
   },
   "types": "./dist/index.d.ts",
   "typesVersions": {

--- a/playground/extra-bundles/package.json
+++ b/playground/extra-bundles/package.json
@@ -14,8 +14,6 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "source": "./src/index.js",
   "scripts": {
     "build": "run-s clean && pkg build --strict && pkg check --strict",
     "clean": "rimraf dist"

--- a/playground/js/package.json
+++ b/playground/js/package.json
@@ -14,8 +14,6 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "source": "./src/index.js",
   "scripts": {
     "build": "run-s clean && pkg build --strict && pkg check --strict",
     "clean": "rimraf dist"

--- a/playground/multi-export/package.json
+++ b/playground/multi-export/package.json
@@ -45,8 +45,6 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {

--- a/playground/multi-exports-commonjs/package.json
+++ b/playground/multi-exports-commonjs/package.json
@@ -26,7 +26,6 @@
   },
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
-  "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {

--- a/playground/node-api/package.json
+++ b/playground/node-api/package.json
@@ -11,6 +11,7 @@
       "default": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
   "scripts": {
     "build": "node scripts/build.js"
   }

--- a/playground/styled-components-module/package.json
+++ b/playground/styled-components-module/package.json
@@ -15,8 +15,6 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",

--- a/playground/ts-bundler/package.json
+++ b/playground/ts-bundler/package.json
@@ -15,8 +15,6 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "run-s clean && pkg build --strict && pkg check --strict",

--- a/playground/ts-node16/package.json
+++ b/playground/ts-node16/package.json
@@ -15,8 +15,6 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "run-s clean && pkg build --strict && pkg check --strict",

--- a/playground/ts/package.json
+++ b/playground/ts/package.json
@@ -15,8 +15,6 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "run-s clean && pkg build --strict && pkg check --strict",

--- a/playground/use-client-directive/package.json
+++ b/playground/use-client-directive/package.json
@@ -16,8 +16,6 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "run-s clean && pkg build --strict && pkg check --strict",

--- a/src/node/core/pkg/parseExports.ts
+++ b/src/node/core/pkg/parseExports.ts
@@ -1,6 +1,7 @@
-import {legacyEnding} from '../../tasks/dts/getTargetPaths'
+import {defaultEnding, fileEnding, legacyEnding} from '../../tasks/dts/getTargetPaths'
 import type {PkgExport} from '../config'
 import {isRecord} from '../isRecord'
+import {pkgExtMap} from './pkgExt'
 import type {PackageJSON} from './types'
 import {validateExports} from './validateExports'
 
@@ -11,8 +12,109 @@ export function parseExports(options: {
   legacyExports: boolean
 }): (PkgExport & {_path: string})[] {
   const {pkg, strict, legacyExports} = options
+  const type = pkg.type || 'commonjs'
+  const errors: string[] = []
 
-  const rootExport: PkgExport & {_path: string} = {
+  if (pkg.source) {
+    if (
+      strict &&
+      pkg.exports?.['.'] &&
+      typeof pkg.exports['.'] === 'object' &&
+      'source' in pkg.exports['.'] &&
+      pkg.exports['.'].source === pkg.source
+    ) {
+      errors.push(
+        'package.json: the "source" property can be removed, as it is equal to exports["."].source.',
+      )
+    } else if (!pkg.exports && pkg.main) {
+      const extMap = pkgExtMap[type]
+      const importExport = pkg.main.replace(fileEnding, extMap.esm)
+      const requireExport = pkg.main.replace(fileEnding, extMap.commonjs)
+      const defaultExport = pkg.main.replace(fileEnding, defaultEnding)
+
+      const maybeBrowserCondition = []
+
+      if (pkg.browser) {
+        const browserConditions = []
+
+        if (pkg.module && pkg.browser?.[pkg.module]) {
+          browserConditions.push(
+            `      "import": ${JSON.stringify(pkg.browser[pkg.module].replace(fileEnding, extMap.esm))}`,
+          )
+        } else if (pkg.browser?.[pkg.main]) {
+          browserConditions.push(
+            `      "import": ${JSON.stringify(pkg.browser?.[pkg.main].replace(fileEnding, extMap.esm))}`,
+          )
+        } else if (legacyExports) {
+          const browserImport = pkg.main.replace(fileEnding, `.browser${extMap.esm}`)
+
+          browserConditions.push(`      "import": ${JSON.stringify(browserImport)}`)
+        }
+
+        if (pkg.browser?.[pkg.main]) {
+          browserConditions.push(
+            `      "require": ${JSON.stringify(pkg.browser[pkg.main].replace(fileEnding, extMap.commonjs))}`,
+          )
+        } else if (legacyExports) {
+          const browserRequire = pkg.main.replace(fileEnding, `.browser${extMap.commonjs}`)
+
+          browserConditions.push(`      "require": ${JSON.stringify(browserRequire)}`)
+        }
+
+        if (browserConditions.length) {
+          maybeBrowserCondition.push(
+            `    "browser": {`,
+            `      "source": ${JSON.stringify(pkg.browser?.[pkg.source] || pkg.source)},`,
+            ...browserConditions,
+            `    }`,
+          )
+        }
+      }
+
+      errors.push(
+        ...([
+          'package.json: `exports` are missing, it should be:',
+          `"exports": {`,
+          `  ".": {`,
+          `    "source": ${JSON.stringify(pkg.source)},`,
+          // If browser conditions are detected then add them to the suggestion
+          ...(maybeBrowserCondition.length > 0 ? maybeBrowserCondition : []),
+          // If legacy exports are enabled we suggest the full list of exports, if not we can use the terse version
+          (legacyExports || type === 'commonjs') &&
+            `    "import": ${JSON.stringify(importExport)},`,
+          (legacyExports || type === 'module') &&
+            `    "require": ${JSON.stringify(requireExport)},`,
+          `    "default": ${JSON.stringify(defaultExport)}`,
+          `  },`,
+          `  "./package.json": "./package.json"`,
+          `}`,
+        ].filter(Boolean) as string[]),
+      )
+    }
+  }
+
+  if (errors.length) {
+    throw new Error('\n- ' + errors.join('\n- '))
+  }
+
+  if (!pkg.exports) {
+    throw new Error(
+      '\n- ' +
+        [
+          'package.json: `exports` are missing, please set a minimal configuration, for example:',
+          `"exports": {`,
+          `  ".": {`,
+          `    "source": "./src/index.js",`,
+          `    "default": "./dist/index.js"`,
+          `  },`,
+          `  "./package.json": "./package.json"`,
+          `}`,
+        ].join('\n- '),
+    )
+  }
+
+  /*
+  const rootExports: PkgExport & {_path: string} = {
     _exported: true,
     _path: '.',
     source: pkg.source || '',
@@ -37,10 +139,9 @@ export function parseExports(options: {
         ? pkg.exports['.'].default || ''
         : pkg.module || pkg.main || '',
   }
+  // */
 
-  const extraExports: (PkgExport & {_path: string})[] = []
-
-  const errors: string[] = []
+  const _exports: (PkgExport & {_path: string})[] = []
 
   // @TODO validate typesVersions when legacyExports is true
 
@@ -48,87 +149,95 @@ export function parseExports(options: {
     errors.push('package.json: `typings` should be `types`')
   }
 
-  if (pkg.exports) {
-    if (strict && !pkg.types && pkg.source?.endsWith('.ts')) {
-      errors.push(
-        'package.json: `types` must be declared for the npm listing to show as a TypeScript module.',
-      )
-    }
-
-    if (strict && !pkg.exports['./package.json']) {
-      errors.push('package.json: `exports["./package.json"] must be declared.')
-    }
-
-    for (const [exportPath, exportEntry] of Object.entries(pkg.exports)) {
-      if (exportPath.endsWith('.json')) {
-        if (exportPath === './package.json') {
-          if (exportEntry !== './package.json') {
-            errors.push('package.json: `exports["./package.json"] must be "./package.json".')
-          }
-        }
-      } else if (isRecord(exportEntry) && 'svelte' in exportEntry) {
-        // @TODO should we report a warning or a debug message here about a detected svelte export that is ignored?
-      } else if (isRecord(exportEntry)) {
-        if (exportPath === '.') {
-          if (
-            exportEntry.require &&
-            rootExport.require &&
-            exportEntry.require !== rootExport.require
-          ) {
-            errors.push(
-              'package.json: mismatch between "main" and "exports.require". These must be equal.',
-            )
-          }
-
-          if (legacyExports) {
-            const indexLegacyExport = (
-              exportEntry.browser?.import ||
-              exportEntry.import ||
-              exportEntry.browser?.require ||
-              exportEntry.require ||
-              ''
-            ).replace(/(\.esm)?\.[mc]?js$/, legacyEnding)
-
-            if (indexLegacyExport !== rootExport.import) {
-              errors.push(
-                `package.json: "module" should be "${indexLegacyExport}" when "legacyExports" is true`,
-              )
-            }
-          } else {
-            if (
-              exportEntry.import &&
-              rootExport.import &&
-              exportEntry.import !== rootExport.import
-            ) {
-              errors.push(
-                'package.json: mismatch between "module" and "exports.import" These must be equal.',
-              )
-            }
-          }
-
-          if (exportEntry.source && rootExport.source && exportEntry.source !== rootExport.source) {
-            errors.push(
-              'package.json: mismatch between "source" and "exports.source". These must be equal.',
-            )
-          }
-
-          Object.assign(rootExport, exportEntry)
-        } else {
-          const extraExport: PkgExport & {_path: string} = {
-            _exported: true,
-            _path: exportPath,
-            ...exportEntry,
-          }
-
-          extraExports.push(extraExport)
-        }
-      } else {
-        errors.push('package.json: exports must be an object')
-      }
-    }
+  if (strict && !pkg.types && pkg.source?.endsWith('.ts')) {
+    errors.push(
+      'package.json: `types` must be declared for the npm listing to show as a TypeScript module.',
+    )
   }
 
-  const _exports = [rootExport, ...extraExports]
+  if (strict && !pkg.exports['./package.json']) {
+    errors.push('package.json: `exports["./package.json"] must be declared.')
+  }
+
+  for (const [exportPath, exportEntry] of Object.entries(pkg.exports)) {
+    if (exportPath.endsWith('.json')) {
+      if (exportPath === './package.json') {
+        if (exportEntry !== './package.json') {
+          errors.push('package.json: `exports["./package.json"] must be "./package.json".')
+        }
+      }
+    } else if (isRecord(exportEntry) && 'svelte' in exportEntry) {
+      // @TODO should we report a warning or a debug message here about a detected svelte export that is ignored?
+    } else if (isRecord(exportEntry)) {
+      const exp = {
+        _exported: true,
+        _path: exportPath,
+        ...exportEntry,
+      } satisfies PkgExport & {_path: string}
+
+      // Infer the `default` condition based on the `type` and other conditions
+      if (!exp.default) {
+        const fallback = type === 'module' ? exp.import : exp.require
+
+        if (fallback) {
+          exp.default = fallback
+        }
+
+        if (legacyExports) {
+          if (fallback) {
+            errors.push(
+              `package.json - \`exports["${exp._path}"].default\` should be set to "${fallback}" when "legacyExports" is true`,
+            )
+          } else {
+            errors.push(
+              `package.json - \`exports["${exp._path}"].default\` should be specified when "legacyExports" is true`,
+            )
+          }
+        }
+      }
+
+      // Infer the `require` condition based on the `type` and other conditions
+      if (!exp.require && type === 'commonjs' && exp.default) {
+        exp.require = exp.default
+      }
+
+      // Infer the `import` condition based on the `type` and other conditions
+      if (!exp.import && type === 'module' && exp.default) {
+        exp.import = exp.default
+      }
+
+      if (exportPath === '.') {
+        if (exportEntry.require && pkg.main && exportEntry.require !== pkg.main) {
+          errors.push(
+            'package.json: mismatch between "main" and "exports.require". These must be equal.',
+          )
+        }
+
+        if (legacyExports) {
+          const indexLegacyExport = (exportEntry.import || exportEntry.require || '').replace(
+            /(\.esm)?\.[mc]?js$/,
+            legacyEnding,
+          )
+
+          if (indexLegacyExport !== pkg.module) {
+            errors.push(
+              `package.json: "module" should be "${indexLegacyExport}" when "legacyExports" is true`,
+            )
+          }
+        } else {
+          if (exportEntry.import && pkg.module && exportEntry.import !== pkg.module) {
+            errors.push(
+              'package.json: mismatch between "module" and "exports.import" These must be equal.',
+            )
+          }
+        }
+      }
+
+      _exports.push(exp)
+    } else {
+      errors.push('package.json: exports must be an object')
+    }
+  }
 
   errors.push(...validateExports(_exports, {pkg}))
 

--- a/src/node/core/pkg/pkgExt.ts
+++ b/src/node/core/pkg/pkgExt.ts
@@ -1,4 +1,4 @@
-import {legacyEnding} from '../../tasks/dts/getTargetPaths'
+import {cjsEnding, defaultEnding, legacyEnding, mjsEnding} from '../../tasks/dts/getTargetPaths'
 
 /** @internal */
 export interface PkgExtMap {
@@ -8,18 +8,18 @@ export interface PkgExtMap {
 }
 
 /** @internal */
-export const pkgExtMap: PkgExtMap = {
+export const pkgExtMap = {
   // pkg.type: "commonjs"
   commonjs: {
-    commonjs: '.js',
-    esm: '.mjs',
+    commonjs: defaultEnding,
+    esm: mjsEnding,
   },
 
   // pkg.type: "module"
   module: {
-    commonjs: '.cjs',
-    esm: '.js',
+    commonjs: cjsEnding,
+    esm: defaultEnding,
   },
   // package.config.legacyExports: true
   legacy: legacyEnding,
-}
+} satisfies PkgExtMap

--- a/src/node/tasks/dts/getTargetPaths.ts
+++ b/src/node/tasks/dts/getTargetPaths.ts
@@ -3,11 +3,17 @@ import type {PackageJSON, PkgBundle, PkgExport} from '../../core'
 /** @internal */
 export const fileEnding = /\.[mc]?js$/
 /** @internal */
-export const dtsEnding = '.d.ts'
+export const dtsEnding = '.d.ts' as const
 /** @internal */
-export const legacyEnding = '.esm.js'
-const mtsEnding = '.d.mts'
-const ctsEnding = '.d.cts'
+export const defaultEnding = '.js' as const
+/** @internal */
+export const legacyEnding = `.esm${defaultEnding}` as const
+/** @internal */
+export const mjsEnding = '.mjs' as const
+/** @internal */
+export const cjsEnding = '.cjs' as const
+const mtsEnding = '.d.mts' as const
+const ctsEnding = '.d.cts' as const
 
 /** @internal */
 export function getTargetPaths(

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -253,7 +253,6 @@ declare module './module2' {
     addedField: string
   }
 }
-//# sourceMappingURL=module1.d.ts.map
 "
 `;
 

--- a/test/__snapshots__/parseExports.test.ts.snap
+++ b/test/__snapshots__/parseExports.test.ts.snap
@@ -1,0 +1,656 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`parseExports({type: 'commonjs', legacyExports: false}) > invalid packages > the "exports" key is required > maps "source" to "browsers" field to specify a "browser" condition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/browser.ts",
+-       "import": "./lib/browser.mjs"
+-       "require": "./lib/browser.js"
+-     }
+-     "import": "./lib/index.mjs",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'commonjs', legacyExports: false}) > invalid packages > the "exports" key is required > shows a best effort message if there is no "main" field 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, please set a minimal configuration, for example:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.js",
+-     "default": "./dist/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'commonjs', legacyExports: false}) > invalid packages > the "exports" key is required > shows a best effort message if there is no "source" field either 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, please set a minimal configuration, for example:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.js",
+-     "default": "./dist/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'commonjs', legacyExports: false}) > invalid packages > the "exports" key is required > uses the "browsers" field to specify a "browser" condition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/index.ts",
+-       "import": "./lib/browser.mjs"
+-       "require": "./lib/browser.js"
+-     }
+-     "import": "./lib/index.mjs",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'commonjs', legacyExports: false}) > invalid packages > the "exports" key is required > uses the "main" and "source" fields to specify a suggested "exports" definition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "import": "./lib/index.mjs",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'commonjs', legacyExports: false}) > invalid packages > the "source" field should be removed when "exports" is set 1`] = `
+[Error: 
+- package.json: the "source" property can be removed, as it is equal to exports["."].source.]
+`;
+
+exports[`parseExports({type: 'commonjs', legacyExports: true}) > invalid packages > legacyExports: true > gracefully falls back if the browsers field is invalid 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/index.ts",
+-       "import": "./lib/index.browser.mjs"
+-       "require": "./lib/index.browser.js"
+-     }
+-     "import": "./lib/index.mjs",
+-     "require": "./lib/index.js",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'commonjs', legacyExports: true}) > invalid packages > legacyExports: true > it handles "browsers" if it only redirects "source" 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/browser.ts",
+-       "import": "./lib/index.browser.mjs"
+-       "require": "./lib/index.browser.js"
+-     }
+-     "import": "./lib/index.mjs",
+-     "require": "./lib/index.js",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'commonjs', legacyExports: true}) > invalid packages > legacyExports: true > minimal CJS package.json requires a default condition when legacyExports: true 1`] = `
+[Error: 
+- package.json - \`exports["."].default\` should be set to "./dist/index.js" when "legacyExports" is true
+- package.json: "module" should be "./dist/index.esm.js" when "legacyExports" is true]
+`;
+
+exports[`parseExports({type: 'commonjs', legacyExports: true}) > invalid packages > legacyExports: true > minimal CJS-only package.json requires a default condition when legacyExports: true 1`] = `
+[Error: 
+- package.json - \`exports["."].default\` should be set to "./dist/index.js" when "legacyExports" is true
+- package.json: "module" should be "./dist/index.esm.js" when "legacyExports" is true]
+`;
+
+exports[`parseExports({type: 'commonjs', legacyExports: true}) > invalid packages > legacyExports: true > the top level "module" condition is required when legacyExports: true 1`] = `
+[Error: 
+- package.json: "module" should be "./dist/index.esm.js" when "legacyExports" is true]
+`;
+
+exports[`parseExports({type: 'commonjs', legacyExports: true}) > invalid packages > legacyExports: true > the top level "module" must end with \`.esm.js\` 1`] = `
+[Error: 
+- package.json: "module" should be "./dist/index.esm.js" when "legacyExports" is true]
+`;
+
+exports[`parseExports({type: 'commonjs', legacyExports: true}) > invalid packages > the "exports" key is required > maps "source" to "browsers" field to specify a "browser" condition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/browser.ts",
+-       "import": "./lib/browser.mjs"
+-       "require": "./lib/browser.js"
+-     }
+-     "import": "./lib/index.mjs",
+-     "require": "./lib/index.js",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'commonjs', legacyExports: true}) > invalid packages > the "exports" key is required > shows a best effort message if there is no "main" field 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, please set a minimal configuration, for example:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.js",
+-     "default": "./dist/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'commonjs', legacyExports: true}) > invalid packages > the "exports" key is required > shows a best effort message if there is no "source" field either 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, please set a minimal configuration, for example:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.js",
+-     "default": "./dist/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'commonjs', legacyExports: true}) > invalid packages > the "exports" key is required > uses the "browsers" field to specify a "browser" condition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/index.ts",
+-       "import": "./lib/browser.mjs"
+-       "require": "./lib/browser.js"
+-     }
+-     "import": "./lib/index.mjs",
+-     "require": "./lib/index.js",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'commonjs', legacyExports: true}) > invalid packages > the "exports" key is required > uses the "main" and "source" fields to specify a suggested "exports" definition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "import": "./lib/index.mjs",
+-     "require": "./lib/index.js",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'commonjs', legacyExports: true}) > invalid packages > the "source" field should be removed when "exports" is set 1`] = `
+[Error: 
+- package.json: the "source" property can be removed, as it is equal to exports["."].source.]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: false}) > invalid packages > the "exports" key is required > maps "source" to "browsers" field to specify a "browser" condition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/browser.ts",
+-       "import": "./lib/browser.js"
+-       "require": "./lib/browser.cjs"
+-     }
+-     "require": "./lib/index.cjs",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: false}) > invalid packages > the "exports" key is required > shows a best effort message if there is no "main" field 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, please set a minimal configuration, for example:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.js",
+-     "default": "./dist/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: false}) > invalid packages > the "exports" key is required > shows a best effort message if there is no "source" field either 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, please set a minimal configuration, for example:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.js",
+-     "default": "./dist/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: false}) > invalid packages > the "exports" key is required > uses the "browsers" field to specify a "browser" condition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/index.ts",
+-       "import": "./lib/browser.js"
+-       "require": "./lib/browser.cjs"
+-     }
+-     "require": "./lib/index.cjs",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: false}) > invalid packages > the "exports" key is required > uses the "main" and "source" fields to specify a suggested "exports" definition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "require": "./lib/index.cjs",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: false}) > invalid packages > the "source" field should be removed when "exports" is set 1`] = `
+[Error: 
+- package.json: the "source" property can be removed, as it is equal to exports["."].source.]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: true}) > invalid packages > legacyExports: true > gracefully falls back if the browsers field is invalid 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/index.ts",
+-       "import": "./lib/index.browser.js"
+-       "require": "./lib/index.browser.cjs"
+-     }
+-     "import": "./lib/index.js",
+-     "require": "./lib/index.cjs",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: true}) > invalid packages > legacyExports: true > it handles "browsers" if it only redirects "source" 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/browser.ts",
+-       "import": "./lib/index.browser.js"
+-       "require": "./lib/index.browser.cjs"
+-     }
+-     "import": "./lib/index.js",
+-     "require": "./lib/index.cjs",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: true}) > invalid packages > legacyExports: true > minimal ESM package.json requires a default condition when legacyExports: true 1`] = `
+[Error: 
+- package.json - \`exports["."].default\` should be set to "./dist/index.js" when "legacyExports" is true]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: true}) > invalid packages > legacyExports: true > minimal ESM-only package.json requires a default condition when legacyExports: true 1`] = `
+[Error: 
+- package.json - \`exports["."].default\` should be set to "./dist/index.js" when "legacyExports" is true]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: true}) > invalid packages > legacyExports: true > the top level "module" condition is required when legacyExports: true 1`] = `
+[Error: 
+- package.json: "module" should be "./dist/index.esm.js" when "legacyExports" is true]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: true}) > invalid packages > legacyExports: true > the top level "module" must end with \`.esm.js\` 1`] = `
+[Error: 
+- package.json: "module" should be "./dist/index.esm.js" when "legacyExports" is true]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: true}) > invalid packages > the "exports" key is required > maps "source" to "browsers" field to specify a "browser" condition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/browser.ts",
+-       "import": "./lib/browser.js"
+-       "require": "./lib/browser.cjs"
+-     }
+-     "import": "./lib/index.js",
+-     "require": "./lib/index.cjs",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: true}) > invalid packages > the "exports" key is required > shows a best effort message if there is no "main" field 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, please set a minimal configuration, for example:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.js",
+-     "default": "./dist/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: true}) > invalid packages > the "exports" key is required > shows a best effort message if there is no "source" field either 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, please set a minimal configuration, for example:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.js",
+-     "default": "./dist/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: true}) > invalid packages > the "exports" key is required > uses the "browsers" field to specify a "browser" condition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/index.ts",
+-       "import": "./lib/browser.js"
+-       "require": "./lib/browser.cjs"
+-     }
+-     "import": "./lib/index.js",
+-     "require": "./lib/index.cjs",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: true}) > invalid packages > the "exports" key is required > uses the "main" and "source" fields to specify a suggested "exports" definition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "import": "./lib/index.js",
+-     "require": "./lib/index.cjs",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: 'module', legacyExports: true}) > invalid packages > the "source" field should be removed when "exports" is set 1`] = `
+[Error: 
+- package.json: the "source" property can be removed, as it is equal to exports["."].source.]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: false}) > invalid packages > the "exports" key is required > maps "source" to "browsers" field to specify a "browser" condition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/browser.ts",
+-       "import": "./lib/browser.mjs"
+-       "require": "./lib/browser.js"
+-     }
+-     "import": "./lib/index.mjs",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: false}) > invalid packages > the "exports" key is required > shows a best effort message if there is no "main" field 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, please set a minimal configuration, for example:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.js",
+-     "default": "./dist/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: false}) > invalid packages > the "exports" key is required > shows a best effort message if there is no "source" field either 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, please set a minimal configuration, for example:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.js",
+-     "default": "./dist/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: false}) > invalid packages > the "exports" key is required > uses the "browsers" field to specify a "browser" condition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/index.ts",
+-       "import": "./lib/browser.mjs"
+-       "require": "./lib/browser.js"
+-     }
+-     "import": "./lib/index.mjs",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: false}) > invalid packages > the "exports" key is required > uses the "main" and "source" fields to specify a suggested "exports" definition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "import": "./lib/index.mjs",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: false}) > invalid packages > the "source" field should be removed when "exports" is set 1`] = `
+[Error: 
+- package.json: the "source" property can be removed, as it is equal to exports["."].source.]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: true}) > invalid packages > legacyExports: true > gracefully falls back if the browsers field is invalid 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/index.ts",
+-       "import": "./lib/index.browser.mjs"
+-       "require": "./lib/index.browser.js"
+-     }
+-     "import": "./lib/index.mjs",
+-     "require": "./lib/index.js",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: true}) > invalid packages > legacyExports: true > it handles "browsers" if it only redirects "source" 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/browser.ts",
+-       "import": "./lib/index.browser.mjs"
+-       "require": "./lib/index.browser.js"
+-     }
+-     "import": "./lib/index.mjs",
+-     "require": "./lib/index.js",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: true}) > invalid packages > legacyExports: true > minimal CJS package.json requires a default condition when legacyExports: true 1`] = `
+[Error: 
+- package.json - \`exports["."].default\` should be set to "./dist/index.js" when "legacyExports" is true
+- package.json: "module" should be "./dist/index.esm.js" when "legacyExports" is true]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: true}) > invalid packages > legacyExports: true > minimal CJS-only package.json requires a default condition when legacyExports: true 1`] = `
+[Error: 
+- package.json - \`exports["."].default\` should be set to "./dist/index.js" when "legacyExports" is true
+- package.json: "module" should be "./dist/index.esm.js" when "legacyExports" is true]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: true}) > invalid packages > legacyExports: true > the top level "module" condition is required when legacyExports: true 1`] = `
+[Error: 
+- package.json: "module" should be "./dist/index.esm.js" when "legacyExports" is true]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: true}) > invalid packages > legacyExports: true > the top level "module" must end with \`.esm.js\` 1`] = `
+[Error: 
+- package.json: "module" should be "./dist/index.esm.js" when "legacyExports" is true]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: true}) > invalid packages > the "exports" key is required > maps "source" to "browsers" field to specify a "browser" condition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/browser.ts",
+-       "import": "./lib/browser.mjs"
+-       "require": "./lib/browser.js"
+-     }
+-     "import": "./lib/index.mjs",
+-     "require": "./lib/index.js",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: true}) > invalid packages > the "exports" key is required > shows a best effort message if there is no "main" field 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, please set a minimal configuration, for example:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.js",
+-     "default": "./dist/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: true}) > invalid packages > the "exports" key is required > shows a best effort message if there is no "source" field either 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, please set a minimal configuration, for example:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.js",
+-     "default": "./dist/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: true}) > invalid packages > the "exports" key is required > uses the "browsers" field to specify a "browser" condition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "browser": {
+-       "source": "./src/index.ts",
+-       "import": "./lib/browser.mjs"
+-       "require": "./lib/browser.js"
+-     }
+-     "import": "./lib/index.mjs",
+-     "require": "./lib/index.js",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: true}) > invalid packages > the "exports" key is required > uses the "main" and "source" fields to specify a suggested "exports" definition 1`] = `
+[Error: 
+- package.json: \`exports\` are missing, it should be:
+- "exports": {
+-   ".": {
+-     "source": "./src/index.ts",
+-     "import": "./lib/index.mjs",
+-     "require": "./lib/index.js",
+-     "default": "./lib/index.js"
+-   },
+-   "./package.json": "./package.json"
+- }]
+`;
+
+exports[`parseExports({type: undefined, legacyExports: true}) > invalid packages > the "source" field should be removed when "exports" is set 1`] = `
+[Error: 
+- package.json: the "source" property can be removed, as it is equal to exports["."].source.]
+`;

--- a/test/__snapshots__/validatePkg.test.ts.snap
+++ b/test/__snapshots__/validatePkg.test.ts.snap
@@ -1,0 +1,23 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'Browser' is not a valid key, did you mean undefined? 1`] = `[TypeError: "Browser" is not a valid key. Did you mean "browser"?]`;
+
+exports[`'Dependencies' is not a valid key, did you mean 'dependencies'? 1`] = `[TypeError: "Dependencies" is not a valid key. Did you mean "dependencies"?]`;
+
+exports[`'Exports' is not a valid key, did you mean 'exports'? 1`] = `[TypeError: "Exports" is not a valid key. Did you mean "exports"?]`;
+
+exports[`'Main' is not a valid key, did you mean undefined? 1`] = `[TypeError: "Main" is not a valid key. Did you mean "main"?]`;
+
+exports[`'Module' is not a valid key, did you mean undefined? 1`] = `[TypeError: "Module" is not a valid key. Did you mean "module"?]`;
+
+exports[`'Source' is not a valid key, did you mean undefined? 1`] = `[TypeError: "Source" is not a valid key. Did you mean "source"?]`;
+
+exports[`'Type' is not a valid key, did you mean 'type'? 1`] = `[TypeError: "Type" is not a valid key. Did you mean "type"?]`;
+
+exports[`'Types' is not a valid key, did you mean undefined? 1`] = `[TypeError: "Types" is not a valid key. Did you mean "types"?]`;
+
+exports[`'devdependencies' is not a valid key, did you mean 'devDependencies'? 1`] = `[TypeError: "devdependencies" is not a valid key. Did you mean "devDependencies"?]`;
+
+exports[`'peerdependencies' is not a valid key, did you mean 'peerDependencies'? 1`] = `[TypeError: "peerdependencies" is not a valid key. Did you mean "peerDependencies"?]`;
+
+exports[`'typesversions' is not a valid key, did you mean 'typesVersions'? 1`] = `[TypeError: "typesversions" is not a valid key. Did you mean "typesVersions"?]`;

--- a/test/env/globalSetup.ts
+++ b/test/env/globalSetup.ts
@@ -1,0 +1,44 @@
+/* eslint-disable no-console */
+import path from 'node:path'
+
+import {mkdirp} from 'mkdirp'
+import rimraf from 'rimraf'
+
+import {exec} from './exec'
+import {ExecError} from './ExecError'
+import {stripColor} from './stripColor'
+
+async function runExec(cmd: string) {
+  try {
+    const env = {
+      ...process.env,
+      PATH: `${process.env.PATH}:${path.resolve(__dirname, '../../bin')}`,
+    }
+    const tmpPath = path.resolve(__dirname, '../..')
+
+    return exec(cmd, {cwd: tmpPath, env})
+  } catch (execErr) {
+    if (execErr instanceof ExecError) {
+      console.log(execErr.stdout)
+      console.error(execErr.stderr)
+
+      return {
+        stdout: stripColor(execErr.stdout),
+        stderr: stripColor(execErr.stderr),
+      }
+    }
+
+    throw execErr
+  }
+}
+
+export async function setup() {
+  const workspacePath = path.resolve(__dirname, '__tmp__')
+
+  await mkdirp(workspacePath)
+
+  return async () => {
+    await rimraf(workspacePath)
+    await runExec('pnpm install --no-frozen-lockfile')
+  }
+}

--- a/test/parseTasks.test.ts
+++ b/test/parseTasks.test.ts
@@ -7,7 +7,6 @@ test('should parse tasks (type: module)', () => {
     type: 'module',
     name: 'test',
     version: '1.0.0',
-    source: './src/index.ts',
     main: './dist/index.cjs',
     module: './dist/index.js',
     types: './dist/index.d.ts',
@@ -142,19 +141,34 @@ test('should parse tasks (type: commonjs, legacyExports: true)', () => {
     type: 'commonjs',
     name: 'test',
     version: '1.0.0',
-    source: './src/index.ts',
     main: './dist/index.js',
-    module: './dist/index.mjs',
+    module: './dist/index.esm.js',
     types: './dist/index.d.ts',
     browser: {
       './dist/index.js': './dist/index.browser.js',
       './dist/index.mjs': './dist/index.browser.mjs',
+      './dist/index.esm.js': './dist/index.browser.esm.js',
+    },
+    exports: {
+      '.': {
+        source: './src/index.ts',
+        browser: {
+          source: './src/index.ts',
+          import: './dist/index.browser.mjs',
+          require: './dist/index.browser.js',
+        },
+        import: './dist/index.mjs',
+        require: './dist/index.js',
+        default: './dist/index.js',
+      },
+      './package.json': './package.json',
     },
   }
 
   const exports = parseExports({pkg, strict: true, legacyExports: true})
 
   const ctx: BuildContext = {
+    config: {legacyExports: true},
     cwd: '/test',
     distPath: '/test/dist',
     emitDeclarationOnly: false,
@@ -254,6 +268,20 @@ test('should parse tasks (type: commonjs, legacyExports: true)', () => {
       runtime: 'browser',
       format: 'esm',
       target: ['chrome102'],
+    },
+    {
+      buildId: 'esm:browser',
+      entries: [
+        {
+          output: './dist/index.browser.esm.js',
+          path: '.',
+          source: './src/index.ts',
+        },
+      ],
+      format: 'esm',
+      runtime: 'browser',
+      target: ['chrome102'],
+      type: 'build:legacy',
     },
   ])
 })

--- a/test/validatePkg.test.ts
+++ b/test/validatePkg.test.ts
@@ -1,0 +1,44 @@
+import {expect, test} from 'vitest'
+
+import {validatePkg} from '../src/node/core/pkg/validatePkg'
+
+const template = {
+  type: 'module',
+  name: 'dummy-module',
+  version: '0.0.0',
+  license: 'MIT',
+  exports: {
+    './package.json': './package.json',
+  },
+}
+
+test.each([
+  {actual: 'Exports' as const, expected: 'exports', value: {'./package.json': './package.json'}},
+  {actual: 'Type', expected: 'type', value: 'module'},
+  {actual: 'Dependencies', expected: 'dependencies', value: {}},
+  {actual: 'devdependencies', expected: 'devDependencies', value: {}},
+  {actual: 'peerdependencies', expected: 'peerDependencies', value: {}},
+  {actual: 'Source', value: './src/index.ts'},
+  {actual: 'Main', value: './dist/index.js'},
+  {actual: 'Browser', value: {}},
+  {actual: 'Module', value: './dist/index.js'},
+  {actual: 'Types', value: './dist/index.js'},
+  {
+    actual: 'typesversions',
+    expected: 'typesVersions',
+    value: {
+      '*': {
+        extra: ['./dist/extra.d.ts'],
+      },
+    },
+  },
+])('$actual is not a valid key, did you mean $expected?', ({actual, expected, value}) => {
+  const pkg = {
+    ...template,
+    [actual]: value,
+  }
+
+  expect(() => validatePkg(pkg)).toThrowError(/is not a valid key/)
+  expect(() => validatePkg(pkg)).toThrowErrorMatchingSnapshot()
+  expect(() => validatePkg({...template, [expected as string]: value})).not.toThrow()
+})

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.settings",
   "include": ["./package.json", "./src"],
+  "exclude": ["./src/**/*.test.ts"],
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,8 @@ import GithubActionsReporter from 'vitest-github-actions-reporter'
 
 export default defineConfig({
   test: {
+    globalSetup: ['./test/env/globalSetup.ts'],
+
     exclude: ['**/node_modules/**', '.cache', '.git', '.idea', 'dist', 'playground'],
 
     // Set to 2 minutes to support long-running Next.js test
@@ -10,6 +12,12 @@ export default defineConfig({
 
     // Enable rich PR failed test annotation on the CI
     reporters: process.env.GITHUB_ACTIONS ? ['default', new GithubActionsReporter()] : 'default',
+
+    // Reduce threads as suites will use the filesystem and `pnpm install` and need to run in sequence
+    fileParallelism: false,
+
+    // Don't rerun test watcher when generated files change, or it'll infinitely loop
+    watchExclude: ['**/node_modules/**', '**/dist/**', 'test/env/__tmp__/**'],
   },
   esbuild: {
     target: 'node14',


### PR DESCRIPTION
If required fields like `exports` is missing from `package.json` you now get helpful errors:
```bash
- package.json: `exports` are missing, it should be:
- "exports": {
-   ".": {
-     "source": "./src/index.ts",
-     "browser": {
-       "source": "./src/index.ts",
-       "import": "./dist/index.browser.js"
-       "require": "./dist/index.browser.cjs"
-     }
-     "import": "./dist/index.js",
-     "require": "./dist/index.cjs",
-     "default": "./dist/index.js"
-   },
-   "./package.json": "./package.json"
- }
```

If there's not enough metadata in `package.json` to predict exactly what it should be you'll get a general:
```bash
- package.json: `exports` are missing, please set a minimal configuration, for example:
- "exports": {
-   ".": {
-     "source": "./src/index.js",
-     "default": "./dist/index.js"
-   },
-   "./package.json": "./package.json"
- }
```