### PR TITLE
refactor(ci): set create pr author to github-actions

### DIFF
--- a/.github/workflows/browserslist.yml
+++ b/.github/workflows/browserslist.yml
@@ -29,6 +29,7 @@ jobs:
           private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       - uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6
         with:
+          author: github-actions <41898282+github-actions[bot]@users.noreply.github.com>
           body: I ran `npx update-browserslist-db@latest` 🧑‍💻
           branch: actions/update-browserslist-database-if-needed
           commit-message: "chore: update browserslist db"

--- a/.github/workflows/format-if-needed.yml
+++ b/.github/workflows/format-if-needed.yml
@@ -35,6 +35,7 @@ jobs:
           private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       - uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6
         with:
+          author: github-actions <41898282+github-actions[bot]@users.noreply.github.com>
           body: I ran `pnpm format` 🧑‍💻
           branch: actions/format
           commit-message: "chore(format): 🤖 ✨"


### PR DESCRIPTION
For some reason I'm set as the commit author on automation PRs: https://github.com/sanity-io/pkg-utils/pull/837
And due to our new strict branch rules it makes me unable to merge said PRs 😅 Setting the author to `github-actions` is a pattern we've used elsewhere, but not enforced since our branch rules were less strict: https://github.com/sanity-io/renovate-config/blob/0293ceaa26f155299f80d5e7a28330af3f6aad5d/.github/workflows/create-node-pr.yml#L39C11-L39C89