### PR TITLE
fix: only enable `minifyInternalExports` by default when `minify: true`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/pkg-utils",
-  "version": "6.8.14",
+  "version": "6.8.15-canary.0",
   "description": "Simple utilities for modern npm packages.",
   "keywords": [
     "sanity-io",

--- a/src/node/tasks/rollup/resolveRollupConfig.ts
+++ b/src/node/tasks/rollup/resolveRollupConfig.ts
@@ -222,6 +222,7 @@ export function resolveRollupConfig(
       interop: 'compat',
       sourcemap: config?.sourcemap ?? true,
       hoistTransitiveImports: false,
+      minifyInternalExports: minify,
       ...config?.rollup?.output,
     },
   }


### PR DESCRIPTION
When debugging builds it's annoying when export identifiers are minified, even when minify isn't enabled (it requires `minify: true` in the `package.config.ts`):
```
Export "P" of module "node_modules/sanity/lib/_chunks-es/StructureToolProvider.mjs" was reexported through module "node_modules/sanity/lib/structure.mjs" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
```
`P`? What's `P`? Now I have to open the build file to figure out what that is. This PR turns off the underlying rollup feature that is causing export identifiers to be minified in internal code 😌 