### PR TITLE
fix: add non-external deps to `bundledPacages` by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/pkg-utils",
-  "version": "6.10.1",
+  "version": "6.10.2-canary.1",
   "description": "Simple utilities for modern npm packages.",
   "keywords": [
     "sanity-io",

--- a/playground/use-client-directive/package.config.ts
+++ b/playground/use-client-directive/package.config.ts
@@ -14,9 +14,11 @@ export default defineConfig({
 
           console.error(`[${severity}] ${reason}`)
           console.log(`${filename}:${loc.start.line}:${loc.start.column} ${description}`)
+
           for (const suggestion of suggestions) {
             console.log(suggestion.description)
           }
+
           console.groupEnd()
         }
       },

--- a/src/node/core/config/types.ts
+++ b/src/node/core/config/types.ts
@@ -179,7 +179,14 @@ export interface PkgConfigOptions {
   dist?: string
   exports?: PkgConfigProperty<PkgExports>
   extract?: {
-    bundledPackages?: string[]
+    /**
+     * Packages in `devDependencies` that are not in `external` are automatically added to the `bundledPackages` config.
+     * You can exclude a package from being bundled by using a callback:
+     * ```
+     * bundledPackages: (prev) => prev.filter(package => package !== 'sanity')
+     * ```
+     */
+    bundledPackages?: PkgConfigProperty<string[]>
     customTags?: TSDocCustomTag[]
     rules?: {
       'ae-forgotten-export'?: PkgRuleLevel

--- a/src/node/core/contexts/buildContext.ts
+++ b/src/node/core/contexts/buildContext.ts
@@ -18,6 +18,7 @@ export interface BuildContext {
   emitDeclarationOnly: boolean
   exports: PkgExports | undefined
   external: string[]
+  bundledPackages: string[]
   files: BuildFile[]
   logger: Logger
   pkg: PackageJSON

--- a/src/node/tasks/dts/doExtract.ts
+++ b/src/node/tasks/dts/doExtract.ts
@@ -18,7 +18,7 @@ export async function doExtract(
   ctx: BuildContext,
   task: DtsTask | DtsWatchTask,
 ): Promise<DtsResult> {
-  const {config, cwd, files, logger, strict, ts} = ctx
+  const {config, cwd, files, logger, strict, ts, bundledPackages} = ctx
 
   if (!ts.config || !ts.configPath) {
     return {type: 'dts', messages: [], results: []}
@@ -48,7 +48,7 @@ export async function doExtract(
     const targetPaths = entry.targetPaths.map((targetPath) => path.resolve(cwd, targetPath))
     const filePaths = targetPaths.map((targetPath) => path.relative(outDir, targetPath))
     const result = await extractTypes({
-      bundledPackages: config?.extract?.bundledPackages || [],
+      bundledPackages: bundledPackages || [],
       customTags: config?.extract?.customTags,
       cwd,
       distPath: outDir,


### PR DESCRIPTION
Fixes #967

Can be tested with `pnpm add @sanity/pkg-utils@canary --save-dev`