### PR TITLE
feat(watcher): add support for dts incremental rebuilds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/pkg-utils",
-  "version": "6.10.12",
+  "version": "6.10.13-canary.0",
   "description": "Simple utilities for modern npm packages.",
   "keywords": [
     "sanity-io",

--- a/scripts/watch.ts
+++ b/scripts/watch.ts
@@ -6,7 +6,7 @@ global.__DEV__ = true
 
 watch({
   cwd: path.resolve(__dirname, '..'),
-  tsconfig: 'tsconfig.dist.json',
+  strict: true,
 }).catch((err) => {
   // eslint-disable-next-line no-console
   console.error(err.stack)

--- a/src/node/tasks/dts/dtsWatchTask.ts
+++ b/src/node/tasks/dts/dtsWatchTask.ts
@@ -1,10 +1,16 @@
+import path from 'node:path'
+
+import type {ExtractorMessage} from '@microsoft/api-extractor'
 import chalk from 'chalk'
+import rimraf from 'rimraf'
 import {Observable} from 'rxjs'
+import ts from 'typescript'
 
 import {printExtractMessages} from '../../printExtractMessages'
 import type {TaskHandler} from '../types'
-import {doExtract} from './doExtract'
+import {buildTypes} from './buildTypes'
 import {DtsError} from './DtsError'
+import {extractTypes} from './extractTypes'
 import type {DtsResult, DtsWatchTask} from './types'
 
 /** @internal */
@@ -22,22 +28,131 @@ export const dtsWatchTask: TaskHandler<DtsWatchTask, DtsResult> = {
       }),
     ].join('\n'),
   exec: (ctx, task) => {
+    const {config, cwd, files, logger, strict, ts: tsContext, bundledPackages} = ctx
+
     return new Observable((observer) => {
-      doExtract(ctx, task)
-        .then((result) => {
-          observer.next(result)
-          observer.complete()
-        })
-        .catch((err) => observer.error(err))
+      if (!tsContext.config || !tsContext.configPath) {
+        observer.next({type: 'dts', messages: [], results: []})
+        observer.complete()
+
+        return
+      }
+
+      const {outDir, rootDir = cwd} = tsContext.config.options
+
+      if (!outDir) {
+        observer.error(new Error('tsconfig.json is missing `compilerOptions.outDir`'))
+
+        return
+      }
+
+      const tmpPath = path.resolve(outDir, '__tmp__')
+
+      buildTypes({
+        cwd,
+        logger,
+        outDir: tmpPath,
+        tsconfig: tsContext.config,
+        strict,
+      }).catch((err) => {
+        observer.error(err)
+      })
+
+      const host = ts.createWatchCompilerHost(
+        tsContext.configPath,
+        {
+          ...tsContext.config.options,
+          declaration: true,
+          declarationDir: tmpPath,
+          emitDeclarationOnly: true,
+          noEmit: false,
+          noEmitOnError: strict ? true : (tsContext.config.options.noEmitOnError ?? true),
+          outDir: tmpPath,
+        },
+        ts.sys,
+        ts.createEmitAndSemanticDiagnosticsBuilderProgram,
+        (diagnostic) => {
+          logger.error(ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))
+        },
+        (diagnostic) => {
+          logger.info(ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))
+        },
+      )
+
+      const origPostProgramCreate = host.afterProgramCreate
+
+      host.afterProgramCreate = async (program) => {
+        origPostProgramCreate?.(program)
+
+        const messages: ExtractorMessage[] = []
+        const results: {sourcePath: string; filePaths: string[]}[] = []
+
+        for (const entry of task.entries) {
+          const exportPath = entry.exportPath === '.' ? './index' : entry.exportPath
+
+          const sourceTypesPath = path.resolve(
+            tmpPath,
+            path.relative(rootDir, path.resolve(cwd, entry.sourcePath)).replace(/\.ts$/, '.d.ts'),
+          )
+
+          const targetPaths = entry.targetPaths.map((targetPath) => path.resolve(cwd, targetPath))
+          const filePaths = targetPaths.map((targetPath) => path.relative(outDir, targetPath))
+
+          try {
+            const result = await extractTypes({
+              bundledPackages: bundledPackages || [],
+              customTags: config?.extract?.customTags,
+              cwd,
+              distPath: outDir,
+              exportPath,
+              files,
+              filePaths,
+              projectPath: cwd,
+              rules: config?.extract?.rules,
+              sourceTypesPath: sourceTypesPath,
+              tsconfig: tsContext.config!,
+              tmpPath,
+              tsconfigPath: path.resolve(cwd, tsContext.configPath || 'tsconfig.json'),
+            })
+
+            messages.push(...result.messages)
+            results.push({sourcePath: path.resolve(cwd, entry.sourcePath), filePaths: targetPaths})
+          } catch (err) {
+            if (err instanceof DtsError) {
+              messages.push(...err.messages)
+            } else {
+              observer.error(err)
+
+              return
+            }
+          }
+        }
+
+        observer.next({type: 'dts', messages, results})
+      }
+
+      const watchProgram = ts.createWatchProgram(host)
+
+      return () => {
+        watchProgram.close()
+        rimraf.sync(tmpPath)
+      }
     })
   },
-  complete: (ctx, _task, result) => {
+  complete: (ctx, task, result) => {
     const {logger} = ctx
 
     printExtractMessages(ctx, result.messages)
 
-    logger.warn('watching typescript definitions is currently not supported')
-    logger.log()
+    logger.success(
+      `build type definitions\n       ${task.entries
+        .map(
+          (entry) =>
+            `    - ${chalk.cyan(entry.importId)}: ${chalk.yellow(entry.sourcePath)} ${chalk.gray('→')} ${chalk.yellow(entry.targetPaths.join(', '))}`,
+        )
+        .join('\n       ')}`,
+    )
+    logger.log('')
   },
   error: (ctx, _task, err) => {
     const {logger} = ctx


### PR DESCRIPTION
Removes the need for `turbo watch dev` patterns as we've been using in https://github.com/sanity-io/visual-editing, as `pkg watch` now rebuilds .dts files on changes 🥳 

Can be tested with `pnpm i @sanity/pkg-utils@canary`