### PR TITLE
fix: remove internal exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/pkg-utils",
-  "version": "7.2.8",
+  "version": "7.2.9-canary.0",
   "description": "Simple utilities for modern npm packages.",
   "keywords": [
     "sanity-io",

--- a/src/node/core/config/loadConfig.ts
+++ b/src/node/core/config/loadConfig.ts
@@ -4,7 +4,7 @@ import pkgUp from 'pkg-up'
 import {findConfigFile} from './findConfigFile'
 import type {PkgConfigOptions} from './types'
 
-/** @internal */
+/** @alpha */
 export async function loadConfig(options: {cwd: string}): Promise<PkgConfigOptions | undefined> {
   const {cwd} = options
 

--- a/src/node/core/pkg/loadPkgWithReporting.ts
+++ b/src/node/core/pkg/loadPkgWithReporting.ts
@@ -5,7 +5,7 @@ import {assertLast, assertOrder} from './helpers'
 import {loadPkg} from './loadPkg'
 import type {PackageJSON} from './types'
 
-/** @internal */
+/** @alpha */
 export async function loadPkgWithReporting(options: {
   cwd: string
   logger: Logger

--- a/src/node/core/pkg/parseExports.ts
+++ b/src/node/core/pkg/parseExports.ts
@@ -9,7 +9,7 @@ import {pkgExtMap} from './pkgExt'
 import type {PackageJSON} from './types'
 import {validateExports} from './validateExports'
 
-/** @internal */
+/** @alpha */
 export function parseExports(options: {
   cwd: string
   pkg: PackageJSON

--- a/src/node/core/pkg/types.ts
+++ b/src/node/core/pkg/types.ts
@@ -1,4 +1,4 @@
-/** @internal */
+/** @alpha */
 export interface PackageJSON {
   type?: 'commonjs' | 'module'
   version: string

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -2,7 +2,6 @@ export {build} from './build'
 export {check} from './check'
 export {defineConfig} from './core/config/defineConfig'
 export {loadConfig} from './core/config/loadConfig'
-export {resolveConfigProperty} from './core/config/resolveConfigProperty'
 export type {
   PkgFormat,
   PkgRuntime,
@@ -18,15 +17,11 @@ export type {
   ReactCompilerLogger,
   PkgConfigOptions,
 } from './core/config/types'
-export type {BuildFile, BuildContext} from './core/contexts/buildContext'
 export {DEFAULT_BROWSERSLIST_QUERY} from './core/defaults'
-export * from './core/isRecord'
 export {loadPkg} from './core/pkg/loadPkg'
 export {loadPkgWithReporting} from './core/pkg/loadPkgWithReporting'
 export {parseExports} from './core/pkg/parseExports'
-export {type PkgExtMap, pkgExtMap} from './core/pkg/pkgExt'
 export * from './core/pkg/types'
-export {createFromTemplate} from './core/template/createFromTemplate'
 export {defineTemplateOption} from './core/template/define'
 export {
   type PkgTemplateFile,
@@ -36,11 +31,9 @@ export {
   type PkgTemplateResolver,
   type PkgTemplate,
 } from './core/template/types'
-export {loadTSConfig} from './core/ts/loadTSConfig'
 
 export {init} from './init'
-export {type Logger, createLogger} from './logger'
-export {resolveBuildTasks} from './resolveBuildTasks'
+export {createLogger} from './logger'
 export {
   type StrictOptions,
   type InferredStrictOptions,
@@ -49,23 +42,7 @@ export {
   toggle,
   type ToggleType,
 } from './strict'
-export {buildTaskHandlers, watchTaskHandlers} from './tasks'
-export {dtsTask} from './tasks/dts/dtsTask'
-export {dtsWatchTask} from './tasks/dts/dtsWatchTask'
 export {getExtractMessagesConfig} from './tasks/dts/getExtractMessagesConfig'
-export type {DtsWatchTask, DtsTask, DtsResult} from './tasks/dts/types'
-export {rollupTask} from './tasks/rollup/rollupTask'
-export {rollupWatchTask} from './tasks/rollup/rollupWatchTask'
-export type {
-  RollupTaskEntry,
-  RollupTask,
-  RollupWatchTask,
-  BuildTask,
-  WatchTask,
-  TaskHandler,
-  BuildTaskHandlers,
-  WatchTaskHandlers,
-} from './tasks/types'
 export {watch} from './watch'
 
 export type {Plugin as RollupPlugin} from 'rollup'

--- a/src/node/logger.ts
+++ b/src/node/logger.ts
@@ -1,7 +1,7 @@
 // oxlint-disable no-console
 import chalk from 'chalk'
 
-/** @internal */
+/** @alpha */
 export interface Logger {
   log: (...args: unknown[]) => void
   info: (...args: unknown[]) => void
@@ -10,7 +10,7 @@ export interface Logger {
   success: (...args: unknown[]) => void
 }
 
-/** @internal */
+/** @alpha */
 export function createLogger(): Logger {
   return {
     log: (...args) => {

--- a/src/node/strict.ts
+++ b/src/node/strict.ts
@@ -78,7 +78,7 @@ export interface StrictOptions {
   alwaysPackageJsonFiles?: ToggleType
 }
 
-/** @internal */
+/** @alpha */
 export function parseStrictOptions(input: unknown): InferredStrictOptions {
   return validationSchema.parse({strictOptions: input}, {errorMap}).strictOptions
 }

--- a/src/node/tasks/dts/getExtractMessagesConfig.ts
+++ b/src/node/tasks/dts/getExtractMessagesConfig.ts
@@ -8,7 +8,7 @@ const LOG_LEVELS: Record<PkgRuleLevel, ExtractorLogLevel> = {
   warn: 'warning' as ExtractorLogLevel.Warning,
 }
 
-/** @internal */
+/** @alpha */
 export function getExtractMessagesConfig(options: {
   rules: NonNullable<PkgConfigOptions['extract']>['rules']
 }): IExtractorMessagesConfig {


### PR DESCRIPTION
Exports marked with `@internal` are no longer exported, this makes the resulting bundle leaner, and makes it clearer what's part of the public API, and what's not.