### PR TITLE
feat: add rolldown powered dts bundling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
           cache: pnpm
           node-version: lts/*
       - run: pnpm install
+      - run: pnpm tsc --noEmit
       - run: pnpm lint --deny-warnings --format github
       - run: pnpm build
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,9 @@ jobs:
           cache: pnpm
           node-version: lts/*
       - run: pnpm install
-      - run: pnpm tsc --noEmit
       - run: pnpm lint --deny-warnings --format github
       - run: pnpm build
+      - run: pnpm tsc --noEmit
       - uses: actions/upload-artifact@v4
         name: Cache build output
         with:

--- a/package.config.ts
+++ b/package.config.ts
@@ -25,5 +25,5 @@ export default defineConfig({
   },
   runtime: 'node',
   tsconfig: 'tsconfig.dist.json',
-  dts: 'rolldown',
+  // dts: 'rolldown',
 })

--- a/package.config.ts
+++ b/package.config.ts
@@ -25,5 +25,5 @@ export default defineConfig({
   },
   runtime: 'node',
   tsconfig: 'tsconfig.dist.json',
-  dts: 'rolldown',
+  dts: 'api-extractor',
 })

--- a/package.config.ts
+++ b/package.config.ts
@@ -25,5 +25,5 @@ export default defineConfig({
   },
   runtime: 'node',
   tsconfig: 'tsconfig.dist.json',
-  dts: 'api-extractor',
+  // dts: 'rolldown',
 })

--- a/package.config.ts
+++ b/package.config.ts
@@ -25,4 +25,5 @@ export default defineConfig({
   },
   runtime: 'node',
   tsconfig: 'tsconfig.dist.json',
+  dts: 'rolldown',
 })

--- a/package.config.ts
+++ b/package.config.ts
@@ -25,5 +25,5 @@ export default defineConfig({
   },
   runtime: 'node',
   tsconfig: 'tsconfig.dist.json',
-  // dts: 'rolldown',
+  dts: 'rolldown',
 })

--- a/package.json
+++ b/package.json
@@ -120,6 +120,8 @@
     "prompts": "^2.4.2",
     "recast": "0.23.11",
     "rimraf": "^4.4.1",
+    "rolldown": "1.0.0-beta.17",
+    "rolldown-plugin-dts": "^0.13.11",
     "rollup": "^4.43.0",
     "rollup-plugin-esbuild": "^6.2.1",
     "rxjs": "^7.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/pkg-utils",
-  "version": "7.2.10-canary.1",
+  "version": "7.2.10-canary.4",
   "description": "Simple utilities for modern npm packages.",
   "keywords": [
     "sanity-io",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/pkg-utils",
-  "version": "7.2.9",
+  "version": "7.2.10-canary.0",
   "description": "Simple utilities for modern npm packages.",
   "keywords": [
     "sanity-io",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "rollup-plugin-visualizer": "^6.0.3",
     "semver": "^7.6.0",
     "ts-node": "^10.9.2",
-    "typescript": "5.8.3",
+    "typescript": "catalog:",
     "vitest": "^3.2.4"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/pkg-utils",
-  "version": "7.2.10-canary.0",
+  "version": "7.2.10-canary.1",
   "description": "Simple utilities for modern npm packages.",
   "keywords": [
     "sanity-io",
@@ -49,14 +49,12 @@
     "bin",
     "dist",
     "tsconfig",
-    "!dist/stats.html",
-    "src",
-    "!src/**/*.test.ts"
+    "!dist/stats.html"
   ],
   "scripts": {
     "build": "run-s clean build:pkg check:pkg",
-    "build:pkg": "node -r esbuild-register scripts/build",
-    "check:pkg": "node -r esbuild-register scripts/check",
+    "build:pkg": "tsx scripts/build",
+    "check:pkg": "tsx scripts/check",
     "check:types": "tsc --build",
     "clean": "rimraf dist test/env/__tmp__",
     "commit": "cz",
@@ -69,7 +67,7 @@
     "pretest": "run-s playground:clean",
     "test": "vitest run",
     "test:update-snapshots": "pnpm test run -- --update",
-    "watch": "node -r esbuild-register scripts/watch"
+    "watch": "tsx scripts/watch"
   },
   "commitlint": {
     "extends": [
@@ -158,6 +156,7 @@
     "rollup-plugin-visualizer": "^6.0.3",
     "semver": "^7.6.0",
     "ts-node": "^10.9.2",
+    "tsx": "^4.20.3",
     "typescript": "catalog:",
     "vitest": "^3.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "@types/cpx": "^1.5.5",
     "@types/find-config": "^1.0.4",
     "@types/git-url-parse": "^16.0.2",
-    "@types/node": "^20.8.7",
+    "@types/node": "^24.0.3",
     "@types/prompts": "^2.4.9",
     "@types/rimraf": "^3.0.2",
     "@types/semver": "^7.5.8",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "recast": "0.23.11",
     "rimraf": "^4.4.1",
     "rolldown": "1.0.0-beta.17",
-    "rolldown-plugin-dts": "^0.13.11",
+    "rolldown-plugin-dts": "0.13.11",
     "rollup": "^4.43.0",
     "rollup-plugin-esbuild": "^6.2.1",
     "rxjs": "^7.8.2",

--- a/playground/reference-cjs/package.json
+++ b/playground/reference-cjs/package.json
@@ -27,6 +27,6 @@
   },
   "devDependencies": {
     "@tsconfig/node-lts": "22.0.1",
-    "typescript": "5.8.3"
+    "typescript": "catalog:"
   }
 }

--- a/playground/reference-esm-only/package.json
+++ b/playground/reference-esm-only/package.json
@@ -46,6 +46,6 @@
   },
   "devDependencies": {
     "@tsconfig/node-lts": "22.0.1",
-    "typescript": "5.8.3"
+    "typescript": "catalog:"
   }
 }

--- a/playground/reference-esm/package.json
+++ b/playground/reference-esm/package.json
@@ -27,6 +27,6 @@
   },
   "devDependencies": {
     "@tsconfig/node-lts": "22.0.1",
-    "typescript": "5.8.3"
+    "typescript": "catalog:"
   }
 }

--- a/playground/runtime-vite/package.json
+++ b/playground/runtime-vite/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "dummy-commonjs": "workspace:*",
     "dummy-module": "workspace:*",
-    "typescript": "5.8.3",
+    "typescript": "catalog:",
     "vite": "^6.3.5"
   }
 }

--- a/playground/ts-rolldown-without-extract/package.config.ts
+++ b/playground/ts-rolldown-without-extract/package.config.ts
@@ -6,5 +6,5 @@ export default defineConfig({
     // This package fails to build with extract enabled
     enabled: false,
   },
-  // dts: 'rolldown',
+  dts: 'rolldown',
 })

--- a/playground/ts-rolldown-without-extract/package.config.ts
+++ b/playground/ts-rolldown-without-extract/package.config.ts
@@ -1,0 +1,10 @@
+import {defineConfig} from '@sanity/pkg-utils'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  extract: {
+    // This package fails to build with extract enabled
+    enabled: false,
+  },
+  // dts: 'rolldown',
+})

--- a/playground/ts-rolldown-without-extract/package.json
+++ b/playground/ts-rolldown-without-extract/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ts-rolldown-without-extract",
+  "version": "0.0.0-development",
+  "private": true,
+  "license": "MIT",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "browserslist": "extends @sanity/browserslist-config",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "pkg build --strict --check --clean",
+    "check:types": "tsc",
+    "clean": "rimraf dist"
+  }
+}

--- a/playground/ts-rolldown-without-extract/src/index.ts
+++ b/playground/ts-rolldown-without-extract/src/index.ts
@@ -1,0 +1,1 @@
+export const VERSION = '1.0.0'

--- a/playground/ts-rolldown-without-extract/tsconfig.dist.json
+++ b/playground/ts-rolldown-without-extract/tsconfig.dist.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["./src"]
+}

--- a/playground/ts-rolldown-without-extract/tsconfig.json
+++ b/playground/ts-rolldown-without-extract/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["./package.config.ts", "./src"]
+}

--- a/playground/ts-rolldown-without-extract/tsconfig.settings.json
+++ b/playground/ts-rolldown-without-extract/tsconfig.settings.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@sanity/pkg-utils/tsconfig/strictest.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist"
+  }
+}

--- a/playground/ts-rolldown/package.config.ts
+++ b/playground/ts-rolldown/package.config.ts
@@ -2,5 +2,5 @@ import {defineConfig} from '@sanity/pkg-utils'
 
 export default defineConfig({
   tsconfig: 'tsconfig.dist.json',
-  // dts: 'rolldown'
+  dts: 'rolldown',
 })

--- a/playground/ts-rolldown/package.config.ts
+++ b/playground/ts-rolldown/package.config.ts
@@ -1,0 +1,6 @@
+import {defineConfig} from '@sanity/pkg-utils'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  // dts: 'rolldown'
+})

--- a/playground/ts-rolldown/package.json
+++ b/playground/ts-rolldown/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ts-rolldown",
+  "version": "0.0.0-development",
+  "private": true,
+  "license": "MIT",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "browserslist": "extends @sanity/browserslist-config",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "pkg build --strict --check --clean",
+    "check:types": "tsc",
+    "clean": "rimraf dist"
+  }
+}

--- a/playground/ts-rolldown/src/index.ts
+++ b/playground/ts-rolldown/src/index.ts
@@ -1,0 +1,2 @@
+/** @public */
+export const VERSION = '1.0.0'

--- a/playground/ts-rolldown/tsconfig.dist.json
+++ b/playground/ts-rolldown/tsconfig.dist.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["./src"]
+}

--- a/playground/ts-rolldown/tsconfig.json
+++ b/playground/ts-rolldown/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["./package.config.ts", "./src"]
+}

--- a/playground/ts-rolldown/tsconfig.settings.json
+++ b/playground/ts-rolldown/tsconfig.settings.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@sanity/pkg-utils/tsconfig/strictest.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist"
+  }
+}

--- a/playground/ts-without-extract/package.config.ts
+++ b/playground/ts-without-extract/package.config.ts
@@ -3,6 +3,7 @@ import {defineConfig} from '@sanity/pkg-utils'
 export default defineConfig({
   tsconfig: 'tsconfig.dist.json',
   extract: {
+    // This package fails to build with extract enabled
     enabled: false,
   },
 })

--- a/playground/ts-without-extract/package.config.ts
+++ b/playground/ts-without-extract/package.config.ts
@@ -1,0 +1,8 @@
+import {defineConfig} from '@sanity/pkg-utils'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  extract: {
+    enabled: false,
+  },
+})

--- a/playground/ts-without-extract/package.json
+++ b/playground/ts-without-extract/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ts-without-extract",
+  "version": "0.0.0-development",
+  "private": true,
+  "license": "MIT",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "browserslist": "extends @sanity/browserslist-config",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "pkg build --strict --check --clean",
+    "check:types": "tsc",
+    "clean": "rimraf dist"
+  }
+}

--- a/playground/ts-without-extract/src/index.ts
+++ b/playground/ts-without-extract/src/index.ts
@@ -1,0 +1,1 @@
+export const VERSION = '1.0.0'

--- a/playground/ts-without-extract/tsconfig.dist.json
+++ b/playground/ts-without-extract/tsconfig.dist.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["./src"]
+}

--- a/playground/ts-without-extract/tsconfig.json
+++ b/playground/ts-without-extract/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["./package.config.ts", "./src"]
+}

--- a/playground/ts-without-extract/tsconfig.settings.json
+++ b/playground/ts-without-extract/tsconfig.settings.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@sanity/pkg-utils/tsconfig/strictest.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,12 +225,15 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@24.0.3)(typescript@5.8.3)
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.3
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(tsx@4.20.3)(yaml@2.8.0)
 
   playground/babel-plugin:
     devDependencies:
@@ -289,7 +292,7 @@ importers:
     devDependencies:
       '@sanity/visual-editing':
         specifier: ^2.15.0
-        version: 2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
+        version: 2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
       dummy-side-effects:
         specifier: workspace:*
         version: link:../dummy-side-effects
@@ -363,7 +366,7 @@ importers:
     devDependencies:
       astro:
         specifier: ^5.9.4
-        version: 5.9.4(@types/node@24.0.3)(jiti@2.4.2)(rollup@4.43.0)(terser@5.43.0)(typescript@5.8.3)(yaml@2.8.0)
+        version: 5.9.4(@types/node@24.0.3)(jiti@2.4.2)(rollup@4.43.0)(terser@5.43.0)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
       dummy-commonjs:
         specifier: workspace:*
         version: link:../dummy-commonjs
@@ -381,7 +384,7 @@ importers:
         version: link:../dummy-module
       next:
         specifier: ^15.3.3
-        version: 15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -423,7 +426,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
+        version: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(tsx@4.20.3)(yaml@2.8.0)
 
   playground/sanity:
     devDependencies:
@@ -4712,6 +4715,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.20.3:
+    resolution: {integrity: sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
@@ -6296,7 +6304,7 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 3.93.0(@types/react@19.1.8)
 
-  '@sanity/visual-editing@2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)':
+  '@sanity/visual-editing@2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)':
     dependencies:
       '@sanity/comlink': 3.0.5
       '@sanity/icons': 3.7.0(react@19.1.0)
@@ -6319,7 +6327,7 @@ snapshots:
       xstate: 5.19.4
     optionalDependencies:
       '@sanity/client': 7.6.0
-      next: 15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@sanity/types'
@@ -6528,13 +6536,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -6683,7 +6691,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  astro@5.9.4(@types/node@24.0.3)(jiti@2.4.2)(rollup@4.43.0)(terser@5.43.0)(typescript@5.8.3)(yaml@2.8.0):
+  astro@5.9.4(@types/node@24.0.3)(jiti@2.4.2)(rollup@4.43.0)(terser@5.43.0)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0):
     dependencies:
       '@astrojs/compiler': 2.12.2
       '@astrojs/internal-helpers': 0.6.1
@@ -6738,8 +6746,8 @@ snapshots:
       unist-util-visit: 5.0.0
       unstorage: 1.16.0
       vfile: 6.0.3
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
-      vitefu: 1.0.6(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0))
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(tsx@4.20.3)(yaml@2.8.0)
+      vitefu: 1.0.6(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(tsx@4.20.3)(yaml@2.8.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -8714,7 +8722,7 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
-  next@15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.3.3
       '@swc/counter': 0.1.3
@@ -8734,7 +8742,6 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.3.3
       '@next/swc-win32-arm64-msvc': 15.3.3
       '@next/swc-win32-x64-msvc': 15.3.3
-      babel-plugin-react-compiler: 19.1.0-rc.2
       sharp: 0.34.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -9813,6 +9820,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.20.3:
+    dependencies:
+      esbuild: 0.25.5
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -9996,13 +10010,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.2.4(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0):
+  vite-node@3.2.4(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -10017,7 +10031,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0):
+  vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.6(picomatch@4.0.2)
@@ -10030,17 +10044,18 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.4.2
       terser: 5.43.0
+      tsx: 4.20.3
       yaml: 2.8.0
 
-  vitefu@1.0.6(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)):
+  vitefu@1.0.6(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(tsx@4.20.3)(yaml@2.8.0)):
     optionalDependencies:
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(tsx@4.20.3)(yaml@2.8.0)
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(tsx@4.20.3)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -10058,8 +10073,8 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
-      vite-node: 3.2.4(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(tsx@4.20.3)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(tsx@4.20.3)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,7 +123,7 @@ importers:
         specifier: 1.0.0-beta.17
         version: 1.0.0-beta.17
       rolldown-plugin-dts:
-        specifier: ^0.13.11
+        specifier: 0.13.11
         version: 0.13.11(@typescript/native-preview@7.0.0-dev.20250618.1)(rolldown@1.0.0-beta.17)(typescript@5.8.3)
       rollup:
         specifier: ^4.43.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,12 @@ importers:
       rimraf:
         specifier: ^4.4.1
         version: 4.4.1
+      rolldown:
+        specifier: 1.0.0-beta.17
+        version: 1.0.0-beta.17
+      rolldown-plugin-dts:
+        specifier: ^0.13.11
+        version: 0.13.11(rolldown@1.0.0-beta.17)(typescript@5.8.3)
       rollup:
         specifier: ^4.43.0
         version: 4.43.0
@@ -206,7 +212,7 @@ importers:
         version: 1.1.0
       rollup-plugin-visualizer:
         specifier: ^6.0.3
-        version: 6.0.3(rollup@4.43.0)
+        version: 6.0.3(rolldown@1.0.0-beta.17)(rollup@4.43.0)
       semver:
         specifier: ^7.6.0
         version: 7.7.2
@@ -277,7 +283,7 @@ importers:
     devDependencies:
       '@sanity/visual-editing':
         specifier: ^2.15.0
-        version: 2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
+        version: 2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
       dummy-side-effects:
         specifier: workspace:*
         version: link:../dummy-side-effects
@@ -369,7 +375,7 @@ importers:
         version: link:../dummy-module
       next:
         specifier: ^15.3.3
-        version: 15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -697,8 +703,14 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
+  '@emnapi/core@1.4.3':
+    resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
+
   '@emnapi/runtime@1.4.3':
     resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
+
+  '@emnapi/wasi-threads@1.0.2':
+    resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
 
   '@emotion/is-prop-valid@1.2.2':
     resolution: {integrity: sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==}
@@ -1144,6 +1156,9 @@ packages:
   '@microsoft/tsdoc@0.15.1':
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
 
+  '@napi-rs/wasm-runtime@0.2.11':
+    resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==}
+
   '@next/env@15.3.3':
     resolution: {integrity: sha512-OdiMrzCl2Xi0VTjiQQUK0Xh7bJHnOuET2s+3V+Y40WJBAXrJeGA3f+I8MZJ/YQ3mVGi5XGR1L66oFlgqXhQ4Vw==}
 
@@ -1220,6 +1235,13 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
+  '@oxc-project/runtime@0.73.0':
+    resolution: {integrity: sha512-YFvBzVQK/ix0RQxOI02ebCumehSHoiJgvb7nOU4o7xFoMnnujLdjmxnEBK/qiOQrEyXlY69gXGMEsKYVe+YZ3A==}
+    engines: {node: '>=6.9.0'}
+
+  '@oxc-project/types@0.73.0':
+    resolution: {integrity: sha512-ZQS7dpsga43R7bjqRKHRhOeNpuIBeLBnlS3M6H3IqWIWiapGOQIxp4lpETLBYupkSd4dh85ESFn6vAvtpPdGkA==}
+
   '@oxlint/darwin-arm64@1.1.0':
     resolution: {integrity: sha512-sSnR3SOxIU/QfaqXrcQ0UVUkzJO0bcInQ7dMhHa102gVAgWjp1fBeMVCM0adEY0UNmEXrRkgD/rQtQgn9YAU+w==}
     cpu: [arm64]
@@ -1275,6 +1297,69 @@ packages:
   '@pnpm/npm-conf@2.3.1':
     resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
     engines: {node: '>=12'}
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.17':
+    resolution: {integrity: sha512-uYxIZ+QdYsjtLUNT3BWCJAww5YJMKL5ZreEO6uJKHCPUE4wbAU1t4JzQudnjrqpkviz4IQYL62Ry/uKuZxzmrw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.17':
+    resolution: {integrity: sha512-uu1ovSv1BmYvpR8nJdhkPcnV90l5jmAE4YNmJHo1sSLXWPqlWfigTJ+4v1g8ww1hU4It6Rd7Odf4fqOFnRu74g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.17':
+    resolution: {integrity: sha512-7PhPJ/V8RxvHtk4VDLYsSlDi43W766X2AXlMEqtUi9qpImVH55PsMUrDq74GvJsSKYAO9pAzncP6/sDB0i6F6g==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.17':
+    resolution: {integrity: sha512-VHmUdihRL3kFYgUjr6n3laeZPdmHEliFW+R1F4JhbkztpjdcZjztuOKGul6/x77JJf+LJuAgny45Gw2W5i/hsg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.17':
+    resolution: {integrity: sha512-P/BDueuHUcw5fHNK1UBtItH/o1HNUb3n0o03/lFh3VkrP5yzC9Ov/bVj5wtat1Gb0JAm4ypVHcvlFtU/XOB57w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.17':
+    resolution: {integrity: sha512-ZUYk2/j335hVqlhwpkbjgH4eENQIA6aCTwt5Lm8yv3Ny3Dp+NJWjW+a98OruAHel5dsqbKVQriP5av5Ga10rMQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.17':
+    resolution: {integrity: sha512-yM9lISQs+es9Mma1qadEj/0hOMJThEVu4azPw9vp1gVtG7fQg/k+AGqULzy175exaZS3IodVwaCC9qtk9QZiUw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.17':
+    resolution: {integrity: sha512-3n+NDnMItllqo09RooFrNJpPjznId7TZcicnGObbnSMBtIfIknkUyjECQssoLajjZ2E4DK7N62yd7jbRkTNZ1g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.17':
+    resolution: {integrity: sha512-CL7bKJg+GhZAM2R2I+mHQb3+8NJmQU1UkXqtR9tJCw60f9yOFi6cwC8lYtFHdM6CuFA+X7+8L3DcTupBNmUiRA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.17':
+    resolution: {integrity: sha512-35aU4xs7zbAsvirVHnpKjAS0Lblrf4PzJPj2cvII0olFyizfqYZ6yxdzgiUjbPFdF34SKc7obmiA4BG16URsvA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.17':
+    resolution: {integrity: sha512-cPQNXNf74epAShehFaudP4TG3+faHcg+SAB+3sTVu5oGfKHfocHwNo/Uhf6HnFr+6gXpRWcnOj3+k2+KDVisCQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.17':
+    resolution: {integrity: sha512-n/3qfwsk6VvDK3RE/mcsA3IIduVAAiAXIkDFGZopj0EZQVYSuFmZ3V3InAk/4cue1YGMARZNPOtTR4LozfzBUA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-beta.17':
+    resolution: {integrity: sha512-i6p5fc1+lAmR3OHmNlv7/3PIY3EtuUu4kVARjkid38p7cmyIyqr0QFnA+k3xoB06wQUpBA91H1HFlRreZ2v5oA==}
 
   '@rollup/plugin-alias@5.1.1':
     resolution: {integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==}
@@ -1647,6 +1732,9 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
+  '@tybys/wasm-util@0.9.0':
+    resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
+
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
 
@@ -1873,6 +1961,10 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
+  ansis@4.1.0:
+    resolution: {integrity: sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==}
+    engines: {node: '>=14'}
+
   anymatch@1.3.2:
     resolution: {integrity: sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==}
 
@@ -1935,6 +2027,10 @@ packages:
     resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
     engines: {node: '>=0.10.0'}
 
+  ast-kit@2.1.0:
+    resolution: {integrity: sha512-ROM2LlXbZBZVk97crfw8PGDOBzzsJvN2uJCmwswvPUNyfH14eg90mSN3xNqsri1JS1G9cz0VzeDUhxJkTrr4Ew==}
+    engines: {node: '>=20.18.0'}
+
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
@@ -1993,6 +2089,9 @@ packages:
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  birpc@2.4.0:
+    resolution: {integrity: sha512-5IdNxTyhXHv2UlgnPHQ0h+5ypVmkrYHzL8QT+DwFZ//2N/oNV8Ch+BCRmTJ3x6/z9Axo/cXYBc9eprsUVK/Jsg==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -2469,6 +2568,15 @@ packages:
   dset@3.1.4:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
+
+  dts-resolver@2.1.1:
+    resolution: {integrity: sha512-3BiGFhB6mj5Kv+W2vdJseQUYW+SKVzAFJL6YNP6ursbrwy1fXHRotfHi3xLNxe4wZl/K8qbAFeCDjZLjzqxxRw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      oxc-resolver: '>=11.0.0'
+    peerDependenciesMeta:
+      oxc-resolver:
+        optional: true
 
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
@@ -4157,6 +4265,26 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  rolldown-plugin-dts@0.13.11:
+    resolution: {integrity: sha512-1TScN31JImk8xcq9kdm52z2W8/QX3zeDpEjFkyZmK+GcD0u8QqSWWARBsCEdfS99NyI6D9NIbUpsABXlcpZhig==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
+      rolldown: ^1.0.0-beta.9
+      typescript: ^5.0.0
+      vue-tsc: ~2.2.0
+    peerDependenciesMeta:
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
+
+  rolldown@1.0.0-beta.17:
+    resolution: {integrity: sha512-L45QWZF/7HYfIO1nZZL83O8xOMOxBlMiFsspMRUus68wkiag3PNn6PDqEFbzbQDYN32YHFEb2qzqkC2M0enZ2A==}
+    hasBin: true
+
   rollup-plugin-esbuild@6.2.1:
     resolution: {integrity: sha512-jTNOMGoMRhs0JuueJrJqbW8tOwxumaWYq+V5i+PD+8ecSCVkuX27tGW7BXqDgoULQ55rO7IdNxPcnsWtshz3AA==}
     engines: {node: '>=14.18.0'}
@@ -5378,7 +5506,18 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@emnapi/core@1.4.3':
+    dependencies:
+      '@emnapi/wasi-threads': 1.0.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.4.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.0.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5714,6 +5853,13 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.1': {}
 
+  '@napi-rs/wasm-runtime@0.2.11':
+    dependencies:
+      '@emnapi/core': 1.4.3
+      '@emnapi/runtime': 1.4.3
+      '@tybys/wasm-util': 0.9.0
+    optional: true
+
   '@next/env@15.3.3': {}
 
   '@next/swc-darwin-arm64@15.3.3':
@@ -5765,6 +5911,10 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
+  '@oxc-project/runtime@0.73.0': {}
+
+  '@oxc-project/types@0.73.0': {}
+
   '@oxlint/darwin-arm64@1.1.0':
     optional: true
 
@@ -5802,6 +5952,46 @@ snapshots:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.17':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.11
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.17':
+    optional: true
+
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-beta.17': {}
 
   '@rollup/plugin-alias@5.1.1(rollup@4.43.0)':
     optionalDependencies:
@@ -6094,7 +6284,7 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 3.93.0(@types/react@19.1.8)
 
-  '@sanity/visual-editing@2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)':
+  '@sanity/visual-editing@2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)':
     dependencies:
       '@sanity/comlink': 3.0.5
       '@sanity/icons': 3.7.0(react@19.1.0)
@@ -6117,7 +6307,7 @@ snapshots:
       xstate: 5.19.4
     optionalDependencies:
       '@sanity/client': 7.6.0
-      next: 15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@sanity/types'
@@ -6176,6 +6366,11 @@ snapshots:
   '@tsconfig/node14@1.0.3': {}
 
   '@tsconfig/node16@1.0.4': {}
+
+  '@tybys/wasm-util@0.9.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/argparse@1.0.38': {}
 
@@ -6421,6 +6616,8 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
+  ansis@4.1.0: {}
+
   anymatch@1.3.2:
     dependencies:
       micromatch: 2.3.11
@@ -6464,6 +6661,11 @@ snapshots:
   assertion-error@2.0.1: {}
 
   assign-symbols@1.0.0: {}
+
+  ast-kit@2.1.0:
+    dependencies:
+      '@babel/parser': 7.27.5
+      pathe: 2.0.3
 
   ast-types@0.16.1:
     dependencies:
@@ -6622,6 +6824,8 @@ snapshots:
     dependencies:
       file-uri-to-path: 1.0.0
     optional: true
+
+  birpc@2.4.0: {}
 
   bl@4.1.0:
     dependencies:
@@ -7109,6 +7313,8 @@ snapshots:
       is-obj: 2.0.0
 
   dset@3.1.4: {}
+
+  dts-resolver@2.1.1: {}
 
   duplexer@0.1.2: {}
 
@@ -8496,7 +8702,7 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
-  next@15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.3.3
       '@swc/counter': 0.1.3
@@ -8516,7 +8722,6 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.3.3
       '@next/swc-win32-arm64-msvc': 15.3.3
       '@next/swc-win32-x64-msvc': 15.3.3
-      babel-plugin-react-compiler: 19.1.0-rc.2
       sharp: 0.34.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -9093,6 +9298,43 @@ snapshots:
     dependencies:
       glob: 9.3.5
 
+  rolldown-plugin-dts@0.13.11(rolldown@1.0.0-beta.17)(typescript@5.8.3):
+    dependencies:
+      '@babel/generator': 7.27.5
+      '@babel/parser': 7.27.5
+      '@babel/types': 7.27.6
+      ast-kit: 2.1.0
+      birpc: 2.4.0
+      debug: 4.4.1
+      dts-resolver: 2.1.1
+      get-tsconfig: 4.10.1
+      rolldown: 1.0.0-beta.17
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - oxc-resolver
+      - supports-color
+
+  rolldown@1.0.0-beta.17:
+    dependencies:
+      '@oxc-project/runtime': 0.73.0
+      '@oxc-project/types': 0.73.0
+      '@rolldown/pluginutils': 1.0.0-beta.17
+      ansis: 4.1.0
+    optionalDependencies:
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.17
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.17
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.17
+
   rollup-plugin-esbuild@6.2.1(esbuild@0.25.5)(rollup@4.43.0):
     dependencies:
       debug: 4.4.1
@@ -9104,13 +9346,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rollup-plugin-visualizer@6.0.3(rollup@4.43.0):
+  rollup-plugin-visualizer@6.0.3(rolldown@1.0.0-beta.17)(rollup@4.43.0):
     dependencies:
       open: 8.4.2
       picomatch: 4.0.2
       source-map: 0.7.4
       yargs: 17.7.2
     optionalDependencies:
+      rolldown: 1.0.0-beta.17
       rollup: 4.43.0
 
   rollup@4.43.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 7.27.6
       '@microsoft/api-extractor':
         specifier: 7.52.8
-        version: 7.52.8(@types/node@20.19.1)
+        version: 7.52.8(@types/node@24.0.3)
       '@microsoft/tsdoc-config':
         specifier: 0.17.1
         version: 0.17.1
@@ -149,7 +149,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.8.1
-        version: 19.8.1(@types/node@20.19.1)(typescript@5.8.3)
+        version: 19.8.1(@types/node@24.0.3)(typescript@5.8.3)
       '@commitlint/config-conventional':
         specifier: ^19.8.1
         version: 19.8.1
@@ -175,8 +175,8 @@ importers:
         specifier: ^16.0.2
         version: 16.0.2
       '@types/node':
-        specifier: ^20.8.7
-        version: 20.19.1
+        specifier: ^24.0.3
+        version: 24.0.3
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
@@ -197,13 +197,13 @@ importers:
         version: 2.1.1(browserslist@4.25.0)
       commitizen:
         specifier: ^4.3.1
-        version: 4.3.1(@types/node@20.19.1)(typescript@5.8.3)
+        version: 4.3.1(@types/node@24.0.3)(typescript@5.8.3)
       cpx:
         specifier: ^1.5.0
         version: 1.5.0
       cz-conventional-changelog:
         specifier: ^3.3.0
-        version: 3.3.0(@types/node@20.19.1)(typescript@5.8.3)
+        version: 3.3.0(@types/node@24.0.3)(typescript@5.8.3)
       husky:
         specifier: ^8.0.3
         version: 8.0.3
@@ -224,13 +224,13 @@ importers:
         version: 7.7.2
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.19.1)(typescript@5.8.3)
+        version: 10.9.2(@types/node@24.0.3)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
 
   playground/babel-plugin:
     devDependencies:
@@ -363,7 +363,7 @@ importers:
     devDependencies:
       astro:
         specifier: ^5.9.4
-        version: 5.9.4(@types/node@20.19.1)(jiti@2.4.2)(rollup@4.43.0)(terser@5.43.0)(typescript@5.8.3)(yaml@2.8.0)
+        version: 5.9.4(@types/node@24.0.3)(jiti@2.4.2)(rollup@4.43.0)(terser@5.43.0)(typescript@5.8.3)(yaml@2.8.0)
       dummy-commonjs:
         specifier: workspace:*
         version: link:../dummy-commonjs
@@ -423,7 +423,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@20.19.1)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
+        version: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
 
   playground/sanity:
     devDependencies:
@@ -1829,8 +1829,8 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
-  '@types/node@20.19.1':
-    resolution: {integrity: sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==}
+  '@types/node@24.0.3':
+    resolution: {integrity: sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==}
 
   '@types/parse-path@7.1.0':
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
@@ -4742,8 +4742,8 @@ packages:
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  undici-types@7.8.0:
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
 
   unicode-properties@1.4.1:
     resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
@@ -5404,11 +5404,11 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@commitlint/cli@19.8.1(@types/node@20.19.1)(typescript@5.8.3)':
+  '@commitlint/cli@19.8.1(@types/node@24.0.3)(typescript@5.8.3)':
     dependencies:
       '@commitlint/format': 19.8.1
       '@commitlint/lint': 19.8.1
-      '@commitlint/load': 19.8.1(@types/node@20.19.1)(typescript@5.8.3)
+      '@commitlint/load': 19.8.1(@types/node@24.0.3)(typescript@5.8.3)
       '@commitlint/read': 19.8.1
       '@commitlint/types': 19.8.1
       tinyexec: 1.0.1
@@ -5455,7 +5455,7 @@ snapshots:
       '@commitlint/rules': 19.8.1
       '@commitlint/types': 19.8.1
 
-  '@commitlint/load@19.8.1(@types/node@20.19.1)(typescript@5.8.3)':
+  '@commitlint/load@19.8.1(@types/node@24.0.3)(typescript@5.8.3)':
     dependencies:
       '@commitlint/config-validator': 19.8.1
       '@commitlint/execute-rule': 19.8.1
@@ -5463,7 +5463,7 @@ snapshots:
       '@commitlint/types': 19.8.1
       chalk: 5.4.1
       cosmiconfig: 9.0.0(typescript@5.8.3)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@20.19.1)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3)
+      cosmiconfig-typescript-loader: 6.1.0(@types/node@24.0.3)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -5830,23 +5830,23 @@ snapshots:
 
   '@juggle/resize-observer@3.4.0': {}
 
-  '@microsoft/api-extractor-model@7.30.6(@types/node@20.19.1)':
+  '@microsoft/api-extractor-model@7.30.6(@types/node@24.0.3)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.13.1(@types/node@20.19.1)
+      '@rushstack/node-core-library': 5.13.1(@types/node@24.0.3)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.52.8(@types/node@20.19.1)':
+  '@microsoft/api-extractor@7.52.8(@types/node@24.0.3)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.30.6(@types/node@20.19.1)
+      '@microsoft/api-extractor-model': 7.30.6(@types/node@24.0.3)
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.13.1(@types/node@20.19.1)
+      '@rushstack/node-core-library': 5.13.1(@types/node@24.0.3)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.15.3(@types/node@20.19.1)
-      '@rushstack/ts-command-line': 5.0.1(@types/node@20.19.1)
+      '@rushstack/terminal': 0.15.3(@types/node@24.0.3)
+      '@rushstack/ts-command-line': 5.0.1(@types/node@24.0.3)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.10
@@ -6131,7 +6131,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.43.0':
     optional: true
 
-  '@rushstack/node-core-library@5.13.1(@types/node@20.19.1)':
+  '@rushstack/node-core-library@5.13.1(@types/node@24.0.3)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -6142,23 +6142,23 @@ snapshots:
       resolve: 1.22.10
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
 
   '@rushstack/rig-package@0.5.3':
     dependencies:
       resolve: 1.22.10
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.15.3(@types/node@20.19.1)':
+  '@rushstack/terminal@0.15.3(@types/node@24.0.3)':
     dependencies:
-      '@rushstack/node-core-library': 5.13.1(@types/node@20.19.1)
+      '@rushstack/node-core-library': 5.13.1(@types/node@24.0.3)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
 
-  '@rushstack/ts-command-line@5.0.1(@types/node@20.19.1)':
+  '@rushstack/ts-command-line@5.0.1(@types/node@24.0.3)':
     dependencies:
-      '@rushstack/terminal': 0.15.3(@types/node@20.19.1)
+      '@rushstack/terminal': 0.15.3(@types/node@24.0.3)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -6413,11 +6413,11 @@ snapshots:
 
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
 
   '@types/cpx@1.5.5':
     dependencies:
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
 
   '@types/debug@4.1.12':
     dependencies:
@@ -6437,11 +6437,11 @@ snapshots:
 
   '@types/follow-redirects@1.14.4':
     dependencies:
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
 
   '@types/fontkit@2.0.8':
     dependencies:
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
 
   '@types/git-url-parse@16.0.2':
     dependencies:
@@ -6450,7 +6450,7 @@ snapshots:
   '@types/glob@8.1.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
 
   '@types/hast@2.3.10':
     dependencies:
@@ -6478,9 +6478,9 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/node@20.19.1':
+  '@types/node@24.0.3':
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 7.8.0
 
   '@types/parse-path@7.1.0':
     dependencies:
@@ -6488,7 +6488,7 @@ snapshots:
 
   '@types/prompts@2.4.9':
     dependencies:
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
       kleur: 3.0.3
 
   '@types/react@19.1.8':
@@ -6500,7 +6500,7 @@ snapshots:
   '@types/rimraf@3.0.2':
     dependencies:
       '@types/glob': 8.1.0
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
 
   '@types/semver@7.7.0': {}
 
@@ -6528,13 +6528,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@20.19.1)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@20.19.1)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -6683,7 +6683,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  astro@5.9.4(@types/node@20.19.1)(jiti@2.4.2)(rollup@4.43.0)(terser@5.43.0)(typescript@5.8.3)(yaml@2.8.0):
+  astro@5.9.4(@types/node@24.0.3)(jiti@2.4.2)(rollup@4.43.0)(terser@5.43.0)(typescript@5.8.3)(yaml@2.8.0):
     dependencies:
       '@astrojs/compiler': 2.12.2
       '@astrojs/internal-helpers': 0.6.1
@@ -6738,8 +6738,8 @@ snapshots:
       unist-util-visit: 5.0.0
       unstorage: 1.16.0
       vfile: 6.0.3
-      vite: 6.3.5(@types/node@20.19.1)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
-      vitefu: 1.0.6(vite@6.3.5(@types/node@20.19.1)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0))
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
+      vitefu: 1.0.6(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -7082,10 +7082,10 @@ snapshots:
 
   commander@2.20.3: {}
 
-  commitizen@4.3.1(@types/node@20.19.1)(typescript@5.8.3):
+  commitizen@4.3.1(@types/node@24.0.3)(typescript@5.8.3):
     dependencies:
       cachedir: 2.3.0
-      cz-conventional-changelog: 3.3.0(@types/node@20.19.1)(typescript@5.8.3)
+      cz-conventional-changelog: 3.3.0(@types/node@24.0.3)(typescript@5.8.3)
       dedent: 0.7.0
       detect-indent: 6.1.0
       find-node-modules: 2.1.3
@@ -7151,9 +7151,9 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@6.1.0(@types/node@20.19.1)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3):
+  cosmiconfig-typescript-loader@6.1.0(@types/node@24.0.3)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 2.4.2
       typescript: 5.8.3
@@ -7218,16 +7218,16 @@ snapshots:
 
   csstype@3.1.3: {}
 
-  cz-conventional-changelog@3.3.0(@types/node@20.19.1)(typescript@5.8.3):
+  cz-conventional-changelog@3.3.0(@types/node@24.0.3)(typescript@5.8.3):
     dependencies:
       chalk: 2.4.2
-      commitizen: 4.3.1(@types/node@20.19.1)(typescript@5.8.3)
+      commitizen: 4.3.1(@types/node@24.0.3)(typescript@5.8.3)
       conventional-commit-types: 3.0.0
       lodash.map: 4.6.0
       longest: 2.0.1
       word-wrap: 1.2.5
     optionalDependencies:
-      '@commitlint/load': 19.8.1(@types/node@20.19.1)(typescript@5.8.3)
+      '@commitlint/load': 19.8.1(@types/node@24.0.3)(typescript@5.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - typescript
@@ -9787,14 +9787,14 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3):
+  ts-node@10.9.2(@types/node@24.0.3)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -9831,7 +9831,7 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
-  undici-types@6.21.0: {}
+  undici-types@7.8.0: {}
 
   unicode-properties@1.4.1:
     dependencies:
@@ -9996,13 +9996,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.2.4(@types/node@20.19.1)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0):
+  vite-node@3.2.4(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@20.19.1)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -10017,7 +10017,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.5(@types/node@20.19.1)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0):
+  vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.6(picomatch@4.0.2)
@@ -10026,21 +10026,21 @@ snapshots:
       rollup: 4.43.0
       tinyglobby: 0.2.14
     optionalDependencies:
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
       fsevents: 2.3.3
       jiti: 2.4.2
       terser: 5.43.0
       yaml: 2.8.0
 
-  vitefu@1.0.6(vite@6.3.5(@types/node@20.19.1)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)):
+  vitefu@1.0.6(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)):
     optionalDependencies:
-      vite: 6.3.5(@types/node@20.19.1)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@20.19.1)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -10058,12 +10058,12 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@20.19.1)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
-      vite-node: 3.2.4(@types/node@20.19.1)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.0)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 20.19.1
+      '@types/node': 24.0.3
     transitivePeerDependencies:
       - jiti
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,7 +292,7 @@ importers:
     devDependencies:
       '@sanity/visual-editing':
         specifier: ^2.15.0
-        version: 2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
+        version: 2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
       dummy-side-effects:
         specifier: workspace:*
         version: link:../dummy-side-effects
@@ -384,7 +384,7 @@ importers:
         version: link:../dummy-module
       next:
         specifier: ^15.3.3
-        version: 15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -6304,7 +6304,7 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 3.93.0(@types/react@19.1.8)
 
-  '@sanity/visual-editing@2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)':
+  '@sanity/visual-editing@2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)':
     dependencies:
       '@sanity/comlink': 3.0.5
       '@sanity/icons': 3.7.0(react@19.1.0)
@@ -6327,7 +6327,7 @@ snapshots:
       xstate: 5.19.4
     optionalDependencies:
       '@sanity/client': 7.6.0
-      next: 15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@sanity/types'
@@ -8722,7 +8722,7 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
-  next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.3.3
       '@swc/counter': 0.1.3
@@ -8742,6 +8742,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.3.3
       '@next/swc-win32-arm64-msvc': 15.3.3
       '@next/swc-win32-x64-msvc': 15.3.3
+      babel-plugin-react-compiler: 19.1.0-rc.2
       sharp: 0.34.2
     transitivePeerDependencies:
       - '@babel/core'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    typescript:
+      specifier: 5.8.3
+      version: 5.8.3
+
 overrides:
   '@sanity/pkg-utils': workspace:*
 
@@ -220,7 +226,7 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.19.1)(typescript@5.8.3)
       typescript:
-        specifier: 5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       vitest:
         specifier: ^3.2.4
@@ -283,7 +289,7 @@ importers:
     devDependencies:
       '@sanity/visual-editing':
         specifier: ^2.15.0
-        version: 2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
+        version: 2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
       dummy-side-effects:
         specifier: workspace:*
         version: link:../dummy-side-effects
@@ -326,7 +332,7 @@ importers:
         specifier: 22.0.1
         version: 22.0.1
       typescript:
-        specifier: 5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   playground/reference-cjs-legacy: {}
@@ -339,7 +345,7 @@ importers:
         specifier: 22.0.1
         version: 22.0.1
       typescript:
-        specifier: 5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   playground/reference-esm-legacy: {}
@@ -350,7 +356,7 @@ importers:
         specifier: 22.0.1
         version: 22.0.1
       typescript:
-        specifier: 5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
 
   playground/runtime-astro:
@@ -375,7 +381,7 @@ importers:
         version: link:../dummy-module
       next:
         specifier: ^15.3.3
-        version: 15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -413,7 +419,7 @@ importers:
         specifier: workspace:*
         version: link:../dummy-module
       typescript:
-        specifier: 5.8.3
+        specifier: 'catalog:'
         version: 5.8.3
       vite:
         specifier: ^6.3.5
@@ -6284,7 +6290,7 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 3.93.0(@types/react@19.1.8)
 
-  '@sanity/visual-editing@2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)':
+  '@sanity/visual-editing@2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)':
     dependencies:
       '@sanity/comlink': 3.0.5
       '@sanity/icons': 3.7.0(react@19.1.0)
@@ -6307,7 +6313,7 @@ snapshots:
       xstate: 5.19.4
     optionalDependencies:
       '@sanity/client': 7.6.0
-      next: 15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@sanity/types'
@@ -8702,7 +8708,7 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
-  next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.3.3(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.3.3
       '@swc/counter': 0.1.3
@@ -8722,6 +8728,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.3.3
       '@next/swc-win32-arm64-msvc': 15.3.3
       '@next/swc-win32-x64-msvc': 15.3.3
+      babel-plugin-react-compiler: 19.1.0-rc.2
       sharp: 0.34.2
     transitivePeerDependencies:
       - '@babel/core'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -452,6 +452,10 @@ importers:
 
   playground/ts-node16: {}
 
+  playground/ts-rolldown: {}
+
+  playground/ts-rolldown-without-extract: {}
+
   playground/ts-without-extract: {}
 
   playground/use-client-directive:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -452,6 +452,8 @@ importers:
 
   playground/ts-node16: {}
 
+  playground/ts-without-extract: {}
+
   playground/use-client-directive:
     devDependencies:
       '@types/react':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,7 +124,7 @@ importers:
         version: 1.0.0-beta.17
       rolldown-plugin-dts:
         specifier: ^0.13.11
-        version: 0.13.11(rolldown@1.0.0-beta.17)(typescript@5.8.3)
+        version: 0.13.11(@typescript/native-preview@7.0.0-dev.20250618.1)(rolldown@1.0.0-beta.17)(typescript@5.8.3)
       rollup:
         specifier: ^4.43.0
         version: 4.43.0
@@ -1871,6 +1871,53 @@ packages:
 
   '@types/uuid@8.3.4':
     resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20250618.1':
+    resolution: {integrity: sha512-h4fokGV0LQ+mCfc/Cpubn1m4OURNozMPQhzyI4pHOlGZdyZyYRj2e2LLzr3OwqeRnn71al2fcBfay63d/P3FSQ==}
+    engines: {node: '>=20.6.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20250618.1':
+    resolution: {integrity: sha512-ERqUV+rbk2/rAhmHq9ivTVtbMvUpkAsgdveFqEGzZsTtrHWvL2ELQOamqqKyK3hQfjzt9RHwdC0VrLE2U3SGbg==}
+    engines: {node: '>=20.6.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20250618.1':
+    resolution: {integrity: sha512-1RyP3DqqDMIYcce9FN7CF3feuRGcf1MLkxs1iMqlReuF7lVrUXdAc+OzPoNIUdiIXPa0Ri6s8H495aDJ5YnGCA==}
+    engines: {node: '>=20.6.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20250618.1':
+    resolution: {integrity: sha512-X9idSQ9FLlBlHbeqh0Yzxr/ReeaOT42vqD9wjOLsuJkOEyc/b19D8zGVDoxBRNnxAGqSWRmbCFXRaqcJF59Kiw==}
+    engines: {node: '>=20.6.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20250618.1':
+    resolution: {integrity: sha512-7YHLpNI6i0TT4SDkeHuXuY533Kgu38P+GVJBuXgS5FkRI8PLmxhBMHaQwyCcHqT13P4o5VPwphBtbS/JsEBBkw==}
+    engines: {node: '>=20.6.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20250618.1':
+    resolution: {integrity: sha512-YTuCMALzxu1aGYLWFHhQG8rUoEbbE6O5zawETfcNC0zwr430la/apSG1nla7x+nG2DBb9bJMuQWYErjTCGyM2g==}
+    engines: {node: '>=20.6.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20250618.1':
+    resolution: {integrity: sha512-DetIr5Cc16W+4vhjfGW8LQHAauvmUJh0F8uf5eWpCPSH9rbbytWSqcQXzMxvfnVT3uek78Hi7oHOXK6A5AoiDQ==}
+    engines: {node: '>=20.6.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20250618.1':
+    resolution: {integrity: sha512-FkisKblT8PEyq08bjVXND137ojhr+1CfRhSIwvzilMcnEwav2wzxEGZndLNSGzwUlqkS+xQCRx1ch8clpsLq9Q==}
+    engines: {node: '>=20.6.0'}
+    hasBin: true
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -6524,6 +6571,38 @@ snapshots:
 
   '@types/uuid@8.3.4': {}
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20250618.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20250618.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20250618.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20250618.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20250618.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20250618.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20250618.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20250618.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20250618.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20250618.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20250618.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20250618.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20250618.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20250618.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20250618.1
+    optional: true
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@vercel/stega@0.1.2': {}
@@ -9319,7 +9398,7 @@ snapshots:
     dependencies:
       glob: 9.3.5
 
-  rolldown-plugin-dts@0.13.11(rolldown@1.0.0-beta.17)(typescript@5.8.3):
+  rolldown-plugin-dts@0.13.11(@typescript/native-preview@7.0.0-dev.20250618.1)(rolldown@1.0.0-beta.17)(typescript@5.8.3):
     dependencies:
       '@babel/generator': 7.27.5
       '@babel/parser': 7.27.5
@@ -9331,6 +9410,7 @@ snapshots:
       get-tsconfig: 4.10.1
       rolldown: 1.0.0-beta.17
     optionalDependencies:
+      '@typescript/native-preview': 7.0.0-dev.20250618.1
       typescript: 5.8.3
     transitivePeerDependencies:
       - oxc-resolver

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - playground/**
   - test/env/__tmp__/**
+
+catalog:
+  typescript: 5.8.3

--- a/src/node/core/config/types.ts
+++ b/src/node/core/config/types.ts
@@ -172,7 +172,7 @@ export interface PkgConfigOptions {
           displayName?: boolean
           /**
            * @defaultValue []
-           * @example ["@xstyled/styled-components", "@xstyled/styled-components/*"]
+           * @example ["\@xstyled/styled-components", "\@xstyled/styled-components/*"]
            */
           topLevelImportPaths?: string[]
           /** @defaultValue true */

--- a/src/node/core/config/types.ts
+++ b/src/node/core/config/types.ts
@@ -155,6 +155,8 @@ export type ReactCompilerLogger = {
   logEvent: (filename: string | null, event: ReactCompilerLoggerEvent) => void
 }
 
+export type DtsType = 'api-extractor' | 'rolldown'
+
 /** @public */
 export interface PkgConfigOptions {
   /** @alpha */
@@ -203,7 +205,16 @@ export interface PkgConfigOptions {
    */
   dist?: string
   exports?: PkgConfigProperty<PkgExports>
+  /**
+   * Runs `@microsoft/api-extractor` to check that TSDoc tags are valid, and release tags are correct.
+   * This is useful for packages that need to be consumed by TSDoc-based tooling.
+   * It's enabled by default, it can be disabled by setting `extract: {enabled: false}`
+   */
   extract?: {
+    /**
+     * @defaultValue true
+     */
+    enabled?: boolean
     /**
      * Packages in `devDependencies` that are not in `external` are automatically added to the `bundledPackages` config.
      * You can exclude a package from being bundled by using a callback:
@@ -295,4 +306,10 @@ export interface PkgConfigOptions {
    * Configure what checks are made when running `--strict` builds and checks
    */
   strictOptions?: StrictOptions
+  /**
+   * .d.ts files can be generated either by using `@microsoft/api-extractor` or `rolldown`.
+   * `rolldown` is the faster option, but is not yet stable.
+   * @defaultValue 'api-extractor'
+   */
+  dts?: DtsType
 }

--- a/src/node/core/contexts/buildContext.ts
+++ b/src/node/core/contexts/buildContext.ts
@@ -1,6 +1,6 @@
 import type ts from 'typescript'
 import type {Logger} from '../../logger'
-import type {PkgConfigOptions, PkgExports, PkgRuntime} from '../config/types'
+import type {DtsType, PkgConfigOptions, PkgExports, PkgRuntime} from '../config/types'
 import type {PackageJSON} from '../pkg/types'
 
 /** @internal */
@@ -28,4 +28,5 @@ export interface BuildContext {
     config?: ts.ParsedCommandLine
     configPath?: string
   }
+  dts: DtsType
 }

--- a/src/node/resolveBuildContext.ts
+++ b/src/node/resolveBuildContext.ts
@@ -180,6 +180,7 @@ export async function resolveBuildContext(options: {
       config: tsconfig,
       configPath: tsconfigPath,
     },
+    dts: config?.dts === 'rolldown' ? 'rolldown' : 'api-extractor',
   }
 
   return ctx

--- a/src/node/resolveBuildTasks.ts
+++ b/src/node/resolveBuildTasks.ts
@@ -3,7 +3,7 @@ import type {PkgExport, PkgFormat, PkgRuntime} from './core/config/types'
 import type {BuildContext} from './core/contexts/buildContext'
 import {getTargetPaths} from './tasks/dts/getTargetPaths'
 import type {DtsTask} from './tasks/dts/types'
-import type {BuildTask, RollupTask, RollupTaskEntry} from './tasks/types'
+import type {BuildTask, RolldownDtsTask, RollupTask, RollupTaskEntry} from './tasks/types'
 
 /** @internal */
 export function resolveBuildTasks(ctx: BuildContext): BuildTask[] {
@@ -22,155 +22,178 @@ export function resolveBuildTasks(ctx: BuildContext): BuildTask[] {
     entries: [],
   }
 
+  const rolldownDtsTask: Record<string, RolldownDtsTask> = {}
   const rollupTasks: Record<string, RollupTask> = {}
 
   function addRollupTaskEntry(format: PkgFormat, runtime: PkgRuntime, entry: RollupTaskEntry) {
     const buildId = `${format}:${runtime}`
 
-    if (rollupTasks[buildId]) {
-      rollupTasks[buildId].entries.push(entry)
-    } else {
-      rollupTasks[buildId] = {
-        type: 'build:js',
-        buildId,
-        entries: [entry],
-        runtime,
-        format,
-        target: target[runtime],
+    if (ctx.dts === 'rolldown') {
+      if (rolldownDtsTask[buildId]) {
+        rolldownDtsTask[buildId].entries.push(entry)
+      } else {
+        rolldownDtsTask[buildId] = {
+          type: 'rolldown:dts',
+          buildId,
+          entries: [entry],
+          runtime,
+          format,
+          target: target[runtime],
+        }
+      }
+    }
+
+    if (!ctx.emitDeclarationOnly) {
+      if (rollupTasks[buildId]) {
+        rollupTasks[buildId].entries.push(entry)
+      } else {
+        rollupTasks[buildId] = {
+          type: 'build:js',
+          buildId,
+          entries: [entry],
+          runtime,
+          format,
+          target: target[runtime],
+        }
       }
     }
   }
 
-  // Parse `dts` tasks
-  for (const exp of exports) {
-    const importId = path.join(pkg.name, exp._path)
-
-    if (exp.source?.endsWith('.ts')) {
-      dtsTask.entries.push({
-        importId,
-        exportPath: exp._path,
-        sourcePath: exp.source,
-        targetPaths: getTargetPaths(pkg.type, exp),
-      })
-    }
-
-    if (exp.browser?.source?.endsWith('.ts')) {
-      dtsTask.entries.push({
-        importId,
-        exportPath: exp._path,
-        sourcePath: exp.browser.source,
-        targetPaths: getTargetPaths(pkg.type, exp.browser),
-      })
-    }
-
-    if (exp.node?.source?.endsWith('.ts')) {
-      dtsTask.entries.push({
-        importId,
-        exportPath: exp._path,
-        sourcePath: exp.node.source,
-        targetPaths: getTargetPaths(pkg.type, exp.node),
-      })
-    }
-  }
-
-  // Handle dts tasks for bundles
-  for (const bundle of bundles) {
-    if (bundle.source?.endsWith('.ts')) {
-      // importId needs to be how the bundle is used, like `@sanity/pkg-utils/dist/cli`
-      // exportPath needs to be the path to the bundle, like `./dist/cli`
-      // targetPaths is then: [./dist/cli.d.ts, ./dist/cli.d.cts]
-      const exportPath = (bundle.import || bundle.require)!.replace(/\.[mc]?js$/, '')
-      const importId = path.join(pkg.name, exportPath)
-
-      dtsTask.entries.push({
-        importId,
-        exportPath,
-        sourcePath: bundle.source,
-        targetPaths: getTargetPaths(pkg.type, bundle),
-      })
-    }
-  }
-
-  // Add dts task
-  if (dtsTask.entries.length) {
-    tasks.push(dtsTask)
-  }
-
-  if (!ctx.emitDeclarationOnly) {
-    // Parse rollup:commonjs:* tasks
+  if (ctx.dts === 'api-extractor') {
+    // Parse `dts` tasks
     for (const exp of exports) {
-      const output = exp.require
+      const importId = path.join(pkg.name, exp._path)
 
-      if (!output) continue
+      if (exp.source?.endsWith('.ts')) {
+        dtsTask.entries.push({
+          importId,
+          exportPath: exp._path,
+          sourcePath: exp.source,
+          targetPaths: getTargetPaths(pkg.type, exp),
+        })
+      }
 
-      addRollupTaskEntry('commonjs', ctx.runtime, {
-        path: exp._path,
-        source: exp.source,
-        output,
-      })
+      if (exp.browser?.source?.endsWith('.ts')) {
+        dtsTask.entries.push({
+          importId,
+          exportPath: exp._path,
+          sourcePath: exp.browser.source,
+          targetPaths: getTargetPaths(pkg.type, exp.browser),
+        })
+      }
+
+      if (exp.node?.source?.endsWith('.ts')) {
+        dtsTask.entries.push({
+          importId,
+          exportPath: exp._path,
+          sourcePath: exp.node.source,
+          targetPaths: getTargetPaths(pkg.type, exp.node),
+        })
+      }
     }
 
-    // Parse rollup:esm:* tasks
-    for (const exp of exports) {
-      const output = exp.import
-
-      if (!output) continue
-
-      addRollupTaskEntry('esm', ctx.runtime, {
-        path: exp._path,
-        source: exp.source,
-        output,
-      })
-    }
-
-    // Parse rollup:commonjs:browser tasks
-    for (const exp of exports) {
-      const output = exp.browser?.require
-
-      if (!output) continue
-
-      addRollupTaskEntry('commonjs', 'browser', {
-        path: exp._path,
-        source: exp.browser?.source || exp.source,
-        output,
-      })
-    }
-
-    // Parse rollup:esm:browser tasks
-    for (const exp of exports) {
-      const output = exp.browser?.import
-
-      if (!output) continue
-
-      addRollupTaskEntry('esm', 'browser', {
-        path: exp._path,
-        source: exp.browser?.source || exp.source,
-        output,
-      })
-    }
-
+    // Handle dts tasks for bundles
     for (const bundle of bundles) {
-      const idx = bundles.indexOf(bundle)
+      if (bundle.source?.endsWith('.ts')) {
+        // importId needs to be how the bundle is used, like `@sanity/pkg-utils/dist/cli`
+        // exportPath needs to be the path to the bundle, like `./dist/cli`
+        // targetPaths is then: [./dist/cli.d.ts, ./dist/cli.d.cts]
+        const exportPath = (bundle.import || bundle.require)!.replace(/\.[mc]?js$/, '')
+        const importId = path.join(pkg.name, exportPath)
 
-      if (bundle.require) {
-        addRollupTaskEntry('commonjs', bundle.runtime || ctx.runtime, {
-          path: `__$$bundle_cjs_${idx}$$__`,
-          source: bundle.source,
-          output: bundle.require,
-        })
-      }
-
-      if (bundle.import) {
-        addRollupTaskEntry('esm', bundle.runtime || ctx.runtime, {
-          path: `__$$bundle_esm_${idx}$$__`,
-          source: bundle.source,
-          output: bundle.import,
+        dtsTask.entries.push({
+          importId,
+          exportPath,
+          sourcePath: bundle.source,
+          targetPaths: getTargetPaths(pkg.type, bundle),
         })
       }
     }
 
-    tasks.push(...Object.values(rollupTasks))
+    // Add dts task
+    if (dtsTask.entries.length) {
+      tasks.push(dtsTask)
+    }
   }
+
+  // Parse rollup:commonjs:* tasks
+  for (const exp of exports) {
+    const output = exp.require
+
+    if (!output) continue
+
+    addRollupTaskEntry('commonjs', ctx.runtime, {
+      path: exp._path,
+      source: exp.source,
+      output,
+    })
+  }
+
+  // Parse rollup:esm:* tasks
+  for (const exp of exports) {
+    const output = exp.import
+
+    if (!output) continue
+
+    addRollupTaskEntry('esm', ctx.runtime, {
+      path: exp._path,
+      source: exp.source,
+      output,
+    })
+  }
+
+  // Parse rollup:commonjs:browser tasks
+  for (const exp of exports) {
+    const output = exp.browser?.require
+
+    if (!output) continue
+
+    addRollupTaskEntry('commonjs', 'browser', {
+      path: exp._path,
+      source: exp.browser?.source || exp.source,
+      output,
+    })
+  }
+
+  // Parse rollup:esm:browser tasks
+  for (const exp of exports) {
+    const output = exp.browser?.import
+
+    if (!output) continue
+
+    addRollupTaskEntry('esm', 'browser', {
+      path: exp._path,
+      source: exp.browser?.source || exp.source,
+      output,
+    })
+  }
+
+  for (const bundle of bundles) {
+    const idx = bundles.indexOf(bundle)
+
+    if (bundle.require) {
+      addRollupTaskEntry('commonjs', bundle.runtime || ctx.runtime, {
+        path: `__$$bundle_cjs_${idx}$$__`,
+        source: bundle.source,
+        output: bundle.require,
+      })
+    }
+
+    if (bundle.import) {
+      addRollupTaskEntry('esm', bundle.runtime || ctx.runtime, {
+        path: `__$$bundle_esm_${idx}$$__`,
+        source: bundle.source,
+        output: bundle.import,
+      })
+    }
+  }
+
+  // Perform rolldown dts tasks first, as they have special logic for removing non .d.ts chunks
+  tasks.push(...Object.values(rolldownDtsTask))
+  // Then run api-extractor tsdoc release tag checking (if rolldown is used for dts bundling, otherwise api-extractor performs both in the build:dts task)
+  // @TODO
+  // Then run rollup tasks
+  tasks.push(...Object.values(rollupTasks))
 
   return tasks
 }

--- a/src/node/tasks/dts/createApiExtractorConfig.ts
+++ b/src/node/tasks/dts/createApiExtractorConfig.ts
@@ -1,7 +1,6 @@
 import path from 'node:path'
 import type {IConfigFile, IExtractorMessagesConfig} from '@microsoft/api-extractor'
 import ts from 'typescript'
-import type {DtsType} from '../../core/config'
 
 export function createApiExtractorConfig(options: {
   bundledPackages?: string[]
@@ -13,7 +12,7 @@ export function createApiExtractorConfig(options: {
   mainEntryPointFilePath: string
   tsconfig: ts.ParsedCommandLine
   tsconfigPath: string
-  dts: DtsType
+  dtsRollupEnabled: boolean
 }): IConfigFile {
   const {
     bundledPackages,
@@ -25,7 +24,7 @@ export function createApiExtractorConfig(options: {
     mainEntryPointFilePath,
     tsconfig,
     tsconfigPath,
-    dts,
+    dtsRollupEnabled,
   } = options
 
   return {
@@ -53,7 +52,7 @@ export function createApiExtractorConfig(options: {
       apiJsonFilePath: path.resolve(distPath, `${exportPath}.api.json`),
     },
     dtsRollup: {
-      enabled: dts === 'api-extractor',
+      enabled: dtsRollupEnabled,
       untrimmedFilePath: path.resolve(distPath, filePath),
       // betaTrimmedFilePath: path.resolve(distPath, filePath.replace('.d.ts', '-beta.d.ts')),
       // publicTrimmedFilePath: path.resolve(distPath, filePath.replace('.d.ts', '-public.d.ts')),

--- a/src/node/tasks/dts/createApiExtractorConfig.ts
+++ b/src/node/tasks/dts/createApiExtractorConfig.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import type {IConfigFile, IExtractorMessagesConfig} from '@microsoft/api-extractor'
 import ts from 'typescript'
+import type {DtsType} from '../../core/config'
 
 export function createApiExtractorConfig(options: {
   bundledPackages?: string[]
@@ -12,6 +13,7 @@ export function createApiExtractorConfig(options: {
   mainEntryPointFilePath: string
   tsconfig: ts.ParsedCommandLine
   tsconfigPath: string
+  dts: DtsType
 }): IConfigFile {
   const {
     bundledPackages,
@@ -23,6 +25,7 @@ export function createApiExtractorConfig(options: {
     mainEntryPointFilePath,
     tsconfig,
     tsconfigPath,
+    dts,
   } = options
 
   return {
@@ -50,7 +53,7 @@ export function createApiExtractorConfig(options: {
       apiJsonFilePath: path.resolve(distPath, `${exportPath}.api.json`),
     },
     dtsRollup: {
-      enabled: true,
+      enabled: dts === 'api-extractor',
       untrimmedFilePath: path.resolve(distPath, filePath),
       // betaTrimmedFilePath: path.resolve(distPath, filePath.replace('.d.ts', '-beta.d.ts')),
       // publicTrimmedFilePath: path.resolve(distPath, filePath.replace('.d.ts', '-public.d.ts')),

--- a/src/node/tasks/dts/doExtract.ts
+++ b/src/node/tasks/dts/doExtract.ts
@@ -60,6 +60,7 @@ export async function doExtract(
       tmpPath,
       tsconfigPath: path.resolve(cwd, ts.configPath || 'tsconfig.json'),
       dts: ctx.dts,
+      extractorDisabled: config?.extract?.enabled === false,
     })
 
     messages.push(...result.messages)

--- a/src/node/tasks/dts/doExtract.ts
+++ b/src/node/tasks/dts/doExtract.ts
@@ -59,6 +59,7 @@ export async function doExtract(
       tsconfig: ts.config,
       tmpPath,
       tsconfigPath: path.resolve(cwd, ts.configPath || 'tsconfig.json'),
+      dts: ctx.dts,
     })
 
     messages.push(...result.messages)

--- a/src/node/tasks/dts/doExtract.ts
+++ b/src/node/tasks/dts/doExtract.ts
@@ -59,7 +59,6 @@ export async function doExtract(
       tsconfig: ts.config,
       tmpPath,
       tsconfigPath: path.resolve(cwd, ts.configPath || 'tsconfig.json'),
-      dts: ctx.dts,
       extractorDisabled: config?.extract?.enabled === false,
     })
 

--- a/src/node/tasks/dts/dtsTask.ts
+++ b/src/node/tasks/dts/dtsTask.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
-import {Observable} from 'rxjs'
+import {from, Observable} from 'rxjs'
 import {printExtractMessages} from '../../printExtractMessages'
+import {resolveRollupConfig} from '../rollup/resolveRollupConfig'
 import type {TaskHandler} from '../types'
 import {doExtract} from './doExtract'
 import {DtsError} from './DtsError'
@@ -24,6 +25,25 @@ export const dtsTask: TaskHandler<DtsTask, DtsResult> = {
       }),
     ].join('\n'),
   exec: (ctx, task) => {
+    if (ctx.dts === 'rolldown') {
+      /**
+       * Based on the `tsdown` implementation:
+       * https://github.com/rolldown/tsdown/blob/0978c68bd505c76d7e3097572cd652f81c23f97e/src/index.ts#L138-L141
+       */
+      const doRolldownExtract = async (): Promise<DtsResult> => {
+        const [{build: rolldownBuild}, {dts: dtsPlugin}] = await Promise.all([
+          import('rolldown'),
+          import('rolldown-plugin-dts'),
+        ])
+
+        const {inputOptions, outputOptions} = resolveRollupConfig(ctx, {
+          type: 'build:js',
+          buildId: 'dts',
+        })
+        // const {output} = await rolldownBuild(buildOptions)
+      }
+      return from(doRolldownExtract())
+    }
     return new Observable((observer) => {
       doExtract(ctx, task)
         .then((result) => {

--- a/src/node/tasks/dts/dtsTask.ts
+++ b/src/node/tasks/dts/dtsTask.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk'
-import {from, Observable} from 'rxjs'
+import {Observable} from 'rxjs'
 import {printExtractMessages} from '../../printExtractMessages'
-import {resolveRollupConfig} from '../rollup/resolveRollupConfig'
 import type {TaskHandler} from '../types'
 import {doExtract} from './doExtract'
 import {DtsError} from './DtsError'
@@ -25,25 +24,6 @@ export const dtsTask: TaskHandler<DtsTask, DtsResult> = {
       }),
     ].join('\n'),
   exec: (ctx, task) => {
-    if (ctx.dts === 'rolldown') {
-      /**
-       * Based on the `tsdown` implementation:
-       * https://github.com/rolldown/tsdown/blob/0978c68bd505c76d7e3097572cd652f81c23f97e/src/index.ts#L138-L141
-       */
-      const doRolldownExtract = async (): Promise<DtsResult> => {
-        const [{build: rolldownBuild}, {dts: dtsPlugin}] = await Promise.all([
-          import('rolldown'),
-          import('rolldown-plugin-dts'),
-        ])
-
-        const {inputOptions, outputOptions} = resolveRollupConfig(ctx, {
-          type: 'build:js',
-          buildId: 'dts',
-        })
-        // const {output} = await rolldownBuild(buildOptions)
-      }
-      return from(doRolldownExtract())
-    }
     return new Observable((observer) => {
       doExtract(ctx, task)
         .then((result) => {

--- a/src/node/tasks/dts/dtsTask.ts
+++ b/src/node/tasks/dts/dtsTask.ts
@@ -8,9 +8,9 @@ import type {DtsResult, DtsTask} from './types'
 
 /** @internal */
 export const dtsTask: TaskHandler<DtsTask, DtsResult> = {
-  name: (_ctx, task) =>
+  name: (ctx, task) =>
     [
-      'Build type definitions...',
+      `Build type definitions with ${chalk.bold(ctx.dts)}...`,
       '  entries:',
       ...task.entries.map((entry) => {
         return entry.targetPaths

--- a/src/node/tasks/dts/dtsWatchTask.ts
+++ b/src/node/tasks/dts/dtsWatchTask.ts
@@ -111,6 +111,7 @@ export const dtsWatchTask: TaskHandler<DtsWatchTask, DtsResult> = {
               tsconfig: tsContext.config!,
               tmpPath,
               tsconfigPath: path.resolve(cwd, tsContext.configPath || 'tsconfig.json'),
+              dts: ctx.dts,
             })
 
             messages.push(...result.messages)

--- a/src/node/tasks/dts/dtsWatchTask.ts
+++ b/src/node/tasks/dts/dtsWatchTask.ts
@@ -112,6 +112,7 @@ export const dtsWatchTask: TaskHandler<DtsWatchTask, DtsResult> = {
               tmpPath,
               tsconfigPath: path.resolve(cwd, tsContext.configPath || 'tsconfig.json'),
               dts: ctx.dts,
+              extractorDisabled: config?.extract?.enabled === false,
             })
 
             messages.push(...result.messages)

--- a/src/node/tasks/dts/dtsWatchTask.ts
+++ b/src/node/tasks/dts/dtsWatchTask.ts
@@ -111,7 +111,6 @@ export const dtsWatchTask: TaskHandler<DtsWatchTask, DtsResult> = {
               tsconfig: tsContext.config!,
               tmpPath,
               tsconfigPath: path.resolve(cwd, tsContext.configPath || 'tsconfig.json'),
-              dts: ctx.dts,
               extractorDisabled: config?.extract?.enabled === false,
             })
 

--- a/src/node/tasks/dts/extractTypes.ts
+++ b/src/node/tasks/dts/extractTypes.ts
@@ -9,7 +9,7 @@ import {
 import {mkdirp} from 'mkdirp'
 import * as prettier from 'prettier'
 import type ts from 'typescript'
-import type {DtsType, PkgConfigOptions} from '../../core/config/types'
+import type {PkgConfigOptions} from '../../core/config/types'
 import type {BuildFile} from '../../core/contexts/buildContext'
 import {createApiExtractorConfig} from './createApiExtractorConfig'
 import {createTSDocConfig} from './createTSDocConfig'
@@ -30,7 +30,6 @@ export async function extractTypes(options: {
   tmpPath: string
   tsconfig: ts.ParsedCommandLine
   tsconfigPath: string
-  dts: DtsType
   /**
    * If the extractor is disabled then it means API Extractor is only used to bundle dts, and not check tsdoc release tags.
    */
@@ -49,7 +48,6 @@ export async function extractTypes(options: {
     tmpPath,
     tsconfig,
     tsconfigPath,
-    dts,
     extractorDisabled,
   } = options
 
@@ -71,7 +69,7 @@ export async function extractTypes(options: {
       mainEntryPointFilePath: sourceTypesPath,
       tsconfig,
       tsconfigPath,
-      dts,
+      dtsRollupEnabled: true,
     }),
     configObjectFullPath: undefined,
     tsdocConfigFile,

--- a/src/node/tasks/dts/extractTypes.ts
+++ b/src/node/tasks/dts/extractTypes.ts
@@ -9,7 +9,7 @@ import {
 import {mkdirp} from 'mkdirp'
 import * as prettier from 'prettier'
 import type ts from 'typescript'
-import type {PkgConfigOptions} from '../../core/config/types'
+import type {DtsType, PkgConfigOptions} from '../../core/config/types'
 import type {BuildFile} from '../../core/contexts/buildContext'
 import {createApiExtractorConfig} from './createApiExtractorConfig'
 import {createTSDocConfig} from './createTSDocConfig'
@@ -30,6 +30,7 @@ export async function extractTypes(options: {
   tmpPath: string
   tsconfig: ts.ParsedCommandLine
   tsconfigPath: string
+  dts: DtsType
 }): Promise<{extractorResult: ExtractorResult; messages: ExtractorMessage[]}> {
   const {
     bundledPackages,
@@ -44,6 +45,7 @@ export async function extractTypes(options: {
     tmpPath,
     tsconfig,
     tsconfigPath,
+    dts,
   } = options
 
   const tsdocConfigFile = await createTSDocConfig({
@@ -64,6 +66,7 @@ export async function extractTypes(options: {
       mainEntryPointFilePath: sourceTypesPath,
       tsconfig,
       tsconfigPath,
+      dts,
     }),
     configObjectFullPath: undefined,
     tsdocConfigFile,

--- a/src/node/tasks/dts/extractTypes.ts
+++ b/src/node/tasks/dts/extractTypes.ts
@@ -31,6 +31,10 @@ export async function extractTypes(options: {
   tsconfig: ts.ParsedCommandLine
   tsconfigPath: string
   dts: DtsType
+  /**
+   * If the extractor is disabled then it means API Extractor is only used to bundle dts, and not check tsdoc release tags.
+   */
+  extractorDisabled: boolean
 }): Promise<{extractorResult: ExtractorResult; messages: ExtractorMessage[]}> {
   const {
     bundledPackages,
@@ -46,6 +50,7 @@ export async function extractTypes(options: {
     tsconfig,
     tsconfigPath,
     dts,
+    extractorDisabled,
   } = options
 
   const tsdocConfigFile = await createTSDocConfig({
@@ -61,7 +66,7 @@ export async function extractTypes(options: {
       distPath,
       exportPath,
       filePath,
-      messages: getExtractMessagesConfig({rules}),
+      messages: getExtractMessagesConfig({rules, disabled: extractorDisabled}),
       projectFolder: projectPath,
       mainEntryPointFilePath: sourceTypesPath,
       tsconfig,

--- a/src/node/tasks/dts/getExtractMessagesConfig.ts
+++ b/src/node/tasks/dts/getExtractMessagesConfig.ts
@@ -11,8 +11,9 @@ const LOG_LEVELS: Record<PkgRuleLevel, ExtractorLogLevel> = {
 /** @alpha */
 export function getExtractMessagesConfig(options: {
   rules: NonNullable<PkgConfigOptions['extract']>['rules']
+  disabled?: boolean
 }): IExtractorMessagesConfig {
-  const {rules} = options
+  const {rules, disabled = false} = options
 
   function ruleToLogLevel(
     key: keyof NonNullable<NonNullable<PkgConfigOptions['extract']>['rules']>,
@@ -26,66 +27,83 @@ export function getExtractMessagesConfig(options: {
   return {
     compilerMessageReporting: {
       default: {
-        logLevel: 'warning' as ExtractorLogLevel,
+        logLevel: (disabled ? 'none' : 'warning') as ExtractorLogLevel,
       },
     },
 
-    extractorMessageReporting: {
-      'default': {
-        logLevel: 'warning' as ExtractorLogLevel,
-        addToApiReportFile: false,
-      },
+    extractorMessageReporting: disabled
+      ? {
+          default: {
+            logLevel: 'none' as ExtractorLogLevel,
+            addToApiReportFile: false,
+          },
+        }
+      : {
+          'default': {
+            logLevel: 'warning' as ExtractorLogLevel,
+            addToApiReportFile: false,
+          },
 
-      'ae-forgotten-export': {
-        /**
-         * This is hardcoded to `none` as it's no longer needed since TypeScript 5.5 https://github.com/microsoft/TypeScript/issues/42873
-         * It's hardcoded to `none` since supported by API Extractor when using `module: 'Preserve'` doesn't support it well since `@microsoft/api-extractor` v7.49.0, which upgraded from TS 5.4 to 5.7 internally
-         */
-        logLevel: 'none' as ExtractorLogLevel,
-        addToApiReportFile: false,
-      },
+          'ae-forgotten-export': {
+            /**
+             * This is hardcoded to `none` as it's no longer needed since TypeScript 5.5 https://github.com/microsoft/TypeScript/issues/42873
+             * It's hardcoded to `none` since supported by API Extractor when using `module: 'Preserve'` doesn't support it well since `@microsoft/api-extractor` v7.49.0, which upgraded from TS 5.4 to 5.7 internally
+             */
+            logLevel: 'none' as ExtractorLogLevel,
+            addToApiReportFile: false,
+          },
 
-      'ae-incompatible-release-tags': {
-        logLevel: ruleToLogLevel('ae-incompatible-release-tags', 'error' as ExtractorLogLevel),
-        addToApiReportFile: false,
-      },
+          'ae-incompatible-release-tags': {
+            logLevel: ruleToLogLevel('ae-incompatible-release-tags', 'error' as ExtractorLogLevel),
+            addToApiReportFile: false,
+          },
 
-      'ae-internal-missing-underscore': {
-        logLevel: ruleToLogLevel('ae-internal-missing-underscore'),
-        addToApiReportFile: false,
-      },
+          'ae-internal-missing-underscore': {
+            logLevel: ruleToLogLevel('ae-internal-missing-underscore'),
+            addToApiReportFile: false,
+          },
 
-      'ae-missing-release-tag': {
-        logLevel: ruleToLogLevel('ae-missing-release-tag', 'error' as ExtractorLogLevel),
-        addToApiReportFile: false,
-      },
+          'ae-missing-release-tag': {
+            logLevel: ruleToLogLevel('ae-missing-release-tag', 'error' as ExtractorLogLevel),
+            addToApiReportFile: false,
+          },
 
-      'ae-wrong-input-file-type': {
-        logLevel: 'none' as ExtractorLogLevel,
-        addToApiReportFile: false,
-      },
-    },
+          'ae-wrong-input-file-type': {
+            logLevel: 'none' as ExtractorLogLevel,
+            addToApiReportFile: false,
+          },
+        },
 
-    tsdocMessageReporting: {
-      'default': {
-        logLevel: 'warning' as ExtractorLogLevel,
-        addToApiReportFile: false,
-      },
+    tsdocMessageReporting: disabled
+      ? {
+          default: {
+            logLevel: 'none' as ExtractorLogLevel,
+            addToApiReportFile: false,
+          },
+        }
+      : {
+          'default': {
+            logLevel: 'warning' as ExtractorLogLevel,
+            addToApiReportFile: false,
+          },
 
-      'tsdoc-link-tag-unescaped-text': {
-        logLevel: ruleToLogLevel('tsdoc-link-tag-unescaped-text', 'warning' as ExtractorLogLevel),
-        addToApiReportFile: false,
-      },
+          'tsdoc-link-tag-unescaped-text': {
+            logLevel: ruleToLogLevel(
+              'tsdoc-link-tag-unescaped-text',
+              'warning' as ExtractorLogLevel,
+            ),
+            addToApiReportFile: false,
+          },
 
-      'tsdoc-undefined-tag': {
-        logLevel: ruleToLogLevel('tsdoc-undefined-tag', 'error' as ExtractorLogLevel),
-        addToApiReportFile: false,
-      },
+          'tsdoc-undefined-tag': {
+            logLevel: ruleToLogLevel('tsdoc-undefined-tag', 'error' as ExtractorLogLevel),
+            addToApiReportFile: false,
+          },
 
-      'tsdoc-unsupported-tag': {
-        logLevel: ruleToLogLevel('tsdoc-unsupported-tag', 'none' as ExtractorLogLevel),
-        addToApiReportFile: false,
-      },
-    },
+          'tsdoc-unsupported-tag': {
+            logLevel: ruleToLogLevel('tsdoc-unsupported-tag', 'none' as ExtractorLogLevel),
+            addToApiReportFile: false,
+          },
+        },
   }
 }

--- a/src/node/tasks/index.ts
+++ b/src/node/tasks/index.ts
@@ -1,5 +1,6 @@
 import {dtsTask} from './dts/dtsTask'
 import {dtsWatchTask} from './dts/dtsWatchTask'
+import {rolldownDtsTask} from './rolldown/rolldownDtsTask'
 import {rollupTask} from './rollup/rollupTask'
 import {rollupWatchTask} from './rollup/rollupWatchTask'
 import type {BuildTaskHandlers, WatchTaskHandlers} from './types'
@@ -8,6 +9,7 @@ import type {BuildTaskHandlers, WatchTaskHandlers} from './types'
 export const buildTaskHandlers: BuildTaskHandlers = {
   'build:dts': dtsTask,
   'build:js': rollupTask,
+  'rolldown:dts': rolldownDtsTask,
 }
 
 /** @internal */

--- a/src/node/tasks/rolldown/resolveRolldownConfig.ts
+++ b/src/node/tasks/rolldown/resolveRolldownConfig.ts
@@ -1,0 +1,206 @@
+import path from 'node:path'
+import {optimizeLodashImports} from '@optimize-lodash/rollup-plugin'
+import alias from '@rollup/plugin-alias'
+import {getBabelOutputPlugin} from '@rollup/plugin-babel'
+import commonjs from '@rollup/plugin-commonjs'
+import json from '@rollup/plugin-json'
+import {nodeResolve} from '@rollup/plugin-node-resolve'
+import terser from '@rollup/plugin-terser'
+import type {InputOptions, OutputOptions, Plugin} from 'rolldown'
+import {dts as dtsPlugin} from 'rolldown-plugin-dts'
+import esbuild from 'rollup-plugin-esbuild'
+import type {BuildContext} from '../../core/contexts/buildContext'
+import {pkgExtMap as extMap} from '../../core/pkg/pkgExt'
+import type {PackageJSON} from '../../core/pkg/types'
+import type {RolldownDtsTask} from '../types'
+
+export interface RolldownConfig {
+  inputOptions: InputOptions
+  outputOptions: OutputOptions
+}
+
+export function resolveRolldownConfig(
+  ctx: BuildContext,
+  buildTask: RolldownDtsTask,
+): RolldownConfig {
+  const {format, runtime, target} = buildTask
+  const {config, cwd, exports: _exports, external, distPath, logger, pkg, ts} = ctx
+  const outputExt = extMap[pkg.type || 'commonjs'][format]
+  const minify = config?.minify ?? false
+  const outDir = path.relative(cwd, distPath)
+
+  const pathAliases = Object.fromEntries(
+    Object.entries(ts.config?.options.paths || {}).map(([key, val]) => {
+      return [key, path.resolve(cwd, ts.config?.options.baseUrl || '.', val[0])]
+    }),
+  )
+
+  const entries = buildTask.entries.map((entry) => {
+    return {
+      ...entry,
+      name: path.relative(outDir, entry.output).replace(/\.[^/.]+$/, ''),
+    }
+  }, {})
+
+  const exportIds =
+    _exports && Object.keys(_exports).map((exportPath) => path.join(pkg.name, exportPath))
+
+  const sourcePaths = _exports && Object.values(_exports).map((e) => path.resolve(cwd, e.source))
+
+  const replacements = Object.fromEntries(
+    Object.entries(config?.define || {}).map(([key, val]) => [key, JSON.stringify(val)]),
+  )
+
+  const {optimizeLodash: enableOptimizeLodash = hasDependency(pkg, 'lodash')} = config?.rollup || {}
+
+  // @ts-expect-error - TODO: fix this
+  const _defaultPlugins = [
+    alias({
+      entries: {...pathAliases},
+    }),
+    nodeResolve({
+      browser: runtime === 'browser',
+      extensions: ['.cjs', '.mjs', '.js', '.jsx', '.json', '.node'],
+      preferBuiltins: true,
+    }),
+    commonjs(),
+    json(),
+    esbuild({
+      // jsx: config?.jsx ?? 'automatic',
+      // jsxFactory: config?.jsxFactory ?? 'createElement',
+      // jsxFragment: config?.jsxFragment ?? 'Fragment',
+      // jsxImportSource: config?.jsxImportSource ?? 'react',
+      target,
+      tsconfig: ctx.ts.configPath || 'tsconfig.json',
+      treeShaking: true,
+      minifySyntax: config?.minify !== false,
+      supported: {
+        'template-literal': true,
+      },
+    }),
+    Array.isArray(config?.babel?.plugins) &&
+      getBabelOutputPlugin({
+        babelrc: false,
+        plugins: config.babel.plugins,
+      }),
+    enableOptimizeLodash &&
+      optimizeLodashImports({
+        useLodashEs: format === 'esm' && hasDependency(pkg, 'lodash-es') ? true : undefined,
+        ...(typeof config?.rollup?.optimizeLodash === 'boolean'
+          ? {}
+          : config?.rollup?.optimizeLodash),
+      }),
+    minify &&
+      terser({
+        compress: {directives: false, passes: 10},
+        ecma: 2020,
+        output: {
+          comments: (_node, comment) => {
+            const text = comment.value
+            const cType = comment.type
+
+            // Check if this is a multiline comment
+            if (cType === 'comment2') {
+              // Keep licensing comments
+              return /@preserve|@license|@cc_on/i.test(text)
+            }
+
+            return false
+          },
+          preserve_annotations: true,
+        },
+      }),
+  ].filter(Boolean) as Plugin[]
+
+  const hashChunkFileNames = config?.rollup?.hashChunkFileNames ?? false
+  const chunksFolder = hashChunkFileNames ? '_chunks' : '_chunks-[format]'
+  const chunkFileNames = `${chunksFolder}/${hashChunkFileNames ? '[name]-[hash]' : '[name]'}${outputExt}`
+  const entryFileNames = `[name]${outputExt}`
+
+  const inputOptions = {
+    cwd,
+    jsx: {
+      mode:
+        config?.jsx === 'automatic'
+          ? 'automatic'
+          : config?.jsx === 'preserve'
+            ? 'preserve'
+            : config?.jsx === 'transform'
+              ? 'classic'
+              : 'automatic',
+      factory: config?.jsxFactory,
+      fragment: config?.jsxFragment,
+      importSource: config?.jsxImportSource,
+    },
+    define:
+      pkg.name === '@sanity/pkg-utils'
+        ? {...replacements}
+        : {
+            'process.env.PKG_FORMAT': JSON.stringify(format),
+            'process.env.PKG_RUNTIME': JSON.stringify(runtime),
+            'process.env.PKG_VERSION': JSON.stringify(process.env['PKG_VERSION'] || pkg.version),
+            ...replacements,
+          },
+
+    external: (id, importer) => {
+      // Check if the id is a self-referencing import
+      if (exportIds?.includes(id)) {
+        return true
+      }
+
+      // Check if the id is a file path that points to an exported source file
+      if (importer && (id.startsWith('.') || id.startsWith('/'))) {
+        const idPath = path.resolve(path.dirname(importer), id)
+
+        if (sourcePaths?.includes(idPath)) {
+          logger.warn(
+            `detected self-referencing import – treating as external: ${path.relative(
+              cwd,
+              idPath,
+            )}`,
+          )
+
+          return true
+        }
+      }
+
+      const idParts = id.split('/')
+
+      const name = idParts[0].startsWith('@') ? `${idParts[0]}/${idParts[1]}` : idParts[0]
+
+      if (name && external.includes(name)) {
+        return true
+      }
+
+      return false
+    },
+
+    input: entries.reduce<{[entryAlias: string]: string}>(
+      (acc, entry) => Object.assign(acc, {[entry.name]: entry.source}),
+      {},
+    ),
+
+    plugins: [dtsPlugin({emitDtsOnly: true, tsconfig: ctx.ts.configPath || 'tsconfig.json'})],
+
+    treeshake: true,
+  } satisfies InputOptions
+  const outputOptions = {
+    chunkFileNames,
+    dir: outDir,
+    entryFileNames,
+    esModule: true,
+    format,
+    sourcemap: config?.sourcemap ?? true,
+    hoistTransitiveImports: false,
+  } satisfies OutputOptions
+
+  return {inputOptions, outputOptions}
+}
+
+function hasDependency(pkg: PackageJSON, packageName: string): boolean {
+  return pkg.dependencies
+    ? packageName in pkg.dependencies
+    : pkg.peerDependencies
+      ? packageName in pkg.peerDependencies
+      : false
+}

--- a/src/node/tasks/rolldown/resolveRolldownConfig.ts
+++ b/src/node/tasks/rolldown/resolveRolldownConfig.ts
@@ -66,10 +66,6 @@ export function resolveRolldownConfig(
     commonjs(),
     json(),
     esbuild({
-      // jsx: config?.jsx ?? 'automatic',
-      // jsxFactory: config?.jsxFactory ?? 'createElement',
-      // jsxFragment: config?.jsxFragment ?? 'Fragment',
-      // jsxImportSource: config?.jsxImportSource ?? 'react',
       target,
       tsconfig: ctx.ts.configPath || 'tsconfig.json',
       treeShaking: true,
@@ -189,8 +185,8 @@ export function resolveRolldownConfig(
     dir: outDir,
     entryFileNames,
     esModule: true,
-    format,
-    sourcemap: config?.sourcemap ?? true,
+    format: buildTask.type === 'rolldown:dts' ? 'es' : format,
+    sourcemap: buildTask.type === 'rolldown:dts' ? false : (config?.sourcemap ?? true),
     hoistTransitiveImports: false,
   } satisfies OutputOptions
 

--- a/src/node/tasks/rolldown/rolldownDtsTask.ts
+++ b/src/node/tasks/rolldown/rolldownDtsTask.ts
@@ -21,7 +21,7 @@ export const rolldownDtsTask: TaskHandler<RolldownDtsTask> = {
           ...bundleEntries.map((e) =>
             [
               `    - `,
-              `${chalk.yellow(e.source)} ${chalk.gray('→')} ${chalk.yellow(e.output)}`,
+              `${chalk.yellow(e.source)} ${chalk.gray('→')} ${chalk.yellow(replaceFileEnding(e.output))}`,
             ].join(''),
           ),
         ]
@@ -34,7 +34,7 @@ export const rolldownDtsTask: TaskHandler<RolldownDtsTask> = {
             [
               `    - `,
               `${chalk.cyan(path.join(ctx.pkg.name, e.path))}: `,
-              `${chalk.yellow(e.source)} ${chalk.gray('→')} ${chalk.yellow(e.output)}`,
+              `${chalk.yellow(e.source)} ${chalk.gray('→')} ${chalk.yellow(replaceFileEnding(e.output))}`,
             ].join(''),
           ),
         ]
@@ -145,5 +145,16 @@ async function execPromise(ctx: BuildContext, task: RolldownDtsTask) {
     // Restore console
     consoleSpy.restore()
     throw err
+  }
+}
+
+function replaceFileEnding(path: string) {
+  switch (true) {
+    case path.endsWith('.mjs'):
+      return path.replace(/\.mjs$/, '.d.mts')
+    case path.endsWith('.cjs'):
+      return path.replace(/\.cjs$/, '.d.cts')
+    default:
+      return path.replace(/\.js$/, '.d.ts')
   }
 }

--- a/src/node/tasks/rolldown/rolldownDtsTask.ts
+++ b/src/node/tasks/rolldown/rolldownDtsTask.ts
@@ -43,7 +43,7 @@ export const rolldownDtsTask: TaskHandler<RolldownDtsTask> = {
       : []
 
     return [
-      `Build javascript files...`,
+      `Build type definitions with ${chalk.bold('rolldown')}...`,
       `  format: ${chalk.yellow(task.format)}`,
       ...targetLines,
       ...bundlesLines,

--- a/src/node/tasks/rolldown/rolldownDtsTask.ts
+++ b/src/node/tasks/rolldown/rolldownDtsTask.ts
@@ -1,11 +1,9 @@
 import path from 'node:path'
 import chalk from 'chalk'
-import {rolldown} from 'rolldown'
 import {from} from 'rxjs'
 import {createConsoleSpy} from '../../consoleSpy'
 import type {BuildContext} from '../../core/contexts/buildContext'
 import type {RolldownDtsTask, TaskHandler} from '../types'
-import {resolveRolldownConfig} from './resolveRolldownConfig'
 
 /** @internal */
 export const rolldownDtsTask: TaskHandler<RolldownDtsTask> = {
@@ -52,14 +50,6 @@ export const rolldownDtsTask: TaskHandler<RolldownDtsTask> = {
   },
   exec: (ctx, task) => {
     return from(execPromise(ctx, task))
-    // return new Observable((observer) => {
-    //   execPromise(ctx, task)
-    //     .then((result) => {
-    //       observer.next(result)
-    //       observer.complete()
-    //     })
-    //     .catch((err) => observer.error(err))
-    // })
   },
   complete: () => {
     //
@@ -70,6 +60,10 @@ export const rolldownDtsTask: TaskHandler<RolldownDtsTask> = {
 }
 
 async function execPromise(ctx: BuildContext, task: RolldownDtsTask) {
+  const [{rolldown}, {resolveRolldownConfig}] = await Promise.all([
+    import('rolldown'),
+    import('./resolveRolldownConfig'),
+  ])
   const {distPath, files, logger} = ctx
   const outDir = path.relative(ctx.cwd, distPath)
 

--- a/src/node/tasks/rolldown/rolldownDtsTask.ts
+++ b/src/node/tasks/rolldown/rolldownDtsTask.ts
@@ -1,0 +1,166 @@
+import path from 'node:path'
+import chalk from 'chalk'
+import {rolldown} from 'rolldown'
+import {from} from 'rxjs'
+import {createConsoleSpy} from '../../consoleSpy'
+import type {BuildContext} from '../../core/contexts/buildContext'
+import {resolveRollupConfig} from '../rollup/resolveRollupConfig'
+import type {RolldownDtsTask, TaskHandler} from '../types'
+
+/** @internal */
+export const rolldownDtsTask: TaskHandler<RolldownDtsTask> = {
+  name: (ctx, task) => {
+    const bundleEntries = task.entries.filter((e) => e.path.includes('__$$bundle_'))
+    const entries = task.entries.filter((e) => !e.path.includes('__$$bundle_'))
+
+    const targetLines = task.target.length
+      ? [`  target:`, ...task.target.map((t) => `    - ${chalk.yellow(t)}`)]
+      : []
+
+    const bundlesLines = bundleEntries.length
+      ? [
+          '  bundles:',
+          ...bundleEntries.map((e) =>
+            [
+              `    - `,
+              `${chalk.yellow(e.source)} ${chalk.gray('→')} ${chalk.yellow(e.output)}`,
+            ].join(''),
+          ),
+        ]
+      : []
+
+    const entriesLines = entries.length
+      ? [
+          '  entries:',
+          ...entries.map((e) =>
+            [
+              `    - `,
+              `${chalk.cyan(path.join(ctx.pkg.name, e.path))}: `,
+              `${chalk.yellow(e.source)} ${chalk.gray('→')} ${chalk.yellow(e.output)}`,
+            ].join(''),
+          ),
+        ]
+      : []
+
+    return [
+      `Build javascript files...`,
+      `  format: ${chalk.yellow(task.format)}`,
+      ...targetLines,
+      ...bundlesLines,
+      ...entriesLines,
+    ].join('\n')
+  },
+  exec: (ctx, task) => {
+    return from(execPromise(ctx, task))
+    // return new Observable((observer) => {
+    //   execPromise(ctx, task)
+    //     .then((result) => {
+    //       observer.next(result)
+    //       observer.complete()
+    //     })
+    //     .catch((err) => observer.error(err))
+    // })
+  },
+  complete: () => {
+    //
+  },
+  error: (_ctx, _task, err) => {
+    console.error(err)
+  },
+}
+
+async function execPromise(ctx: BuildContext, task: RolldownDtsTask) {
+  const {distPath, files, logger} = ctx
+  const outDir = path.relative(ctx.cwd, distPath)
+
+  // Prevent rolldown from printing directly to the console
+  const consoleSpy = createConsoleSpy({
+    onRestored: (messages) => {
+      for (const msg of messages) {
+        const text = String(msg.args[0])
+
+        if (msg.code === 'CIRCULAR_DEPENDENCY') {
+          continue // ignore
+        }
+
+        if (text.startsWith('Dynamic import can only')) {
+          continue // ignore
+        }
+
+        if (text.startsWith('Sourcemap is likely to be incorrect')) {
+          continue // ignore
+        }
+
+        if (msg.type === 'log') {
+          logger.info(...msg.args)
+        }
+
+        if (msg.type === 'warn') {
+          logger.warn(...msg.args)
+        }
+
+        if (msg.type === 'error') {
+          logger.error(...msg.args)
+        }
+      }
+    },
+  })
+
+  const {dts: dtsPlugin} = await import('rolldown-plugin-dts')
+
+  try {
+    const {inputOptions: _inputOptions, outputOptions} = resolveRollupConfig(ctx, task)
+    const {treeshake: _treeshake, plugins: _plugins, ...inputOptions} = _inputOptions
+
+    // Create bundle
+    // @ts-expect-error - TODO: fix this
+    const bundle = await rolldown({
+      ...inputOptions,
+      plugins: [dtsPlugin({emitDtsOnly: true, tsconfig: ctx.ts.configPath || 'tsconfig.json'})],
+      onwarn(warning) {
+        consoleSpy.messages.push({
+          type: 'warn',
+          code: warning.code,
+          args: [warning.message],
+        })
+      },
+    })
+
+    // generate output specific code in-memory
+    // you can call this function multiple times on the same bundle object
+    const {output} = await bundle.generate(
+      // @ts-expect-error - TODO: fix this
+      outputOptions,
+    )
+
+    for (const chunkOrAsset of output) {
+      if (chunkOrAsset.type === 'asset') {
+        files.push({
+          type: 'asset',
+          path: path.resolve(outDir, chunkOrAsset.fileName),
+        })
+      } else {
+        files.push({
+          type: 'chunk',
+          path: path.resolve(outDir, chunkOrAsset.fileName),
+        })
+      }
+    }
+
+    // or write the bundle to disk
+    await bundle.write(
+      // @ts-expect-error - TODO: fix this
+      outputOptions,
+    )
+
+    // closes the bundle
+    await bundle.close()
+
+    // Restore console
+    consoleSpy.restore()
+  } catch (err) {
+    // Restore console
+    consoleSpy.restore()
+    throw err
+  }
+}

--- a/src/node/tasks/types.ts
+++ b/src/node/tasks/types.ts
@@ -22,6 +22,16 @@ export interface RollupTask {
 }
 
 /** @internal */
+export interface RolldownDtsTask {
+  type: 'rolldown:dts'
+  buildId: string
+  entries: RollupTaskEntry[]
+  runtime: PkgRuntime
+  format: 'commonjs' | 'esm'
+  target: string[]
+}
+
+/** @internal */
 export interface RollupWatchTask {
   type: 'watch:js'
   buildId: string
@@ -32,7 +42,7 @@ export interface RollupWatchTask {
 }
 
 /** @internal */
-export type BuildTask = DtsTask | RollupTask
+export type BuildTask = DtsTask | RollupTask | RolldownDtsTask
 
 /** @internal */
 export type WatchTask = DtsWatchTask | RollupWatchTask

--- a/src/node/tasks/types.ts
+++ b/src/node/tasks/types.ts
@@ -59,6 +59,7 @@ export type TaskHandler<Task, Result = void> = {
 export interface BuildTaskHandlers {
   'build:dts': TaskHandler<DtsTask, DtsResult>
   'build:js': TaskHandler<RollupTask>
+  'rolldown:dts': TaskHandler<RolldownDtsTask>
 }
 
 /** @internal */

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -739,10 +739,8 @@ exports.VERSION = VERSION;
 
 exports[`should build \`ts-rolldown\` package 2`] = `
 "/** @public */
-export declare const VERSION = '1.0.0'
-
-export {}
-"
+declare const VERSION = "1.0.0";
+export { VERSION };"
 `;
 
 exports[`should build \`ts-rolldown\` package 3`] = `
@@ -756,10 +754,8 @@ export {
 
 exports[`should build \`ts-rolldown\` package 4`] = `
 "/** @public */
-export declare const VERSION = '1.0.0'
-
-export {}
-"
+declare const VERSION = "1.0.0";
+export { VERSION };"
 `;
 
 exports[`should build \`ts-rolldown-without-extract\` package 1`] = `
@@ -772,10 +768,8 @@ exports.VERSION = VERSION;
 `;
 
 exports[`should build \`ts-rolldown-without-extract\` package 2`] = `
-"export declare const VERSION = '1.0.0'
-
-export {}
-"
+"declare const VERSION = "1.0.0";
+export { VERSION };"
 `;
 
 exports[`should build \`ts-rolldown-without-extract\` package 3`] = `
@@ -788,10 +782,8 @@ export {
 `;
 
 exports[`should build \`ts-rolldown-without-extract\` package 4`] = `
-"export declare const VERSION = '1.0.0'
-
-export {}
-"
+"declare const VERSION = "1.0.0";
+export { VERSION };"
 `;
 
 exports[`should build \`ts-without-extract\` package 1`] = `

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -699,13 +699,6 @@ declare module './module2' {
 "
 `;
 
-exports[`should build \`ts-without-extract\` package 1`] = `
-"export declare const VERSION = '1.0.0'
-
-export {}
-"
-`;
-
 exports[`should build \`ts-node16\` package 1`] = `
 "/**
  * @internal
@@ -732,5 +725,78 @@ declare module './module2.js' {
   }
 }
 //# sourceMappingURL=module1.d.ts.map
+"
+`;
+
+exports[`should build \`ts-rolldown\` package 1`] = `
+""use strict";
+Object.defineProperty(exports, "__esModule", { value: !0 });
+const VERSION = "1.0.0";
+exports.VERSION = VERSION;
+//# sourceMappingURL=index.cjs.map
+"
+`;
+
+exports[`should build \`ts-rolldown\` package 2`] = `
+"/** @public */
+export declare const VERSION = '1.0.0'
+
+export {}
+"
+`;
+
+exports[`should build \`ts-rolldown\` package 3`] = `
+"const VERSION = "1.0.0";
+export {
+  VERSION
+};
+//# sourceMappingURL=index.js.map
+"
+`;
+
+exports[`should build \`ts-rolldown\` package 4`] = `
+"/** @public */
+export declare const VERSION = '1.0.0'
+
+export {}
+"
+`;
+
+exports[`should build \`ts-rolldown-without-extract\` package 1`] = `
+""use strict";
+Object.defineProperty(exports, "__esModule", { value: !0 });
+const VERSION = "1.0.0";
+exports.VERSION = VERSION;
+//# sourceMappingURL=index.cjs.map
+"
+`;
+
+exports[`should build \`ts-rolldown-without-extract\` package 2`] = `
+"export declare const VERSION = '1.0.0'
+
+export {}
+"
+`;
+
+exports[`should build \`ts-rolldown-without-extract\` package 3`] = `
+"const VERSION = "1.0.0";
+export {
+  VERSION
+};
+//# sourceMappingURL=index.js.map
+"
+`;
+
+exports[`should build \`ts-rolldown-without-extract\` package 4`] = `
+"export declare const VERSION = '1.0.0'
+
+export {}
+"
+`;
+
+exports[`should build \`ts-without-extract\` package 1`] = `
+"export declare const VERSION = '1.0.0'
+
+export {}
 "
 `;

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -699,6 +699,13 @@ declare module './module2' {
 "
 `;
 
+exports[`should build \`ts-without-extract\` package 1`] = `
+"export declare const VERSION = '1.0.0'
+
+export {}
+"
+`;
+
 exports[`should build \`ts-node16\` package 1`] = `
 "/**
  * @internal

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -152,7 +152,8 @@ test.skipIf(isWindows)('should build `ts-rolldown-without-extract` package', asy
 
   const {stdout} = await project.run('build')
 
-  expect(stdout).toContain('with api-extractor')
+  expect(stdout).toContain('with rolldown')
+  expect(stdout).not.toContain('Check tsdoc release tags')
 
   expect(await project.readFile('dist/index.cjs')).toMatchSnapshot()
   expect(await project.readFile('dist/index.d.cts')).toMatchSnapshot()
@@ -169,7 +170,8 @@ test.skipIf(isWindows)('should build `ts-rolldown` package', async () => {
 
   const {stdout} = await project.run('build')
 
-  expect(stdout).toContain('with api-extractor')
+  expect(stdout).toContain('with rolldown')
+  expect(stdout).not.toContain('Check tsdoc release tags')
 
   expect(await project.readFile('dist/index.cjs')).toMatchSnapshot()
   expect(await project.readFile('dist/index.d.cts')).toMatchSnapshot()

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -131,6 +131,20 @@ test.skipIf(isWindows)('should build `ts` package', async () => {
   await project.remove()
 })
 
+test.skipIf(isWindows)('should build `ts-without-extract` package', async () => {
+  const project = await spawnProject('ts-without-extract')
+
+  await project.install()
+
+  const {stdout} = await project.run('build')
+
+  expect(stdout).toContain('./src/index.ts → ./dist/index.d.ts')
+
+  expect(await project.readFile('dist/index.d.ts')).toMatchSnapshot()
+
+  await project.remove()
+})
+
 test.skipIf(isWindows)('should build `ts-node16` package', async () => {
   const project = await spawnProject('ts-node16')
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -145,6 +145,40 @@ test.skipIf(isWindows)('should build `ts-without-extract` package', async () => 
   await project.remove()
 })
 
+test.skipIf(isWindows)('should build `ts-rolldown-without-extract` package', async () => {
+  const project = await spawnProject('ts-rolldown-without-extract')
+
+  await project.install()
+
+  const {stdout} = await project.run('build')
+
+  expect(stdout).toContain('with api-extractor')
+
+  expect(await project.readFile('dist/index.cjs')).toMatchSnapshot()
+  expect(await project.readFile('dist/index.d.cts')).toMatchSnapshot()
+  expect(await project.readFile('dist/index.js')).toMatchSnapshot()
+  expect(await project.readFile('dist/index.d.ts')).toMatchSnapshot()
+
+  await project.remove()
+})
+
+test.skipIf(isWindows)('should build `ts-rolldown` package', async () => {
+  const project = await spawnProject('ts-rolldown')
+
+  await project.install()
+
+  const {stdout} = await project.run('build')
+
+  expect(stdout).toContain('with api-extractor')
+
+  expect(await project.readFile('dist/index.cjs')).toMatchSnapshot()
+  expect(await project.readFile('dist/index.d.cts')).toMatchSnapshot()
+  expect(await project.readFile('dist/index.js')).toMatchSnapshot()
+  expect(await project.readFile('dist/index.d.ts')).toMatchSnapshot()
+
+  await project.remove()
+})
+
 test.skipIf(isWindows)('should build `ts-node16` package', async () => {
   const project = await spawnProject('ts-node16')
 

--- a/test/env/globalSetup.ts
+++ b/test/env/globalSetup.ts
@@ -9,7 +9,7 @@ async function runExec(cmd: string) {
   try {
     const env = {
       ...process.env,
-      PATH: `${process.env.PATH}:${path.resolve(__dirname, '../../bin')}`,
+      PATH: `${process.env['PATH']}:${path.resolve(__dirname, '../../bin')}`,
     }
     const tmpPath = path.resolve(__dirname, '../..')
 

--- a/test/env/spawnProject.ts
+++ b/test/env/spawnProject.ts
@@ -48,7 +48,7 @@ export function spawnProject(name: string): Promise<{
             try {
               const env = {
                 ...process.env,
-                PATH: `${process.env.PATH}:${path.resolve(__dirname, '../../bin')}`,
+                PATH: `${process.env['PATH']}:${path.resolve(__dirname, '../../bin')}`,
               }
 
               return exec(cmd, {cwd: tmpPath, env})

--- a/test/parseTasks.test.ts
+++ b/test/parseTasks.test.ts
@@ -71,6 +71,7 @@ test('should parse tasks (type: module)', () => {
     },
     strict: true,
     ts: {},
+    dts: 'api-extractor',
   }
 
   const tasks = resolveBuildTasks(ctx)

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -5,6 +5,6 @@
   "compilerOptions": {
     "paths": {
       "@sanity/pkg-utils": ["./src/node"]
-    }
-  }
+    },
+  },
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,16 +9,16 @@ export default defineConfig({
     // Set to 2 minutes to support long-running Next.js test
     testTimeout: 2 * 60 * 1000,
 
-    // Enable rich PR failed test annotation on the CI
-    reporters: process.env.GITHUB_ACTIONS ? ['default', 'github-actions'] : 'default',
-
     // Reduce threads as suites will use the filesystem and `pnpm install` and need to run in sequence
     fileParallelism: false,
-
-    // Don't rerun test watcher when generated files change, or it'll infinitely loop
-    watchExclude: ['**/node_modules/**', '**/dist/**', 'test/env/__tmp__/**'],
   },
   esbuild: {
     target: 'node14',
+  },
+  server: {
+    watch: {
+      // Don't rerun test watcher when generated files change, or it'll infinitely loop
+      ignored: ['**/node_modules/**', '**/dist/**', 'test/env/__tmp__/**'],
+    },
   },
 })


### PR DESCRIPTION
By adding this to your `package.config.ts` file:
```ts
import {defineConfig} from '@sanity/pkg-utils'

export default defineConfig({
  dts: 'rolldown'
})
```
A faster pipeline is used to generate `.d.ts` files. Instead of using `@microsoft/api-extractor` it'll use `rolldown` + `rolldown-plugin-dts`, which is much faster. Especially if `isolatedDeclarations: true` is added to your `tsconfig.json` file 🙌 