### PR TITLE
feat: run CLI on native ESM

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,8 @@
   "ignorePresets": [
     ":ignoreModulesAndTests",
     "github>sanity-io/renovate-config:group-non-major",
-    "github>sanity-io/renovate-config:typescript"
+    "github>sanity-io/renovate-config:typescript",
+    "github>sanity-io/renovate-config:workarounds-esm"
   ],
   "packageRules": [
     {

--- a/bin/pkg-utils.cjs
+++ b/bin/pkg-utils.cjs
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-require('../dist/cli.cjs')

--- a/bin/pkg-utils.js
+++ b/bin/pkg-utils.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/cli.js'

--- a/package.config.ts
+++ b/package.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   bundles: [
     {
       source: './src/cli/index.ts',
-      require: './dist/cli.cjs',
+      import: './dist/cli.js',
     },
   ],
   extract: {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "pkg": "./bin/pkg-utils.cjs",
-    "pkg-utils": "./bin/pkg-utils.cjs"
+    "pkg": "./bin/pkg-utils.js",
+    "pkg-utils": "./bin/pkg-utils.js"
   },
   "files": [
     "bin",

--- a/src/node/core/config/loadConfig.ts
+++ b/src/node/core/config/loadConfig.ts
@@ -1,8 +1,11 @@
+import {createRequire} from 'node:module'
 import path from 'node:path'
 import {register} from 'esbuild-register/dist/node'
 import pkgUp from 'pkg-up'
 import {findConfigFile} from './findConfigFile'
 import type {PkgConfigOptions} from './types'
+
+const require = createRequire(import.meta.url)
 
 /** @alpha */
 export async function loadConfig(options: {cwd: string}): Promise<PkgConfigOptions | undefined> {

--- a/src/node/tasks/dts/createTSDocConfig.ts
+++ b/src/node/tasks/dts/createTSDocConfig.ts
@@ -1,6 +1,9 @@
 import {readFile} from 'node:fs/promises'
+import {createRequire} from 'node:module'
 import {TSDocConfigFile} from '@microsoft/tsdoc-config'
 import {parse} from 'jsonc-parser'
+
+const require = createRequire(import.meta.url)
 
 /** @public */
 export interface TSDocCustomTag {


### PR DESCRIPTION
This opens up the door to run esm-only packages in the future, without impacting regular consumers of `@sanity/pkg-utils` which only uses it through the CLI or `package.config.ts` files.