### PR TITLE
feat: option for disabling API extractor checks

### DIFF
--- a/package.config.ts
+++ b/package.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     },
   ],
   extract: {
+
     rules: {
       'ae-incompatible-release-tags': 'error',
       'ae-internal-missing-underscore': 'off',
@@ -25,5 +26,5 @@ export default defineConfig({
   },
   runtime: 'node',
   tsconfig: 'tsconfig.dist.json',
-  // dts: 'rolldown',
+  dts: 'rolldown',
 })

--- a/playground/sanity/package.config.ts
+++ b/playground/sanity/package.config.ts
@@ -14,4 +14,5 @@ export default defineConfig({
       'ae-missing-release-tag': 'error',
     },
   },
+  dts: 'rolldown',
 })

--- a/playground/ts-rolldown-without-extract/tsconfig.dist.json
+++ b/playground/ts-rolldown-without-extract/tsconfig.dist.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.settings",
-  "include": ["./src"]
+  "include": ["./src"],
+  "compilerOptions": {
+    "isolatedDeclarations": true
+  }
 }

--- a/playground/ts-rolldown/tsconfig.dist.json
+++ b/playground/ts-rolldown/tsconfig.dist.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.settings",
-  "include": ["./src"]
+  "include": ["./src"],
+  "compilerOptions": {
+    "isolatedDeclarations": true
+  }
 }


### PR DESCRIPTION
It's now possible to disable `@microsoft/api-extractor` checks by using:
```ts
import {defineConfig} from '@sanity/pkg-utils'

export default defineConfig({
  extract: {
    enabled: false
  }
})
```

By default `@microsoft/api-extractor` is still used to bundle `.d.ts` files in this mode.
You can completely disable it by also opting into using `rolldown` for `.d.ts` generation:
```ts
import {defineConfig} from '@sanity/pkg-utils'

export default defineConfig({
  extract: {
    enabled: false
  },
  dts: 'rolldown'
})
```