### PR TITLE
feat: add `tsgo` support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/pkg-utils",
-  "version": "7.5.0",
+  "version": "7.5.1-canary.0",
   "description": "Simple utilities for modern npm packages.",
   "keywords": [
     "sanity-io",
@@ -144,6 +144,7 @@
     "@types/semver": "^7.5.8",
     "@types/treeify": "^1.0.3",
     "@types/uuid": "^10.0.0",
+    "@typescript/native-preview": "catalog:",
     "browserslist-to-esbuild": "2.1.1",
     "commitizen": "^4.3.1",
     "cpx": "^1.5.0",

--- a/playground/tsgo/package.config.ts
+++ b/playground/tsgo/package.config.ts
@@ -1,0 +1,6 @@
+import {defineConfig} from '@sanity/pkg-utils'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  dts: 'rolldown',
+})

--- a/playground/tsgo/package.json
+++ b/playground/tsgo/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "tsgo",
+  "version": "0.0.0-development",
+  "private": true,
+  "license": "MIT",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "pkg build --strict --check --clean",
+    "check:types": "tsc",
+    "clean": "rimraf dist"
+  },
+  "browserslist": "extends @sanity/browserslist-config",
+  "devDependencies": {
+    "@typescript/native-preview": "catalog:"
+  }
+}

--- a/playground/tsgo/src/index.ts
+++ b/playground/tsgo/src/index.ts
@@ -1,0 +1,2 @@
+/** @public */
+export const VERSION = '1.0.0'

--- a/playground/tsgo/tsconfig.dist.json
+++ b/playground/tsgo/tsconfig.dist.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["./src"]
+}

--- a/playground/tsgo/tsconfig.json
+++ b/playground/tsgo/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["./package.config.ts", "./src"]
+}

--- a/playground/tsgo/tsconfig.settings.json
+++ b/playground/tsgo/tsconfig.settings.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@sanity/pkg-utils/tsconfig/strictest.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@typescript/native-preview':
+      specifier: 7.0.0-dev.20250618.1
+      version: 7.0.0-dev.20250618.1
     typescript:
       specifier: 5.8.3
       version: 5.8.3
@@ -124,7 +127,7 @@ importers:
         version: 1.0.0-beta.17
       rolldown-plugin-dts:
         specifier: 0.13.11
-        version: 0.13.11(rolldown@1.0.0-beta.17)(typescript@5.8.3)
+        version: 0.13.11(@typescript/native-preview@7.0.0-dev.20250618.1)(rolldown@1.0.0-beta.17)(typescript@5.8.3)
       rollup:
         specifier: ^4.43.0
         version: 4.43.0
@@ -192,6 +195,9 @@ importers:
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20250618.1
       browserslist-to-esbuild:
         specifier: 2.1.1
         version: 2.1.1(browserslist@4.25.0)
@@ -460,6 +466,12 @@ importers:
   playground/ts-rolldown-without-extract: {}
 
   playground/ts-without-extract: {}
+
+  playground/tsgo:
+    devDependencies:
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20250618.1
 
   playground/use-client-directive:
     devDependencies:
@@ -1871,6 +1883,53 @@ packages:
 
   '@types/uuid@8.3.4':
     resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20250618.1':
+    resolution: {integrity: sha512-h4fokGV0LQ+mCfc/Cpubn1m4OURNozMPQhzyI4pHOlGZdyZyYRj2e2LLzr3OwqeRnn71al2fcBfay63d/P3FSQ==}
+    engines: {node: '>=20.6.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20250618.1':
+    resolution: {integrity: sha512-ERqUV+rbk2/rAhmHq9ivTVtbMvUpkAsgdveFqEGzZsTtrHWvL2ELQOamqqKyK3hQfjzt9RHwdC0VrLE2U3SGbg==}
+    engines: {node: '>=20.6.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20250618.1':
+    resolution: {integrity: sha512-1RyP3DqqDMIYcce9FN7CF3feuRGcf1MLkxs1iMqlReuF7lVrUXdAc+OzPoNIUdiIXPa0Ri6s8H495aDJ5YnGCA==}
+    engines: {node: '>=20.6.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20250618.1':
+    resolution: {integrity: sha512-X9idSQ9FLlBlHbeqh0Yzxr/ReeaOT42vqD9wjOLsuJkOEyc/b19D8zGVDoxBRNnxAGqSWRmbCFXRaqcJF59Kiw==}
+    engines: {node: '>=20.6.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20250618.1':
+    resolution: {integrity: sha512-7YHLpNI6i0TT4SDkeHuXuY533Kgu38P+GVJBuXgS5FkRI8PLmxhBMHaQwyCcHqT13P4o5VPwphBtbS/JsEBBkw==}
+    engines: {node: '>=20.6.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20250618.1':
+    resolution: {integrity: sha512-YTuCMALzxu1aGYLWFHhQG8rUoEbbE6O5zawETfcNC0zwr430la/apSG1nla7x+nG2DBb9bJMuQWYErjTCGyM2g==}
+    engines: {node: '>=20.6.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20250618.1':
+    resolution: {integrity: sha512-DetIr5Cc16W+4vhjfGW8LQHAauvmUJh0F8uf5eWpCPSH9rbbytWSqcQXzMxvfnVT3uek78Hi7oHOXK6A5AoiDQ==}
+    engines: {node: '>=20.6.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20250618.1':
+    resolution: {integrity: sha512-FkisKblT8PEyq08bjVXND137ojhr+1CfRhSIwvzilMcnEwav2wzxEGZndLNSGzwUlqkS+xQCRx1ch8clpsLq9Q==}
+    engines: {node: '>=20.6.0'}
+    hasBin: true
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -6524,6 +6583,37 @@ snapshots:
 
   '@types/uuid@8.3.4': {}
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20250618.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20250618.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20250618.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20250618.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20250618.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20250618.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20250618.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20250618.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20250618.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20250618.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20250618.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20250618.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20250618.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20250618.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20250618.1
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@vercel/stega@0.1.2': {}
@@ -9319,7 +9409,7 @@ snapshots:
     dependencies:
       glob: 9.3.5
 
-  rolldown-plugin-dts@0.13.11(rolldown@1.0.0-beta.17)(typescript@5.8.3):
+  rolldown-plugin-dts@0.13.11(@typescript/native-preview@7.0.0-dev.20250618.1)(rolldown@1.0.0-beta.17)(typescript@5.8.3):
     dependencies:
       '@babel/generator': 7.27.5
       '@babel/parser': 7.27.5
@@ -9331,6 +9421,7 @@ snapshots:
       get-tsconfig: 4.10.1
       rolldown: 1.0.0-beta.17
     optionalDependencies:
+      '@typescript/native-preview': 7.0.0-dev.20250618.1
       typescript: 5.8.3
     transitivePeerDependencies:
       - oxc-resolver

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,5 @@ packages:
   - test/env/__tmp__/**
 
 catalog:
+  '@typescript/native-preview': 7.0.0-dev.20250618.1
   typescript: 5.8.3

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -792,3 +792,33 @@ exports[`should build \`ts-without-extract\` package 1`] = `
 export {}
 "
 `;
+
+exports[`should build \`tsgo\` package 1`] = `
+""use strict";
+Object.defineProperty(exports, "__esModule", { value: !0 });
+const VERSION = "1.0.0";
+exports.VERSION = VERSION;
+//# sourceMappingURL=index.cjs.map
+"
+`;
+
+exports[`should build \`tsgo\` package 2`] = `
+"/** @public */
+declare const VERSION = "1.0.0";
+export { VERSION };"
+`;
+
+exports[`should build \`tsgo\` package 3`] = `
+"const VERSION = "1.0.0";
+export {
+  VERSION
+};
+//# sourceMappingURL=index.js.map
+"
+`;
+
+exports[`should build \`tsgo\` package 4`] = `
+"/** @public */
+declare const VERSION = "1.0.0";
+export { VERSION };"
+`;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -171,7 +171,24 @@ test.skipIf(isWindows)('should build `ts-rolldown` package', async () => {
   const {stdout} = await project.run('build')
 
   expect(stdout).toContain('with rolldown')
-  expect(stdout).not.toContain('Check tsdoc release tags')
+
+  expect(await project.readFile('dist/index.cjs')).toMatchSnapshot()
+  expect(await project.readFile('dist/index.d.cts')).toMatchSnapshot()
+  expect(await project.readFile('dist/index.js')).toMatchSnapshot()
+  expect(await project.readFile('dist/index.d.ts')).toMatchSnapshot()
+
+  await project.remove()
+})
+
+test.skipIf(isWindows)('should build `tsgo` package', async () => {
+  const project = await spawnProject('tsgo')
+
+  await project.install()
+
+  const {stdout} = await project.run('build')
+
+  expect(stdout).toContain('with rolldown')
+  expect(stdout).toContain('The `tsgo` option is experimental')
 
   expect(await project.readFile('dist/index.cjs')).toMatchSnapshot()
   expect(await project.readFile('dist/index.d.cts')).toMatchSnapshot()


### PR DESCRIPTION
By adding `dts: 'rolldown'` to `package.config.ts`:
```ts
import {defineConfig} from '@sanity/pkg-utils'

export default defineConfg({
  dts: 'rolldown',
})
```

It's possible to use `tsgo` by running:
```bash
pnpm add -D @typescript/native-preview
```

This is faster than using `tsc`. Faster still is `isolatedDeclarations` in your `compilerOptions`, but it may not be possible to opt in to that without large refactors on the codebase.