### PR TITLE
fix: detect if `@sanity/browserslist-config` can't be resolved

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/pkg-utils",
-  "version": "7.7.0",
+  "version": "7.7.1-canary.3",
   "description": "Simple utilities for modern npm packages.",
   "keywords": [
     "sanity-io",


### PR DESCRIPTION
Fixes #1397 but unsure if it can land since `findPackageJSON` isn't well supported yet. I initially tried with `createRequire`, but I couldn't get it to fail when running from within `@sanity/pkg-utils`, it has to detect resolution errors from `cwd`. Since `@sanity/pkg-utils` has a direct dependency on `@sanity/browserslist-config` there's always going to be `./node_modules/@sanity/pkg-utils/node_modules/@sanity/browserslist-config` or `./node_modules/@sanity/browserslist-config`. 
It needs to detect the `./node_modules/@sanity/pkg-utils/node_modules/@sanity/browserslist-config` case specifically, or rather, that `./node_modules/@sanity/browserslist-config` is "missing" and thus `"browserslist": "extends @sanity/browserslist-config"` won't have an effect in other tooling than `@sanity/pkg-utils` itself.

I put "missing" in quotes, as it's not that simple. `./node_modules/@sanity/browserslist-config` might be missing and its fine, if `../../node_modules/@sanity/browserslist-config` does. That's why I'm trying to rely on core node resolution APIs so that we can know for a fact wether it's failing to resolve or not.