### PR TITLE
fix(rollup): revert improve treeshake for react and styled components

### DIFF
--- a/src/node/tasks/rollup/resolveRollupConfig.ts
+++ b/src/node/tasks/rollup/resolveRollupConfig.ts
@@ -283,14 +283,6 @@ export function resolveRollupConfig(
         // this option used to be `moduleSideEffects: 'no-external'`, and thus if it's not CSS it uses `!external`, which is equivalent to `'no-external'`
         moduleSideEffects: (id, external) => (id.endsWith('.css') ? true : !external),
         annotations: true,
-        manualPureFunctions: [
-          'memo',
-          'forwardRef',
-          'lazy',
-          'createContext',
-          'styled',
-          'createGlobalStyle',
-        ],
         ...config?.rollup?.treeshake,
       },
       experimentalLogSideEffects: config?.rollup?.experimentalLogSideEffects,


### PR DESCRIPTION
Reverts sanity-io/pkg-utils#1548, as it has caused regressions in repos like `@portabletext/editor`