### PR TITLE
feat: use typings from babel-plugin-react-compiler

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @sanity-io/ecosystem

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "@types/treeify": "^1.0.3",
     "@types/uuid": "^10.0.0",
     "@typescript/native-preview": "catalog:",
+    "babel-plugin-react-compiler": "19.1.0-rc.2",
     "browserslist-to-esbuild": "2.1.1",
     "commitizen": "^4.3.1",
     "cz-conventional-changelog": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,9 +77,6 @@ importers:
       '@vanilla-extract/rollup-plugin':
         specifier: ^1.4.1
         version: 1.4.1(rollup@4.48.1)
-      babel-plugin-react-compiler:
-        specifier: '*'
-        version: 19.1.0-rc.2
       browserslist:
         specifier: ^4.25.3
         version: 4.25.3
@@ -210,6 +207,9 @@ importers:
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20250825.1
+      babel-plugin-react-compiler:
+        specifier: 19.1.0-rc.2
+        version: 19.1.0-rc.2
       browserslist-to-esbuild:
         specifier: 2.1.1
         version: 2.1.1(browserslist@4.25.3)

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -4,7 +4,7 @@ import {build} from '../src/node'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-global.__DEV__ = true
+global.___DEV___ = true
 
 build({cwd: path.resolve(__dirname, '..'), strict: true}).catch((err) => {
   console.error(err.stack)

--- a/scripts/check.ts
+++ b/scripts/check.ts
@@ -4,7 +4,7 @@ import {check} from '../src/node'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-global.__DEV__ = true
+global.___DEV___ = true
 
 check({
   cwd: path.resolve(__dirname, '..'),

--- a/scripts/init.ts
+++ b/scripts/init.ts
@@ -5,7 +5,7 @@ import {init} from '../src/node'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-global.__DEV__ = true
+global.___DEV___ = true
 
 const args = argv.slice(2)
 

--- a/scripts/watch.ts
+++ b/scripts/watch.ts
@@ -4,7 +4,7 @@ import {watch} from '../src/node'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-global.__DEV__ = true
+global.___DEV___ = true
 
 watch({
   cwd: path.resolve(__dirname, '..'),

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,5 +1,0 @@
-declare global {
-  var __DEV__: boolean
-}
-
-export type {}

--- a/src/node/core/config/loadConfig.ts
+++ b/src/node/core/config/loadConfig.ts
@@ -7,6 +7,10 @@ import type {PkgConfigOptions} from './types'
 
 const require = createRequire(import.meta.url)
 
+declare global {
+  var ___DEV___: boolean
+}
+
 /** @alpha */
 export async function loadConfig(options: {cwd: string}): Promise<PkgConfigOptions | undefined> {
   const {cwd} = options
@@ -28,7 +32,7 @@ export async function loadConfig(options: {cwd: string}): Promise<PkgConfigOptio
     return undefined
   }
 
-  const unregister = globalThis.__DEV__ ? () => undefined : register()
+  const unregister = globalThis.___DEV___ ? () => undefined : register()
 
   const mod = require(configFile)
 

--- a/src/node/core/config/types.ts
+++ b/src/node/core/config/types.ts
@@ -1,6 +1,7 @@
 import type {PluginItem as BabelPluginItem} from '@babel/core'
 import type {OptimizeLodashOptions} from '@optimize-lodash/rollup-plugin'
 import type {Options as VanillaExtractOptions} from '@vanilla-extract/rollup-plugin'
+import type {PluginOptions as ReactCompilerOptions} from 'babel-plugin-react-compiler'
 import type {NormalizedOutputOptions, Plugin as RollupPlugin, TreeshakingOptions} from 'rollup'
 import type {StrictOptions} from '../../strict'
 
@@ -64,98 +65,6 @@ export interface TSDocCustomTag {
   allowMultiple?: boolean
 }
 
-/**
- * Until these types are on npm: https://github.com/facebook/react/blob/0bc30748730063e561d87a24a4617526fdd38349/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts#L39-L122
- * @alpha
- */
-export interface ReactCompilerOptions {
-  logger?: ReactCompilerLogger | null
-
-  panicThreshold?: 'ALL_ERRORS' | 'CRITICAL_ERRORS' | 'NONE'
-
-  compilationMode?: 'infer' | 'syntax' | 'annotation' | 'all'
-
-  /*
-   * If enabled, Forget will import `useMemoCache` from the given module
-   * instead of `react/compiler-runtime`.
-   *
-   * ```
-   * // If set to "react-compiler-runtime"
-   * import {c as useMemoCache} from 'react-compiler-runtime';
-   * ```
-   */
-  runtimeModule?: string | null | undefined
-
-  /**
-   * By default React Compiler will skip compilation of code that suppresses the default
-   * React ESLint rules, since this is a strong indication that the code may be breaking React rules
-   * in some way.
-   *
-   * Use eslintSuppressionRules to pass a custom set of rule names: any code which suppresses the
-   * provided rules will skip compilation. To disable this feature (never bailout of compilation
-   * even if the default ESLint is suppressed), pass an empty array.
-   */
-  eslintSuppressionRules?: Array<string> | null | undefined
-
-  sources?: Array<string> | ((filename: string) => boolean) | null
-
-  /**
-   * The minimum major version of React that the compiler should emit code for. If the target is 19
-   * or higher, the compiler emits direct imports of React runtime APIs needed by the compiler. On
-   * versions prior to 19, an extra runtime package react-compiler-runtime is necessary to provide
-   * a userspace approximation of runtime APIs.
-   */
-  target: '17' | '18' | '19'
-}
-
-/**
- * @alpha
- * Represents 'events' that may occur during compilation. Events are only
- * recorded when a logger is set (through the config).
- * These are the different types of events:
- * CompileError:
- *   Forget skipped compilation of a function / file due to a known todo,
- *   invalid input, or compiler invariant being broken.
- * CompileSuccess:
- *   Forget successfully compiled a function.
- * PipelineError:
- *   Unexpected errors that occurred during compilation (e.g. failures in
- *   babel or other unhandled exceptions).
- */
-export type ReactCompilerLoggerEvent =
-  | {
-      kind: 'CompileError'
-      fnLoc: unknown
-      detail: unknown
-    }
-  | {
-      kind: 'CompileDiagnostic'
-      fnLoc: unknown
-      detail: unknown
-    }
-  | {
-      kind: 'CompileSuccess'
-      fnLoc: unknown
-      fnName: string | null
-      memoSlots: number
-      memoBlocks: number
-      memoValues: number
-      prunedMemoBlocks: number
-      prunedMemoValues: number
-    }
-  | {
-      kind: 'PipelineError'
-      fnLoc: unknown
-      data: string
-    }
-
-/**
- * @alpha
- */
-export type ReactCompilerLogger = {
-  logEvent: (filename: string | null, event: ReactCompilerLoggerEvent) => void
-}
-
 export type DtsType = 'api-extractor' | 'rolldown'
 
 /** @public */
@@ -193,11 +102,9 @@ export interface PkgConfigOptions {
   }
   /**
    * Configure the React Compiler.
-   * To enable it, either:
-   * - set `babel.reactCompiler` to `true`
-   * - add a `react-compiler` export condition,  before any `browser`, `require` or `import` conditions. After any `react-server` and `node` conditions
-   * @alpha */
-  reactCompilerOptions?: ReactCompilerOptions
+   * To enable it set `babel.reactCompiler` to `true`
+   * @beta */
+  reactCompilerOptions?: Partial<ReactCompilerOptions>
   bundles?: PkgBundle[]
   /** @alpha */
   define?: Record<string, string | number | boolean | undefined | null>

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -12,9 +12,6 @@ export type {
   PkgExports,
   PkgRuleLevel,
   TSDocCustomTag,
-  ReactCompilerOptions,
-  ReactCompilerLoggerEvent,
-  ReactCompilerLogger,
   PkgConfigOptions,
 } from './core/config/types'
 export {DEFAULT_BROWSERSLIST_QUERY} from './core/defaults'


### PR DESCRIPTION
- removes CODEOWNERS as team ecosystem no longer owns the repo.
- renames `globalThis.__DEV__` usage to `globalThis.___DEV___` as `__DEV__` has special meaning both for the `babel-plugin-react-compiler` as well as the sanity monorepo build tooling.
- removes manual typings and uses the `.d.ts` typings that now ship with `babel-plugin-react-compiler`