### PR TITLE
refactor: move `.npmrc` and `package.json` settings to `pnpm-workspace.yaml`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-; This is needed for prettier to be able to use the plugin specified by the `@sanity/prettier-config` preset
-public-hoist-pattern[]=*prettier*

--- a/package.json
+++ b/package.json
@@ -176,10 +176,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "pnpm": {
-    "overrides": {
-      "@sanity/pkg-utils": "workspace:*"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10350,19 +10350,19 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@sanity/presentation-comlink@1.0.28(@sanity/client@7.9.0(debug@4.4.1))(@sanity/types@4.5.0(@types/react@18.3.24)(debug@4.4.1))':
-    dependencies:
-      '@sanity/client': 7.9.0(debug@4.4.1)
-      '@sanity/comlink': 3.0.9
-      '@sanity/visual-editing-types': 1.1.5(@sanity/client@7.9.0(debug@4.4.1))(@sanity/types@4.5.0(@types/react@18.3.24)(debug@4.4.1))
-    transitivePeerDependencies:
-      - '@sanity/types'
-
   '@sanity/presentation-comlink@1.0.28(@sanity/client@7.9.0(debug@4.4.1))(@sanity/types@4.5.0(@types/react@19.1.11))':
     dependencies:
       '@sanity/client': 7.9.0(debug@4.4.1)
       '@sanity/comlink': 3.0.9
       '@sanity/visual-editing-types': 1.1.5(@sanity/client@7.9.0(debug@4.4.1))(@sanity/types@4.5.0(@types/react@19.1.11))
+    transitivePeerDependencies:
+      - '@sanity/types'
+
+  '@sanity/presentation-comlink@1.0.28(@sanity/client@7.9.0)(@sanity/types@4.5.0(@types/react@18.3.24)(debug@4.4.1))':
+    dependencies:
+      '@sanity/client': 7.9.0(debug@4.4.1)
+      '@sanity/comlink': 3.0.9
+      '@sanity/visual-editing-types': 1.1.5(@sanity/client@7.9.0)(@sanity/types@4.5.0(@types/react@18.3.24)(debug@4.4.1))
     transitivePeerDependencies:
       - '@sanity/types'
 
@@ -10631,17 +10631,17 @@ snapshots:
       '@types/uuid': 8.3.4
       uuid: 8.3.2
 
-  '@sanity/visual-editing-types@1.1.5(@sanity/client@7.9.0(debug@4.4.1))(@sanity/types@4.5.0(@types/react@18.3.24)(debug@4.4.1))':
-    dependencies:
-      '@sanity/client': 7.9.0(debug@4.4.1)
-    optionalDependencies:
-      '@sanity/types': 4.5.0(@types/react@18.3.24)(debug@4.4.1)
-
   '@sanity/visual-editing-types@1.1.5(@sanity/client@7.9.0(debug@4.4.1))(@sanity/types@4.5.0(@types/react@19.1.11))':
     dependencies:
       '@sanity/client': 7.9.0(debug@4.4.1)
     optionalDependencies:
       '@sanity/types': 4.5.0(@types/react@19.1.11)(debug@4.4.1)
+
+  '@sanity/visual-editing-types@1.1.5(@sanity/client@7.9.0)(@sanity/types@4.5.0(@types/react@18.3.24)(debug@4.4.1))':
+    dependencies:
+      '@sanity/client': 7.9.0(debug@4.4.1)
+    optionalDependencies:
+      '@sanity/types': 4.5.0(@types/react@18.3.24)(debug@4.4.1)
 
   '@sentry-internal/browser-utils@8.55.0':
     dependencies:
@@ -14978,7 +14978,7 @@ snapshots:
       '@sanity/message-protocol': 0.17.2
       '@sanity/migrate': 4.5.0(@types/react@18.3.24)
       '@sanity/mutator': 4.5.0(@types/react@18.3.24)
-      '@sanity/presentation-comlink': 1.0.28(@sanity/client@7.9.0(debug@4.4.1))(@sanity/types@4.5.0(@types/react@18.3.24)(debug@4.4.1))
+      '@sanity/presentation-comlink': 1.0.28(@sanity/client@7.9.0)(@sanity/types@4.5.0(@types/react@18.3.24)(debug@4.4.1))
       '@sanity/preview-url-secret': 2.1.14(@sanity/client@7.9.0(debug@4.4.1))
       '@sanity/schema': 4.5.0(@types/react@18.3.24)(debug@4.4.1)
       '@sanity/sdk': 2.1.2(@types/react@18.3.24)(debug@4.4.1)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,10 @@ catalog:
   '@sanity/logos': ^2.2.1
   '@typescript/native-preview': 7.0.0-dev.20250826.1
   typescript: 5.9.2
+
+overrides:
+  '@sanity/pkg-utils': workspace:*
+
+# This is needed for prettier to be able to use the plugin specified by the `@sanity/prettier-config` preset
+publicHoistPattern:
+  - '*prettier*'


### PR DESCRIPTION
Fixes warnings like:
```sh
npm warn Unknown project config "public-hoist-pattern". This will stop working in the next major version of npm.
```

By moving pnpm options out of the `.npmrc` and into `pnpm-workspace.yaml`.
Since the overall shift is to use `pnpm-workspace.yaml` to generally configure pnpm I've also moved options from `package.json#pnpm` there.