### PR TITLE
fix: call stack size exceeded regression

### DIFF
--- a/.changeset/fancy-eggs-beg.md
+++ b/.changeset/fancy-eggs-beg.md
@@ -1,0 +1,5 @@
+---
+'@sanity/pkg-utils': patch
+---
+
+Fixes a regression introduced by #2175 leading to a max call stack size exceeded error when running `pkg-utils watch`

--- a/packages/@sanity/pkg-utils/src/node/core/ts/loadTSConfig.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/ts/loadTSConfig.ts
@@ -7,13 +7,15 @@ export async function loadTSConfig(options: {
 }): Promise<ts.ParsedCommandLine | undefined> {
   const {cwd, tsconfigPath} = options
 
-  const configPath = ts.findConfigFile(cwd, (fileName) => ts.sys.fileExists(fileName), tsconfigPath)
+  // oxlint-disable-next-line unbound-method
+  const configPath = ts.findConfigFile(cwd, ts.sys.fileExists, tsconfigPath)
 
   if (!configPath) {
     return undefined
   }
 
-  const configFile = ts.readConfigFile(configPath, (path) => ts.sys.readFile(path))
+  // oxlint-disable-next-line unbound-method
+  const configFile = ts.readConfigFile(configPath, ts.sys.readFile)
 
   return ts.parseJsonConfigFileContent(configFile.config, ts.sys, cwd)
 }

--- a/packages/@sanity/pkg-utils/src/node/tasks/dts/dtsWatchTask.ts
+++ b/packages/@sanity/pkg-utils/src/node/tasks/dts/dtsWatchTask.ts
@@ -77,10 +77,8 @@ export const dtsWatchTask: TaskHandler<DtsWatchTask, DtsResult> = {
         },
       )
 
+      // oxlint-disable-next-line unbound-method
       const origPostProgramCreate = host.afterProgramCreate
-        ? (program: ts.EmitAndSemanticDiagnosticsBuilderProgram) =>
-            host.afterProgramCreate?.(program)
-        : undefined
 
       host.afterProgramCreate = async (program) => {
         origPostProgramCreate?.(program)


### PR DESCRIPTION
Fixes a regression introduced by #2175 leading to a max call stack size exceeded error when running `pkg-utils watch`
