### PR TITLE
fix: preserve subpath imports of external packages in rolldown dts output

### DIFF
--- a/.changeset/rolldown-external-subpath-imports.md
+++ b/.changeset/rolldown-external-subpath-imports.md
@@ -1,0 +1,7 @@
+---
+'@sanity/pkg-utils': patch
+---
+
+fix: preserve subpath imports of external packages in rolldown dts output
+
+Bare specifiers are now matched against their package name when deciding externals in the rolldown dts pipeline, so subpath imports of external dependencies (e.g. `@sanity/client/stega`) keep their original specifier instead of resolving to an absolute filesystem path in the emitted declarations.

--- a/packages/@sanity/pkg-utils/src/node/tasks/rolldown/resolveRolldownConfig.ts
+++ b/packages/@sanity/pkg-utils/src/node/tasks/rolldown/resolveRolldownConfig.ts
@@ -105,7 +105,18 @@ export function resolveRolldownConfig(
         }
       }
 
-      return external.some((name) => name === id || id.includes(`/node_modules/${name}/`))
+      // Derive the package name of bare specifiers so that subpath imports
+      // (e.g. `@sanity/client/stega`) are externalized before resolution,
+      // instead of resolving to absolute filesystem paths that leak into the
+      // emitted declarations
+      const idParts = id.split('/')
+      const idPackageName = idParts[0]!.startsWith('@')
+        ? `${idParts[0]}/${idParts[1]}`
+        : idParts[0]!
+
+      return external.some(
+        (name) => name === id || name === idPackageName || id.includes(`/node_modules/${name}/`),
+      )
     },
 
     input: entries.reduce<{[entryAlias: string]: string}>(

--- a/packages/@sanity/pkg-utils/test/__snapshots__/cli.test.ts.snap
+++ b/packages/@sanity/pkg-utils/test/__snapshots__/cli.test.ts.snap
@@ -1455,6 +1455,38 @@ export {
 "
 `;
 
+exports[`cli > should build \`ts-rolldown-external-subpath-import\` package > ./dist/index.d.cts 1`] = `
+"import { AgentActionPath } from "@sanity/client/stega";
+/**
+* @public
+*/
+interface ExternalSubpathImport {
+  path: AgentActionPath;
+}
+/**
+* @public
+*/
+declare function identity(path: AgentActionPath): AgentActionPath;
+export { ExternalSubpathImport, identity };
+//# sourceMappingURL=index.d.cts.map"
+`;
+
+exports[`cli > should build \`ts-rolldown-external-subpath-import\` package > ./dist/index.d.ts 1`] = `
+"import { AgentActionPath } from "@sanity/client/stega";
+/**
+* @public
+*/
+interface ExternalSubpathImport {
+  path: AgentActionPath;
+}
+/**
+* @public
+*/
+declare function identity(path: AgentActionPath): AgentActionPath;
+export { ExternalSubpathImport, identity };
+//# sourceMappingURL=index.d.ts.map"
+`;
+
 exports[`cli > should build \`ts-rolldown-inline-types-external-js\` package > ./dist/index.cjs 1`] = `
 ""use strict";
 Object.defineProperty(exports, "__esModule", { value: !0 });

--- a/packages/@sanity/pkg-utils/test/cli.test.ts
+++ b/packages/@sanity/pkg-utils/test/cli.test.ts
@@ -324,6 +324,29 @@ describe.skipIf(process.platform === 'win32')('cli', () => {
     expect(distIndexDts).toMatchSnapshot('./dist/index.d.ts')
   })
 
+  test('should build `ts-rolldown-external-subpath-import` package', async () => {
+    const project = await spawnProject('ts-rolldown-external-subpath-import')
+    const stdout = await project.run('build')
+
+    expect(stdout).toContain('with rolldown')
+
+    const [distIndexDcts, distIndexDts] = await Promise.all([
+      project.readFile('dist/index.d.cts'),
+      project.readFile('dist/index.d.ts'),
+    ])
+
+    // The `AgentActionPath` type is imported from the `@sanity/client/stega` subpath export.
+    // `@sanity/client` is a prod dependency, so the emitted declarations must preserve the
+    // original specifier instead of the resolved absolute filesystem path.
+    expect(distIndexDcts).toContain('@sanity/client/stega')
+    expect(distIndexDts).toContain('@sanity/client/stega')
+    expect(distIndexDcts).not.toContain('node_modules')
+    expect(distIndexDts).not.toContain('node_modules')
+    // Snapshot the contents for easier debugging
+    expect(distIndexDcts).toMatchSnapshot('./dist/index.d.cts')
+    expect(distIndexDts).toMatchSnapshot('./dist/index.d.ts')
+  })
+
   test('should build `ts-rolldown-inline-types-external-js` package', async () => {
     const project = await spawnProject('ts-rolldown-inline-types-external-js')
     const stdout = await project.run('build')

--- a/playground/ts-rolldown-external-subpath-import/package.config.ts
+++ b/playground/ts-rolldown-external-subpath-import/package.config.ts
@@ -1,0 +1,6 @@
+import {defineConfig} from '@sanity/pkg-utils'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  dts: 'rolldown',
+})

--- a/playground/ts-rolldown-external-subpath-import/package.json
+++ b/playground/ts-rolldown-external-subpath-import/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "ts-rolldown-external-subpath-import",
+  "version": "0.0.0-development",
+  "private": true,
+  "license": "MIT",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "pkg build --strict --check --clean",
+    "clean": "rimraf dist",
+    "typecheck": "tsc"
+  },
+  "browserslist": "extends @sanity/browserslist-config",
+  "dependencies": {
+    "@sanity/client": "catalog:"
+  }
+}

--- a/playground/ts-rolldown-external-subpath-import/src/index.ts
+++ b/playground/ts-rolldown-external-subpath-import/src/index.ts
@@ -1,0 +1,15 @@
+import type {AgentActionPath} from '@sanity/client/stega'
+
+/**
+ * @public
+ */
+export interface ExternalSubpathImport {
+  path: AgentActionPath
+}
+
+/**
+ * @public
+ */
+export function identity(path: AgentActionPath): AgentActionPath {
+  return path
+}

--- a/playground/ts-rolldown-external-subpath-import/tsconfig.dist.json
+++ b/playground/ts-rolldown-external-subpath-import/tsconfig.dist.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["./tsconfig.settings", "@sanity/tsconfig/isolated-declarations"],
+  "include": ["./src"]
+}

--- a/playground/ts-rolldown-external-subpath-import/tsconfig.json
+++ b/playground/ts-rolldown-external-subpath-import/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["./package.config.ts", "./src"]
+}

--- a/playground/ts-rolldown-external-subpath-import/tsconfig.settings.json
+++ b/playground/ts-rolldown-external-subpath-import/tsconfig.settings.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@sanity/tsconfig/strictest",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -672,6 +672,12 @@ importers:
         specifier: '*'
         version: 19.2.6
 
+  playground/ts-rolldown-external-subpath-import:
+    dependencies:
+      '@sanity/client':
+        specifier: 'catalog:'
+        version: 7.22.1
+
   playground/ts-rolldown-inline-types-external-js:
     dependencies:
       '@sanity/client':


### PR DESCRIPTION
Fixes #2845

## Problem

When a package built with `dts: 'rolldown'` imports a type from a subpath export of an external dependency, the emitted declarations contain the build machine's absolute filesystem path instead of the original specifier:

```ts
// src/index.ts
import type {AgentActionPath} from '@sanity/client/stega'
```

```ts
// dist/index.d.ts
import { AgentActionPath } from "/home/runner/work/plugins/plugins/node_modules/.pnpm/@sanity+client@7.22.1/node_modules/@sanity/client/dist/stega.js";
```

The path is unresolvable anywhere but the machine that ran the build, so the affected types degrade to error types for consumers. `@sanity/assist@6.0.5` through `6.1.0` publish this breakage today — see line 4 of [`dist/index.d.ts` on unpkg](https://unpkg.com/@sanity/assist@6.1.0/dist/index.d.ts).

The rolldown external option matches external package names only by exact equality (`name === id`) or by resolved path (`id.includes('/node_modules/<name>/')`). A subpath specifier matches neither, so it is not externalized up front; rolldown resolves it to an absolute path, the `/node_modules/` clause externalizes the resolved id, and `rolldown-plugin-dts` ≥ 0.23.0 preserves that resolution for externalized ids ([sxzz/rolldown-plugin-dts#213](https://github.com/sxzz/rolldown-plugin-dts/pull/213)) — which is why builds were clean with `10.4.11` (pre-0.23 plugin) and broke from `10.4.17` onward. The rollup pipeline is unaffected because `resolveRollupConfig.ts` derives the package name from the specifier before matching.

## Solution

Port the rollup pipeline's package-name derivation to `resolveRolldownConfig.ts`, so bare specifiers are matched against their package name and externalized before resolution. The existing exact-id and `/node_modules/` clauses are preserved, covering explicitly configured subpath externals and ids that arrive already resolved.

## Testing

- New playground fixture `ts-rolldown-external-subpath-import`: `@sanity/client` as a prod dependency with a type-only import from the `@sanity/client/stega` subpath re-exposed through the public API — mirroring the `@sanity/assist` source pattern.
- The new `cli.test.ts` case asserts the emitted `.d.ts`/`.d.cts` contain `@sanity/client/stega` and do not contain `node_modules`. It fails against the unpatched build (reproducing the absolute-path emission locally) and passes with this change.
- Full suite green: 14 files, 133 tests passed, no type errors; `oxlint --type-aware` and Prettier clean.
