### PR TITLE
fix: mirror auto-added bundle.css export into publishConfig.exports

### DIFF
--- a/.changeset/bundle-css-publish-config-exports.md
+++ b/.changeset/bundle-css-publish-config-exports.md
@@ -1,0 +1,9 @@
+---
+"@sanity/pkg-utils": patch
+---
+
+fix: mirror the auto-added `bundle.css` export into `publishConfig.exports`
+
+In vanilla-extract compat mode, pkg-utils auto-writes the conditional `"./bundle.css"` export to `package.json`. It only updated the top-level `exports`, so packages that also declare `publishConfig.exports` ended up out of sync, and the next strict `--check` failed with `publishConfig.exports: missing export path "./bundle.css" that exists in exports`.
+
+The conditional CSS export is now mirrored into `publishConfig.exports` as well (when that field exists), keeping the two in sync. The entry is identical in both places since the CSS export has no `source`/`development`/`monorepo` conditions to strip. `publishConfig.exports` is never created when it is absent.

--- a/packages/@sanity/pkg-utils/src/node/core/pkg/writeBundleCssExports.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/pkg/writeBundleCssExports.ts
@@ -1,6 +1,7 @@
 import {readFile, writeFile} from 'node:fs/promises'
 import path from 'node:path'
 import type {Logger} from '../../logger.ts'
+import {isRecord} from '../isRecord.ts'
 
 /**
  * Build the conditional CSS export object that vanilla-extract compat mode expects, e.g.
@@ -26,6 +27,31 @@ function hasMatchingExport(value: unknown, expected: Record<string, string>): bo
   )
 }
 
+/**
+ * Insert (or replace) the `"./<cssName>"` export in an `exports`-shaped map, preserving the existing
+ * order and placing it before `./package.json` when present.
+ */
+function insertCssExport(
+  exports: Record<string, unknown>,
+  exportKey: string,
+  conditionalExport: Record<string, string>,
+): Record<string, unknown> {
+  const nextExports: Record<string, unknown> = {}
+  let inserted = false
+  for (const [key, value] of Object.entries(exports)) {
+    if (key === exportKey) continue
+    if (key === './package.json' && !inserted) {
+      nextExports[exportKey] = conditionalExport
+      inserted = true
+    }
+    nextExports[key] = value
+  }
+  if (!inserted) {
+    nextExports[exportKey] = conditionalExport
+  }
+  return nextExports
+}
+
 function detectIndent(source: string): string | number {
   const match = source.match(/\n([ \t]+)\S/)
   if (!match) return 2
@@ -37,6 +63,11 @@ function detectIndent(source: string): string | number {
  * Write the conditional `"./<cssName>"` export to `package.json` (used by vanilla-extract compat
  * mode), so userland does not have to maintain it by hand. The write is idempotent: if the export
  * already matches, the file is left untouched.
+ *
+ * When `publishConfig.exports` is present, the same conditional CSS export is mirrored into it. The
+ * conditional CSS export has no `source`/`development`/`monorepo` conditions to strip, so the entry
+ * is identical in both places. Keeping them in sync prevents the `publishConfig.exports` validation
+ * from failing with a "missing export path" error for the auto-added `./<cssName>` export.
  *
  * @internal
  */
@@ -51,7 +82,10 @@ export async function writeBundleCssExports(options: {
   const pkgPath = path.resolve(cwd, 'package.json')
   const source = await readFile(pkgPath, 'utf8')
   // oxlint-disable-next-line no-unsafe-type-assertion
-  const pkg = JSON.parse(source) as {exports?: Record<string, unknown>}
+  const pkg = JSON.parse(source) as {
+    exports?: Record<string, unknown>
+    publishConfig?: {exports?: Record<string, unknown>}
+  }
 
   // Normalize to POSIX separators - `path.relative` uses `\\` on Windows, but `exports` paths in
   // package.json must always use `/`.
@@ -61,28 +95,28 @@ export async function writeBundleCssExports(options: {
   const shimFile = `./${path.posix.join(distRel, `${cssName}.js`)}`
   const conditionalExport = createConditionalCssExport(cssFile, shimFile)
 
-  if (hasMatchingExport(pkg.exports?.[exportKey], conditionalExport)) {
+  // Only mirror into `publishConfig.exports` when it already exists; never create it here.
+  const publishConfig = pkg.publishConfig
+  const publishConfigExports = isRecord(publishConfig?.exports) ? publishConfig.exports : undefined
+
+  const exportsMatch = hasMatchingExport(pkg.exports?.[exportKey], conditionalExport)
+  const publishConfigExportsMatch =
+    !publishConfigExports || hasMatchingExport(publishConfigExports[exportKey], conditionalExport)
+
+  if (exportsMatch && publishConfigExportsMatch) {
     return
   }
 
-  // Re-insert the css export (before `./package.json` when present) preserving the existing order.
-  const nextExports: Record<string, unknown> = {}
-  let inserted = false
-  for (const [key, value] of Object.entries(pkg.exports ?? {})) {
-    if (key === exportKey) continue
-    if (key === './package.json' && !inserted) {
-      nextExports[exportKey] = conditionalExport
-      inserted = true
-    }
-    nextExports[key] = value
+  pkg.exports = insertCssExport(pkg.exports ?? {}, exportKey, conditionalExport)
+
+  if (publishConfig && publishConfigExports) {
+    publishConfig.exports = insertCssExport(publishConfigExports, exportKey, conditionalExport)
   }
-  if (!inserted) {
-    nextExports[exportKey] = conditionalExport
-  }
-  pkg.exports = nextExports
 
   await writeFile(pkgPath, `${JSON.stringify(pkg, null, detectIndent(source))}\n`)
   logger.log(
-    `Updated package.json: added \`exports["${exportKey}"]\` for vanilla-extract compat mode`,
+    `Updated package.json: added \`exports["${exportKey}"]\`${
+      publishConfigExports ? ` and \`publishConfig.exports["${exportKey}"]\`` : ''
+    } for vanilla-extract compat mode`,
   )
 }

--- a/packages/@sanity/pkg-utils/test/publishConfigExports.test.ts
+++ b/packages/@sanity/pkg-utils/test/publishConfigExports.test.ts
@@ -3,16 +3,27 @@ import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 import {describe, expect, test} from 'vitest'
 import {loadPkgWithReporting} from '../src/node/core/pkg/loadPkgWithReporting'
+import {writeBundleCssExports} from '../src/node/core/pkg/writeBundleCssExports'
 import {createLogger} from '../src/node/logger'
 
 describe('publishConfig.exports validation', () => {
   const testDir = join(tmpdir(), 'pkg-utils-test-publishconfig')
 
-  async function testPackage(pkg: any, shouldFail: boolean) {
+  async function testPackage(
+    pkg: any,
+    shouldFail: boolean,
+    // Optional hook to mutate the package on disk after it is written but before validation, e.g. to
+    // run `writeBundleCssExports` (which is what a real build does between load and check).
+    beforeValidate?: (cwd: string) => Promise<void>,
+  ) {
     const testPath = join(testDir, Math.random().toString(36).substring(7))
     mkdirSync(testPath, {recursive: true})
     const pkgPath = join(testPath, 'package.json')
     writeFileSync(pkgPath, JSON.stringify(pkg, null, 2))
+
+    if (beforeValidate) {
+      await beforeValidate(testPath)
+    }
 
     const logger = createLogger(true)
 
@@ -308,6 +319,46 @@ describe('publishConfig.exports validation', () => {
         files: ['dist'],
       },
       true,
+    )
+  })
+
+  // Regression test: a vanilla-extract build adds the `./bundle.css` export to `exports` via
+  // `writeBundleCssExports` and then runs the strict `--check`. If the export is not mirrored into
+  // `publishConfig.exports`, the check fails with "missing export path". This asserts the build +
+  // check stays green for packages that declare `publishConfig.exports`.
+  test('should pass after writeBundleCssExports mirrors the css export into publishConfig.exports', async () => {
+    await testPackage(
+      {
+        name: 'test-pkg',
+        version: '1.0.0',
+        license: 'MIT',
+        type: 'module',
+        exports: {
+          '.': {
+            source: './src/index.ts',
+            default: './dist/index.js',
+          },
+          './package.json': './package.json',
+        },
+        publishConfig: {
+          exports: {
+            '.': {
+              default: './dist/index.js',
+            },
+            './package.json': './package.json',
+          },
+        },
+        files: ['dist'],
+      },
+      false,
+      async (cwd) => {
+        await writeBundleCssExports({
+          cwd,
+          distPath: join(cwd, 'dist'),
+          cssName: 'bundle.css',
+          logger: createLogger(true),
+        })
+      },
     )
   })
 })

--- a/packages/@sanity/pkg-utils/test/writeBundleCssExports.test.ts
+++ b/packages/@sanity/pkg-utils/test/writeBundleCssExports.test.ts
@@ -13,7 +13,10 @@ async function setupPackage(pkg: Record<string, unknown>): Promise<string> {
   return cwd
 }
 
-async function readPkg(cwd: string): Promise<{exports: Record<string, unknown>}> {
+async function readPkg(cwd: string): Promise<{
+  exports: Record<string, unknown>
+  publishConfig?: {exports?: Record<string, unknown>}
+}> {
   return JSON.parse(await readFile(path.join(cwd, 'package.json'), 'utf8'))
 }
 
@@ -93,5 +96,166 @@ describe('writeBundleCssExports', () => {
       node: './lib/styles.css.js',
       default: './lib/styles.css.js',
     })
+  })
+
+  test('mirrors the css export into publishConfig.exports when it exists', async () => {
+    const cwd = await setupPackage({
+      name: 'example',
+      version: '1.0.0',
+      exports: {
+        '.': {source: './src/index.ts', default: './dist/index.js'},
+        './package.json': './package.json',
+      },
+      publishConfig: {
+        exports: {
+          '.': {default: './dist/index.js'},
+          './package.json': './package.json',
+        },
+      },
+    })
+
+    await writeBundleCssExports({
+      cwd,
+      distPath: path.join(cwd, 'dist'),
+      cssName: 'bundle.css',
+      logger,
+    })
+
+    const pkg = await readPkg(cwd)
+    const expected = {
+      browser: './dist/bundle.css',
+      style: './dist/bundle.css',
+      node: './dist/bundle.css.js',
+      default: './dist/bundle.css.js',
+    }
+    expect(pkg.exports['./bundle.css']).toEqual(expected)
+    expect(pkg.publishConfig?.exports?.['./bundle.css']).toEqual(expected)
+    // Inserted before `./package.json` in publishConfig.exports too, preserving order.
+    expect(Object.keys(pkg.publishConfig!.exports!)).toEqual([
+      '.',
+      './bundle.css',
+      './package.json',
+    ])
+  })
+
+  test('appends the css export to publishConfig.exports when there is no ./package.json entry', async () => {
+    const cwd = await setupPackage({
+      name: 'example',
+      version: '1.0.0',
+      exports: {
+        '.': {source: './src/index.ts', default: './dist/index.js'},
+      },
+      publishConfig: {
+        exports: {
+          '.': {default: './dist/index.js'},
+        },
+      },
+    })
+
+    await writeBundleCssExports({
+      cwd,
+      distPath: path.join(cwd, 'dist'),
+      cssName: 'bundle.css',
+      logger,
+    })
+
+    const pkg = await readPkg(cwd)
+    expect(Object.keys(pkg.publishConfig!.exports!)).toEqual(['.', './bundle.css'])
+  })
+
+  test('does not create publishConfig.exports when it does not exist', async () => {
+    const cwd = await setupPackage({
+      name: 'example',
+      version: '1.0.0',
+      exports: {
+        '.': {source: './src/index.ts', default: './dist/index.js'},
+      },
+      // publishConfig without an `exports` map should be left alone.
+      publishConfig: {access: 'public'},
+    })
+
+    await writeBundleCssExports({
+      cwd,
+      distPath: path.join(cwd, 'dist'),
+      cssName: 'bundle.css',
+      logger,
+    })
+
+    const pkg = await readPkg(cwd)
+    expect(pkg.exports['./bundle.css']).toBeDefined()
+    expect(pkg.publishConfig?.exports).toBeUndefined()
+  })
+
+  test('adds the css export to publishConfig.exports even when exports already has it', async () => {
+    const cwd = await setupPackage({
+      name: 'example',
+      version: '1.0.0',
+      exports: {
+        '.': {source: './src/index.ts', default: './dist/index.js'},
+        './bundle.css': {
+          browser: './dist/bundle.css',
+          style: './dist/bundle.css',
+          node: './dist/bundle.css.js',
+          default: './dist/bundle.css.js',
+        },
+        './package.json': './package.json',
+      },
+      publishConfig: {
+        exports: {
+          '.': {default: './dist/index.js'},
+          './package.json': './package.json',
+        },
+      },
+    })
+
+    await writeBundleCssExports({
+      cwd,
+      distPath: path.join(cwd, 'dist'),
+      cssName: 'bundle.css',
+      logger,
+    })
+
+    const pkg = await readPkg(cwd)
+    expect(pkg.publishConfig?.exports?.['./bundle.css']).toEqual({
+      browser: './dist/bundle.css',
+      style: './dist/bundle.css',
+      node: './dist/bundle.css.js',
+      default: './dist/bundle.css.js',
+    })
+  })
+
+  test('is idempotent when both exports and publishConfig.exports already match', async () => {
+    const conditionalExport = {
+      browser: './dist/bundle.css',
+      style: './dist/bundle.css',
+      node: './dist/bundle.css.js',
+      default: './dist/bundle.css.js',
+    }
+    const cwd = await setupPackage({
+      name: 'example',
+      version: '1.0.0',
+      exports: {
+        '.': {source: './src/index.ts', default: './dist/index.js'},
+        './bundle.css': conditionalExport,
+        './package.json': './package.json',
+      },
+      publishConfig: {
+        exports: {
+          '.': {default: './dist/index.js'},
+          './bundle.css': conditionalExport,
+          './package.json': './package.json',
+        },
+      },
+    })
+    const before = await readFile(path.join(cwd, 'package.json'), 'utf8')
+
+    await writeBundleCssExports({
+      cwd,
+      distPath: path.join(cwd, 'dist'),
+      cssName: 'bundle.css',
+      logger,
+    })
+
+    expect(await readFile(path.join(cwd, 'package.json'), 'utf8')).toEqual(before)
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In vanilla-extract compat mode, `writeBundleCssExports` auto-writes the conditional `"./bundle.css"` export to `package.json` so userland doesn't have to maintain it by hand. However, it only updated the top-level `exports` field — not `publishConfig.exports`.

For packages that declare `publishConfig.exports` (the recommended setup whenever `exports` uses `source`/`development`/`monorepo` conditions), this leaves the two out of sync. The next strict `--check` then hard-fails with:

```
publishConfig.exports: missing export path "./bundle.css" that exists in exports
```

This is a `process.exit(1)`, so `pkg build --strict --check` (the typical build command) breaks for any package using both vanilla-extract compat mode and `publishConfig.exports`.

## Fix

`writeBundleCssExports` now mirrors the conditional CSS export into `publishConfig.exports` as well — but only when that field already exists (it is never created when absent). The entry is identical in both places because the conditional CSS export has no `source`/`development`/`monorepo` conditions to strip, which is exactly what the `publishConfig.exports` validation expects.

The write stays idempotent: if both `exports` and `publishConfig.exports` already contain a matching entry, the file is left untouched. The insertion logic (place before `./package.json`, preserve order) was extracted into a small helper and reused for both maps.

## Tests

- `writeBundleCssExports.test.ts`: added cases covering mirroring into `publishConfig.exports`, insertion ordering, not creating `publishConfig.exports` when absent, updating `publishConfig.exports` even when `exports` already has the entry, and idempotency when both already match.
- `publishConfigExports.test.ts`: added a regression test that runs `writeBundleCssExports` and then the strict `publishConfig.exports` validation, asserting the build + check stays green. Verified this test fails on the pre-fix code and passes with the fix.

All checks pass locally: full `@sanity/pkg-utils` test suite (incl. the `sanity-plugin-with-vanilla-extract` cli build), lint, typecheck, prettier, and knip.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4949ed3-fa09-436c-a573-ef556550f91d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4949ed3-fa09-436c-a573-ef556550f91d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

