### PR TITLE
fix(pkg-utils): only inject bundle.css import on index entry chunk

### DIFF
--- a/packages/@sanity/pkg-utils/src/node/tasks/rollup/resolveRollupConfig.ts
+++ b/packages/@sanity/pkg-utils/src/node/tasks/rollup/resolveRollupConfig.ts
@@ -360,8 +360,8 @@ export function resolveRollupConfig(
       minifyInternalExports: minify,
       assetFileNames: '[name][extname]',
       ...config?.rollup?.output,
-      // In compat mode, inject the self-referential bundle.css import into entry chunks so userland
-      // does not need to set `rollup.output.intro` themselves. Use `require()` for CommonJS output
+      // In compat mode, inject the self-referential bundle.css import into the `index` entry chunk
+      // so userland does not need to set `rollup.output.intro` themselves. Use `require()` for CommonJS output
       // (a top-level `import` would be invalid in a `.cjs` bundle).
       ...(vanillaExtract.compatMode
         ? {
@@ -378,15 +378,15 @@ export function resolveRollupConfig(
 }
 
 /**
- * Build an `intro` function that prepends `autoImport` to every entry chunk, preserving any
- * user-provided `intro`.
+ * Build an `intro` function that prepends `autoImport` to the `index` entry chunk only,
+ * preserving any user-provided `intro`.
  */
 function composeIntro(
   autoImport: string,
   userIntro: OutputOptions['intro'],
 ): (chunkInfo: RenderedChunk) => Promise<string> {
   return async (chunkInfo) => {
-    const auto = chunkInfo.isEntry ? `${autoImport}\n` : ''
+    const auto = chunkInfo.isEntry && chunkInfo.name === 'index' ? `${autoImport}\n` : ''
     const user =
       typeof userIntro === 'function'
         ? await userIntro(chunkInfo)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In `vanillaExtract` compat mode, the self-referential `import "<pkg>/bundle.css"` (and the CommonJS `require()` equivalent) was injected into the `output.intro` of **every** entry chunk. It should only be added to the `index` entry chunk.

## Fix

`composeIntro` in `resolveRollupConfig.ts` previously gated injection on `chunkInfo.isEntry`. It now also requires `chunkInfo.name === 'index'`, so the bundle.css import is only prepended to the `index` entry chunk. Non-index entry chunks no longer receive the self-referential import.

```12:13:packages/@sanity/pkg-utils/src/node/tasks/rollup/resolveRollupConfig.ts
const auto = chunkInfo.isEntry && chunkInfo.name === 'index' ? `${autoImport}\n` : ''
```

Comments updated to reflect the new behavior.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d6870cb-b60d-4980-a655-7855baac1b6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d6870cb-b60d-4980-a655-7855baac1b6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

