### PR TITLE
fix: emit .d.ts alongside bundle.css shim for dts export checkers

### DIFF
--- a/.changeset/css-shim-dts.md
+++ b/.changeset/css-shim-dts.md
@@ -1,0 +1,5 @@
+---
+'@sanity/pkg-utils': patch
+---
+
+Emit a `<css>.d.ts` declaration alongside the vanilla-extract compat-mode CSS shim, so dts export checkers that resolve a `.d.ts` for every export target don't crash on a missing declaration file.

--- a/packages/@sanity/pkg-utils/src/node/tasks/rollup/bundleCssShim.ts
+++ b/packages/@sanity/pkg-utils/src/node/tasks/rollup/bundleCssShim.ts
@@ -6,6 +6,11 @@ import type {Plugin} from 'rollup'
  * `import "<pkg>/<css>"` resolves to a harmless module in runtimes that cannot import `.css` files,
  * instead of throwing `Error: Unknown file extension ".css"`.
  *
+ * A matching `.d.ts` declaration is emitted next to the shim as well. Both the `browser`/`style`
+ * (`<css>`) and the `node`/`default` (`<css>.js`) conditions of the `./<css>` export resolve their
+ * types to the same `<css>.d.ts` file, so type-aware tooling (e.g. dts export checkers that load a
+ * `.d.ts` for every export target) does not crash on a missing declaration file.
+ *
  * @param options.fileName - The shim file name, e.g. `bundle.css.js`.
  * @internal
  */
@@ -19,6 +24,11 @@ export function bundleCssShim(options: {fileName: string}): Plugin {
         type: 'asset',
         fileName: options.fileName,
         source: `// No-op shim for \`${cssName}\` in runtimes that cannot import \`.css\` files directly.\nexport default ""\n`,
+      })
+      this.emitFile({
+        type: 'asset',
+        fileName: `${cssName}.d.ts`,
+        source: `// Type declarations for \`${cssName}\` and its no-op JS shim.\ndeclare const _default: string\nexport default _default\n`,
       })
     },
   }

--- a/packages/@sanity/pkg-utils/test/bundleCssShim.test.ts
+++ b/packages/@sanity/pkg-utils/test/bundleCssShim.test.ts
@@ -1,0 +1,43 @@
+import {describe, expect, test, vi} from 'vitest'
+import {bundleCssShim} from '../src/node/tasks/rollup/bundleCssShim'
+
+function runGenerateBundle(fileName: string) {
+  const plugin = bundleCssShim({fileName})
+  const emitFile = vi.fn()
+  const generateBundle = plugin.generateBundle
+  if (typeof generateBundle !== 'function') {
+    throw new Error('expected `generateBundle` to be a function')
+  }
+  // The plugin only relies on `this.emitFile`, so a minimal context is sufficient.
+  generateBundle.call({emitFile} as never, {} as never, {} as never, false)
+  return emitFile.mock.calls.map(
+    (call) => call[0] as {type: string; fileName: string; source: string},
+  )
+}
+
+describe('bundleCssShim', () => {
+  test('emits the no-op JS shim', () => {
+    const emitted = runGenerateBundle('bundle.css.js')
+    const shim = emitted.find((file) => file.fileName === 'bundle.css.js')
+    expect(shim).toBeDefined()
+    expect(shim?.type).toBe('asset')
+    expect(shim?.source).toContain('export default ""')
+  })
+
+  test('emits a matching `.d.ts` declaration so dts export checkers do not crash', () => {
+    const emitted = runGenerateBundle('bundle.css.js')
+    const dts = emitted.find((file) => file.fileName === 'bundle.css.d.ts')
+    expect(dts).toBeDefined()
+    expect(dts?.type).toBe('asset')
+    expect(dts?.source).toContain('declare const _default: string')
+    expect(dts?.source).toContain('export default _default')
+  })
+
+  test('respects a custom css name', () => {
+    const emitted = runGenerateBundle('styles.css.js')
+    expect(emitted.map((file) => file.fileName).toSorted()).toEqual([
+      'styles.css.d.ts',
+      'styles.css.js',
+    ])
+  })
+})

--- a/packages/@sanity/pkg-utils/test/cli.test.ts
+++ b/packages/@sanity/pkg-utils/test/cli.test.ts
@@ -518,15 +518,23 @@ describe.skipIf(process.platform === 'win32')('cli', () => {
     const project = await spawnProject('sanity-plugin-with-vanilla-extract')
     await project.run('build')
 
-    const [distChunksColorInput, distIndexJs, distIndexDts, distBundleCss, distBundleCssShim, pkg] =
-      await Promise.all([
-        project.readFile('dist/_chunks-es/ColorInput.js'),
-        project.readFile('dist/index.js'),
-        project.readFile('dist/index.d.ts'),
-        project.readFile('dist/bundle.css'),
-        project.readFile('dist/bundle.css.js'),
-        project.readFile('package.json'),
-      ])
+    const [
+      distChunksColorInput,
+      distIndexJs,
+      distIndexDts,
+      distBundleCss,
+      distBundleCssShim,
+      distBundleCssDts,
+      pkg,
+    ] = await Promise.all([
+      project.readFile('dist/_chunks-es/ColorInput.js'),
+      project.readFile('dist/index.js'),
+      project.readFile('dist/index.d.ts'),
+      project.readFile('dist/bundle.css'),
+      project.readFile('dist/bundle.css.js'),
+      project.readFile('dist/bundle.css.d.ts'),
+      project.readFile('package.json'),
+    ])
 
     // The inline CSS should be extracted to a separate file
     expect(distChunksColorInput).not.toContain('border:')
@@ -537,6 +545,9 @@ describe.skipIf(process.platform === 'win32')('cli', () => {
     expect(distIndexJs).toContain(`import "sanity-plugin-with-vanilla-extract/bundle.css"`)
     // …emits a no-op JS shim for CSS-unaware runtimes
     expect(distBundleCssShim).toContain('export default ""')
+    // …emits a matching `.d.ts` so dts export checkers don't crash on a missing declaration file
+    expect(distBundleCssDts).toContain('declare const _default: string')
+    expect(distBundleCssDts).toContain('export default _default')
     // …and declares the conditional `./bundle.css` export in package.json
     expect(JSON.parse(pkg).exports['./bundle.css']).toEqual({
       browser: './dist/bundle.css',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When a package uses vanilla-extract compat mode, `@sanity/pkg-utils` writes a conditional `./<css>` export to `package.json`:

```json
{
  "browser": "./lib/bundle.css",
  "style": "./lib/bundle.css",
  "node": "./lib/bundle.css.js",
  "default": "./lib/bundle.css.js"
}
```

It emits the extracted CSS (`bundle.css`) and a no-op JS shim (`bundle.css.js`), but no type declaration. Type-aware tooling that resolves a `.d.ts` for every export target then crashes on the missing file. For example, the `sanity` monorepo's dts export checker (which loads a `.d.ts` per export via `ts-morph`) fails with:

```
FileNotFoundError: File not found: .../packages/@sanity/vision/lib/bundle.css.d.ts
```

Both the `browser`/`style` (`bundle.css`) and `node`/`default` (`bundle.css.js`) conditions resolve their types to the same `bundle.css.d.ts`, so a single declaration file covers both.

## Change

`bundleCssShim` now emits a matching `<css>.d.ts` next to the JS shim:

```ts
declare const _default: string
export default _default
```

This mirrors the shim's `export default ""` and gives the CSS export a real declaration file, so dts export checkers no longer crash on a missing `.d.ts`.

## Tests

- New `test/bundleCssShim.test.ts` verifies the plugin emits both the JS shim and the `.d.ts` (including a custom css name).
- Extended the `sanity-plugin-with-vanilla-extract` integration test in `test/cli.test.ts` to assert `dist/bundle.css.d.ts` is produced with the expected contents.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-906f99c7-02f1-4a16-897f-47cadb4299f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-906f99c7-02f1-4a16-897f-47cadb4299f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

