### PR TITLE
fix: make order of paths passed into findCommonDirPath irrelevant

### DIFF
--- a/.changeset/bright-melons-remain.md
+++ b/.changeset/bright-melons-remain.md
@@ -1,0 +1,5 @@
+---
+'@sanity/pkg-utils': patch
+---
+
+fix: order of paths passed into `findCommonDirPath` no longer matters.

--- a/packages/@sanity/pkg-utils/src/node/core/findCommonPath.test.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/findCommonPath.test.ts
@@ -3,6 +3,7 @@ import {findCommonDirPath} from './findCommonPath.ts'
 
 test('should find common parent directory of paths', () => {
   expect(findCommonDirPath(['test/a', 'test/b/a'])).toBe('test')
+  expect(findCommonDirPath(['test/a/b/c', 'test/a/b'])).toBe('test/a')
   expect(findCommonDirPath(['/test/a', '/test/b/a'])).toBe('/test')
   expect(findCommonDirPath(['/test/a/b', '/test/a/b/c'])).toBe('/test/a')
   expect(findCommonDirPath(['/test/a/b/c', '/test/a/b'])).toBe('/test/a')

--- a/packages/@sanity/pkg-utils/src/node/core/findCommonPath.test.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/findCommonPath.test.ts
@@ -5,5 +5,6 @@ test('should find common parent directory of paths', () => {
   expect(findCommonDirPath(['test/a', 'test/b/a'])).toBe('test')
   expect(findCommonDirPath(['/test/a', '/test/b/a'])).toBe('/test')
   expect(findCommonDirPath(['/test/a/b', '/test/a/b/c'])).toBe('/test/a')
+  expect(findCommonDirPath(['/test/a/b/c', '/test/a/b'])).toBe('/test/a')
   expect(findCommonDirPath(['test/a/b', 'test/a/b', 'test/b/c', 'test/b/a'])).toBe('test')
 })

--- a/packages/@sanity/pkg-utils/src/node/core/findCommonPath.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/findCommonPath.ts
@@ -16,14 +16,14 @@ export function findCommonDirPath(filePaths: string[]): string | undefined {
     }
 
     while (dirPath !== ret) {
-      dirPath = path.dirname(dirPath)
-
-      if (dirPath === ret) {
+      if (pathContains(dirPath, ret)) {
+        ret = dirPath
         break
       }
 
-      if (pathContains(dirPath, ret)) {
-        ret = dirPath
+      dirPath = path.dirname(dirPath)
+
+      if (dirPath === ret) {
         break
       }
 


### PR DESCRIPTION
### Description

Order of directories passed into `findCommonPath` matters. This PR attaches a failing test case.

This was super annoying to figure out as I worked in the CLI repo to remove barrel files and export fine-grained modules. Since the `exports` of ` package.json` is passed into `pkg-utils`, which eventually passes the `exports` paths into `findComonPath`, this bug ended up breaking my local CLI builds for what seemed like mysterious reasons.
