### PR TITLE
feat(pkg-utils): enable `transpileTemplateLiterals` for styled-components by default

### DIFF
--- a/.changeset/olive-pandas-sort.md
+++ b/.changeset/olive-pandas-sort.md
@@ -1,0 +1,18 @@
+---
+'@sanity/pkg-utils': minor
+---
+
+Enable `transpileTemplateLiterals` by default in the `babel.styledComponents` transform, so unused styled components can be tree-shaken.
+
+The `pure: true` default has been emitting `/*#__PURE__*/` annotations in front of tagged template expressions, a position no bundler supports (see [rollup#4035](https://github.com/rollup/rollup/issues/4035)), so the annotations were dropped and unused styled components were never tree-shaken - not by pkg-utils itself, and not by the bundlers of apps consuming the published package. Transpiling `` styled.button`...` `` to `styled.button(["..."])` turns the styled component initializer into a plain call expression, which pure annotations are defined for:
+
+```js
+const UsedButton = /*#__PURE__*/ styled.button.withConfig({
+  displayName: "UsedButton",
+  componentId: "sc-1fal5wv-1"
+})(["cursor:pointer;"]);
+```
+
+With this shape, unused styled components are now removed from the build output, and the annotation survives into the published output so app bundlers (rollup, webpack, esbuild, etc) can drop exported styled components that the app never imports.
+
+To restore the previous output, set `babel: {styledComponents: {transpileTemplateLiterals: false}}` in `package.config.ts`.

--- a/packages/@sanity/pkg-utils/src/node/core/config/types.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/config/types.ts
@@ -112,13 +112,19 @@ export interface PkgConfigOptions {
           topLevelImportPaths?: string[]
           /** @defaultValue true */
           ssr?: boolean
-          /** @defaultValue fale */
+          /** @defaultValue false */
           fileName?: boolean
           /** @defaultValue ["index"] */
           meaninglessFileNames?: string[]
           /** @defaultValue true */
           minify?: boolean
-          /** @defaultValue false */
+          /**
+           * Transpiles `styled.button`...`` to `styled.button(["..."])` so that the `pure` option can
+           * annotate a plain call expression, as pure annotations on tagged template expressions aren't
+           * supported by bundlers (https://github.com/rollup/rollup/issues/4035). Without it unused
+           * styled components can't be tree-shaken.
+           * @defaultValue true
+           */
           transpileTemplateLiterals?: boolean
           namespace?: string
           /** @defaultValue true */

--- a/packages/@sanity/pkg-utils/src/node/tasks/rollup/resolveRollupConfig.ts
+++ b/packages/@sanity/pkg-utils/src/node/tasks/rollup/resolveRollupConfig.ts
@@ -210,8 +210,11 @@ export function resolveRollupConfig(
             {
               // Unnecessary, as the way we use styled-components in Sanity is usually by wrapping `@sanity/ui` primitives, not declaring new ones like "const Button = styled.button``"
               fileName: false,
-              // Native template literals take less space than this transpilation
-              transpileTemplateLiterals: false,
+              // Transpile `styled.button`...`` to `styled.button(["..."])` so that the `pure` option below
+              // can annotate a plain call expression. Pure annotations on tagged template expressions are
+              // not supported by any bundler (https://github.com/rollup/rollup/issues/4035), so without
+              // this transpilation unused styled components can't be tree-shaken at all.
+              transpileTemplateLiterals: true,
               // Massively helps dead code elimination and tree-shaking
               pure: true,
               // disabled, as pkg-utils tends to be used for npm publishing, while other tooling, like `sanity dev`, `next dev`, etc are used for testing

--- a/packages/@sanity/pkg-utils/test/__snapshots__/cli.test.ts.snap
+++ b/packages/@sanity/pkg-utils/test/__snapshots__/cli.test.ts.snap
@@ -718,22 +718,22 @@ exports[`cli > should build \`sanity-plugin-with-styled-components\` package > .
 import { c } from "react-compiler-runtime";
 import { Text, Stack } from "@sanity/ui";
 import { styled } from "styled-components";
-const CustomTextInput = styled.input.attrs({
+const CustomTextInput = /* @__PURE__ */ styled.input.attrs({
   type: "color"
 }).withConfig({
   displayName: "CustomTextInput",
   componentId: "sc-11pprad-0"
-})\`cursor:pointer;box-sizing:border-box;background:var(--card-border-color);border:0 solid transparent;border-radius:2px;padding:0;appearance:none;margin:0;height:1.6rem;width:8ch;&:hover{box-shadow:0 0 0 2px \${({
+})(["cursor:pointer;box-sizing:border-box;background:var(--card-border-color);border:0 solid transparent;border-radius:2px;padding:0;appearance:none;margin:0;height:1.6rem;width:8ch;&:hover{box-shadow:0 0 0 2px ", ";}&::-webkit-color-swatch-wrapper{padding:0;}&::-webkit-color-swatch{padding:0;border:0 solid transparent;border-radius:2px;box-shadow:inset 0 0 0 1px ", ";@supports (color:rgb(from white r g b / 20%)){box-shadow:inset 0 0 0 1px rgb(from ", " r g b / 20%);}}&::-moz-color-swatch{padding:0;border:0 solid transparent;border-radius:2px;box-shadow:inset 0 0 0 1px ", ";@supports (color:rgb(from white r g b / 20%)){box-shadow:inset 0 0 0 1px rgb(from ", " r g b / 20%);}}"], ({
   theme
-}) => theme.sanity.color.card.hovered.border};}&::-webkit-color-swatch-wrapper{padding:0;}&::-webkit-color-swatch{padding:0;border:0 solid transparent;border-radius:2px;box-shadow:inset 0 0 0 1px \${({
+}) => theme.sanity.color.card.hovered.border, ({
   theme
-}) => theme.sanity.color.card.enabled.fg};@supports (color:rgb(from white r g b / 20%)){box-shadow:inset 0 0 0 1px rgb(from \${({
+}) => theme.sanity.color.card.enabled.fg, ({
   theme
-}) => theme.sanity.color.card.enabled.fg} r g b / 20%);}}&::-moz-color-swatch{padding:0;border:0 solid transparent;border-radius:2px;box-shadow:inset 0 0 0 1px \${({
+}) => theme.sanity.color.card.enabled.fg, ({
   theme
-}) => theme.sanity.color.card.enabled.fg};@supports (color:rgb(from white r g b / 20%)){box-shadow:inset 0 0 0 1px rgb(from \${({
+}) => theme.sanity.color.card.enabled.fg, ({
   theme
-}) => theme.sanity.color.card.enabled.fg} r g b / 20%);}}\`;
+}) => theme.sanity.color.card.enabled.fg);
 function ColorInput(props) {
   const $ = c(10), t0 = props.schemaType.options?.colorspace ?? "limited-srgb", t1 = props.schemaType.options?.alpha ? "true" : void 0;
   let t2;

--- a/packages/@sanity/pkg-utils/test/cli.test.ts
+++ b/packages/@sanity/pkg-utils/test/cli.test.ts
@@ -525,6 +525,11 @@ describe.skipIf(process.platform === 'win32')('cli', () => {
 
     // The ColorInput component should have babel-plugin-styled-components applied, which adds a static `.withConfig` call
     expect(distChunksColorInput).toContain('.withConfig({')
+    // The tagged template literal is transpiled to a plain call expression with a `/*#__PURE__*/`
+    // annotation, so bundlers can tree-shake unused styled components (pure annotations on tagged
+    // template expressions aren't supported: https://github.com/rollup/rollup/issues/4035)
+    expect(distChunksColorInput).toContain('/* @__PURE__ */ styled.input.attrs({')
+    expect(distChunksColorInput).toContain('})(["')
     // React Compiler adds a `c` function call
     expect(distChunksColorInput).toContain('const $ = c(')
     // The index has a lazy loaded import to the chunk


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Enables `transpileTemplateLiterals: true` by default in the `babel.styledComponents` transform, so unused styled components can actually be tree-shaken.

## Why

The `pure: true` default emits `/*#__PURE__*/` annotations, but for `` styled.button`...` `` declarations the annotation ends up in front of a *tagged template expression* — a position no bundler supports ([rollup#4035](https://github.com/rollup/rollup/issues/4035), [esbuild#3472](https://github.com/evanw/esbuild/issues/3472)). Rollup flags it as `INVALID_ANNOTATION` and strips it, so the annotations never made it into the published output and unused styled components were never removed — neither by pkg-utils' own rollup build nor by the bundlers of apps consuming the package. Verified against `rollup@4.62.2`: with the old defaults an unused styled component's binding is dropped but its `withConfig` call and CSS remain as a side-effect expression.

Transpiling `` styled.button`...` `` to `styled.button(["..."])` turns the initializer into a plain call expression, which the pure annotation convention is defined for:

```js
const UsedButton = /*#__PURE__*/ styled.button.withConfig({
  displayName: "UsedButton",
  componentId: "sc-1fal5wv-1"
})(["cursor:pointer;"]);
```

With this shape (verified via rollup with `treeshake: {preset: 'recommended'}`):

- unused styled components are now fully removed from the build output, and
- the annotation survives the babel → esbuild → rollup pipeline into the published dist (see the updated `sanity-plugin-with-styled-components` snapshot), so app bundlers can drop exported styled components the app never imports.

The array-call form is what `babel-plugin-styled-components` has emitted for ES5 targets for years, and `styled-components` handles it natively at runtime — only the module format changes, not behavior. The output is a few bytes larger per component than a tagged template, which the tree-shaking upside more than offsets.

Opting out restores the previous output: `babel: {styledComponents: {transpileTemplateLiterals: false}}`.

Related: [#2953](https://github.com/sanity-io/pkg-utils/pull/2953) adds the `styledComponents` feature to `@sanity/tsdown-config`, where the same tree-shaking outcome is achieved via `treeshake.manualPureFunctions` since oxc's port doesn't emit pure annotations for (transpiled) tagged templates yet.

## Test plan

- Updated the `sanity-plugin-with-styled-components` snapshot: the `ColorInput` chunk now contains `/* @__PURE__ */ styled.input.attrs({...}).withConfig({...})(["..."])` with interpolations passed as arguments.
- Added explicit assertions in `cli.test.ts` for the pure annotation and the transpiled call form.
- Full `pnpm test` suite passes (183 passed, 15 skipped, no type errors), plus `pnpm typecheck` and `pnpm lint`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e800a4e-9f67-4e77-b856-c895e7091113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e800a4e-9f67-4e77-b856-c895e7091113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

