### PR TITLE
Add `outDir: "${configDir}/dist"` to the `recommended` tsconfig preset

### DIFF
--- a/.changeset/olive-buttons-shine.md
+++ b/.changeset/olive-buttons-shine.md
@@ -1,0 +1,16 @@
+---
+'@sanity/tsconfig': minor
+---
+
+Add `outDir: "${configDir}/dist"` to the `recommended` preset
+
+Since `${configDir}` resolves to the directory of the tsconfig that extends the preset, output always lands in the `dist` folder next to your `package.json`, and it no longer needs to be declared manually:
+
+```diff
+{
+  "extends": "@sanity/tsconfig/strictest",
+-  "compilerOptions": {
+-    "outDir": "${configDir}/dist"
+-  }
+}
+```

--- a/.changeset/olive-buttons-shine.md
+++ b/.changeset/olive-buttons-shine.md
@@ -4,7 +4,7 @@
 
 Add `outDir: "${configDir}/dist"` to the `recommended` preset
 
-Since `${configDir}` resolves to the directory of the tsconfig that extends the preset, output always lands in the `dist` folder next to your `package.json`, and it no longer needs to be declared manually:
+Emitting to `dist` is already the default in `@sanity/pkg-utils` and `tsdown`, but every repo extending these presets had to repeat it in their own tsconfig. Since `${configDir}` resolves to the directory of the tsconfig that extends the preset, output now lands in the `dist` folder next to your `package.json` by default, and the manual declaration can be removed:
 
 ```diff
 {

--- a/css-playground/sanity-css-vanilla-extract-test/tsconfig.settings.json
+++ b/css-playground/sanity-css-vanilla-extract-test/tsconfig.settings.json
@@ -2,7 +2,6 @@
   "extends": "@sanity/tsconfig/strictest",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "dist",
     "jsx": "react-jsx",
     "lib": ["dom", "dom.iterable", "esnext"]
   }

--- a/packages/@sanity/parse-package-json/tsconfig.json
+++ b/packages/@sanity/parse-package-json/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@sanity/tsconfig/strictest",
   "exclude": ["**/dist/**"],
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   }
 }

--- a/packages/@sanity/pkg-utils/tsconfig.settings.json
+++ b/packages/@sanity/pkg-utils/tsconfig.settings.json
@@ -2,7 +2,6 @@
   "extends": "@sanity/tsconfig/strictest",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "./dist",
     "allowImportingTsExtensions": true
   }
 }

--- a/packages/@sanity/tsconfig/README.md
+++ b/packages/@sanity/tsconfig/README.md
@@ -34,6 +34,8 @@ Add to your `tsconfig.json`:
 }
 ```
 
+The preset sets `outDir` to `${configDir}/dist`. Since [`${configDir}`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#the-configdir-template-variable-for-configuration-files) resolves to the directory of the tsconfig that extends the preset, output lands in the `dist` folder next to your `package.json`, matching the defaults of `@sanity/pkg-utils` and `tsdown`. Set your own `outDir` to override it.
+
 ### Strict <kbd><a href="./strict.tsconfig.json">tsconfig.json</a></kbd>
 
 Add to your `tsconfig.json`:

--- a/packages/@sanity/tsconfig/recommended.tsconfig.json
+++ b/packages/@sanity/tsconfig/recommended.tsconfig.json
@@ -13,6 +13,7 @@
     "allowJs": true,
     "noEmit": true,
     "noEmitOnError": true,
+    "outDir": "${configDir}/dist",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/packages/@sanity/tsdown-config/test/fixtures/external-side-effect/tsconfig.dist.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/external-side-effect/tsconfig.dist.json
@@ -2,7 +2,6 @@
   "extends": ["@sanity/tsconfig/strictest", "@sanity/tsconfig/isolated-declarations"],
   "include": ["./src"],
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   }
 }

--- a/packages/@sanity/tsdown-config/test/fixtures/react-19-library/tsconfig.dist.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/react-19-library/tsconfig.dist.json
@@ -2,7 +2,6 @@
   "extends": ["@sanity/tsconfig/strictest", "@sanity/tsconfig/isolated-declarations"],
   "include": ["./src"],
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   }
 }

--- a/packages/@sanity/tsdown-config/test/fixtures/styled-components-library/tsconfig.dist.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/styled-components-library/tsconfig.dist.json
@@ -2,7 +2,6 @@
   "extends": ["@sanity/tsconfig/strictest", "@sanity/tsconfig/isolated-declarations"],
   "include": ["./src"],
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   }
 }

--- a/packages/@sanity/tsdown-config/tsconfig.json
+++ b/packages/@sanity/tsdown-config/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@sanity/tsconfig/strictest",
   "exclude": ["**/dist/**"],
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   }
 }

--- a/playground/external-side-effect/tsconfig.settings.json
+++ b/playground/external-side-effect/tsconfig.settings.json
@@ -1,7 +1,6 @@
 {
   "extends": "@sanity/tsconfig/strictest",
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   }
 }

--- a/playground/multi-exports-commonjs/tsconfig.json
+++ b/playground/multi-exports-commonjs/tsconfig.json
@@ -7,7 +7,6 @@
     },
 
     "rootDir": ".",
-    "outDir": "./dist",
 
     // Strict type-checking
     "strict": true,

--- a/playground/react-18/tsconfig.dist.json
+++ b/playground/react-18/tsconfig.dist.json
@@ -3,7 +3,6 @@
   "include": ["./src"],
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "./dist",
     "emitDeclarationOnly": true
   }
 }

--- a/playground/react-19/tsconfig.dist.json
+++ b/playground/react-19/tsconfig.dist.json
@@ -3,7 +3,6 @@
   "include": ["./src"],
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "./dist",
     "emitDeclarationOnly": true
   }
 }

--- a/playground/sanity-plugin-with-styled-components/tsconfig.settings.json
+++ b/playground/sanity-plugin-with-styled-components/tsconfig.settings.json
@@ -1,7 +1,6 @@
 {
   "extends": "@sanity/tsconfig/strictest",
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   }
 }

--- a/playground/sanity-plugin-with-vanilla-extract/tsconfig.settings.json
+++ b/playground/sanity-plugin-with-vanilla-extract/tsconfig.settings.json
@@ -2,7 +2,6 @@
   "extends": "@sanity/tsconfig/strictest",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "dist",
     "types": ["vite/client"]
   }
 }

--- a/playground/ts-rolldown-bundle-dev-dependency/tsconfig.settings.json
+++ b/playground/ts-rolldown-bundle-dev-dependency/tsconfig.settings.json
@@ -1,7 +1,6 @@
 {
   "extends": "@sanity/tsconfig/strictest",
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   }
 }

--- a/playground/ts-rolldown-bundle-peer-dependency/tsconfig.settings.json
+++ b/playground/ts-rolldown-bundle-peer-dependency/tsconfig.settings.json
@@ -1,7 +1,6 @@
 {
   "extends": "@sanity/tsconfig/strictest",
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   }
 }

--- a/playground/ts-rolldown-bundle-prod-dependency/tsconfig.settings.json
+++ b/playground/ts-rolldown-bundle-prod-dependency/tsconfig.settings.json
@@ -1,7 +1,6 @@
 {
   "extends": "@sanity/tsconfig/strictest",
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   }
 }

--- a/playground/ts-rolldown-external-subpath-import/tsconfig.settings.json
+++ b/playground/ts-rolldown-external-subpath-import/tsconfig.settings.json
@@ -1,7 +1,6 @@
 {
   "extends": "@sanity/tsconfig/strictest",
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   }
 }

--- a/playground/ts-rolldown-inline-types-external-js/tsconfig.settings.json
+++ b/playground/ts-rolldown-inline-types-external-js/tsconfig.settings.json
@@ -1,7 +1,6 @@
 {
   "extends": "@sanity/tsconfig/strictest",
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   }
 }

--- a/playground/ts-rolldown-without-extract/tsconfig.settings.json
+++ b/playground/ts-rolldown-without-extract/tsconfig.settings.json
@@ -1,7 +1,6 @@
 {
   "extends": "@sanity/tsconfig/strictest",
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   }
 }

--- a/playground/ts-rolldown/tsconfig.settings.json
+++ b/playground/ts-rolldown/tsconfig.settings.json
@@ -2,7 +2,6 @@
   "extends": "@sanity/tsconfig/strictest",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "dist",
     "types": ["node"]
   }
 }

--- a/playground/ts-without-extract/tsconfig.settings.json
+++ b/playground/ts-without-extract/tsconfig.settings.json
@@ -1,7 +1,6 @@
 {
   "extends": "@sanity/tsconfig/strictest",
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   }
 }

--- a/playground/ts/tsconfig.settings.json
+++ b/playground/ts/tsconfig.settings.json
@@ -1,7 +1,6 @@
 {
   "extends": "@sanity/tsconfig/strictest",
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   }
 }

--- a/playground/tsgo-disabled/tsconfig.settings.json
+++ b/playground/tsgo-disabled/tsconfig.settings.json
@@ -1,7 +1,6 @@
 {
   "extends": "@sanity/tsconfig/strictest",
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   }
 }

--- a/playground/tsgo/tsconfig.settings.json
+++ b/playground/tsgo/tsconfig.settings.json
@@ -1,7 +1,6 @@
 {
   "extends": "@sanity/tsconfig/strictest",
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Makes `outDir` default to `${configDir}/dist` in `@sanity/tsconfig/recommended` (and therefore also in `strict` and `strictest`, which extend it). Emitting to `dist` is already the default in `@sanity/pkg-utils` and `tsdown`, but every repo extending these presets had to repeat it in their own tsconfig:

```diff
{
  "extends": "@sanity/tsconfig/strictest",
-  "compilerOptions": {
-    "outDir": "${configDir}/dist"
-  }
}
```

Since [`${configDir}`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#the-configdir-template-variable-for-configuration-files) resolves to the directory of the final tsconfig that extends the preset (not the preset's own directory in `node_modules`), output always lands in the `dist` folder next to the consumer's `package.json`. Consumers with a different layout can still override `outDir` as before.

This also means `@sanity/pkg-utils` dts extraction (which errors with ``tsconfig.json is missing `compilerOptions.outDir` `` when unset) works out of the box with the presets.

### What to review

- `packages/@sanity/tsconfig/recommended.tsconfig.json`: the new `outDir` default, grouped with the other emit options (`noEmit`, `noEmitOnError`).
- `packages/@sanity/tsconfig/README.md`: documents the default and how to override it.
- `.changeset/olive-buttons-shine.md`: minor release for `@sanity/tsconfig`.
- Everything else is dogfooding: the redundant `outDir: "dist"` declarations across this repo's packages, playgrounds, and test fixtures are removed, so the monorepo itself now relies on (and continuously exercises) the preset default across the pkg-utils dts pipeline, tsdown, rolldown dts, and tsgo. Configs that don't extend the presets (e.g. `reference-esm`, `custom-dist` with its intentional `lib` output) are untouched.

### Testing

- `pnpm build`, `pnpm exec tsc --build --force`, `pnpm playground:typecheck`, `pnpm playground:build`, `pnpm --filter sanity-css-vanilla-extract-test build`, and `pnpm knip` all pass.
- `pnpm test`: 19 test files passed, 189 tests passed, 15 skipped.
- Spot-checked emitted artifacts: `playground/ts`, `playground/tsgo`, `playground/react-19`, and `playground/multi-exports-commonjs` all emit `js`/`cjs`/`d.ts`/`d.cts` into `./dist` purely via the preset default.

### Notes for release

Documented in the changeset as a `minor` bump for `@sanity/tsconfig`, matching how the `noEmitOnError` default was released in v2.1.0.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f27d9-fa73-7236-9365-089efa3b577b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f27d9-fa73-7236-9365-089efa3b577b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

