### PR TITLE
feat(tsdown-config): expose tsdown's `dts` and `define` options as-is

### DIFF
--- a/.changeset/tsdown-config-dts-define.md
+++ b/.changeset/tsdown-config-dts-define.md
@@ -1,0 +1,27 @@
+---
+"@sanity/tsdown-config": minor
+---
+
+Add `dts` and `define` options, passed through to `tsdown` as-is.
+
+The `dts` option customizes how `.d.ts` files are generated, for example to use `tsgo` for type generation (the same feature as the `tsgo` option in `@sanity/pkg-utils`, requires `@typescript/native-preview` to be installed):
+
+```ts
+import {defineConfig} from '@sanity/tsdown-config'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  dts: {tsgo: true},
+})
+```
+
+The `define` option replaces global identifiers with constant expressions at build time (the same feature as the `define` option in `@sanity/pkg-utils`):
+
+```ts
+import {defineConfig} from '@sanity/tsdown-config'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  define: {'process.env.NODE_ENV': JSON.stringify('production')},
+})
+```

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -109,3 +109,34 @@ consumers by adding it to `sideEffects` in `package.json`:
 Pass an options object instead of `true` to customize (e.g. `minify`, `browserslist`,
 `extract.name`), or set `extract.compatMode: false` to wire up the import, shim, and export
 yourself.
+
+## dts
+
+tsdown's [`dts` option](https://tsdown.dev/options/dts) is passed through as-is. By default tsdown
+auto-detects it from `package.json` (it's enabled when a `types` field or a `types` condition in
+`exports` is present). Pass an object to customize how the `.d.ts` files are generated, for example
+to use [`tsgo`](https://github.com/microsoft/typescript-go) (the same feature as the `tsgo` option
+in `@sanity/pkg-utils`, requires `@typescript/native-preview` to be installed):
+
+```ts
+import {defineConfig} from '@sanity/tsdown-config'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  dts: {tsgo: true},
+})
+```
+
+## define
+
+tsdown's `define` option is also passed through as-is. It replaces global identifiers with constant
+expressions at build time (the same feature as the `define` option in `@sanity/pkg-utils`):
+
+```ts
+import {defineConfig} from '@sanity/tsdown-config'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  define: {'process.env.NODE_ENV': JSON.stringify('production')},
+})
+```

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -43,7 +43,10 @@ export type ReactCompilerOptions = Partial<ReactCompilerPluginOptions>
 /**
  * @public
  */
-export interface PackageOptions extends Pick<UserConfig, 'tsconfig' | 'entry' | 'format'> {
+export interface PackageOptions extends Pick<
+  UserConfig,
+  'tsconfig' | 'entry' | 'format' | 'dts' | 'define'
+> {
   /**
    * @defaultValue 'neutral'
    */
@@ -83,7 +86,9 @@ export interface PackageOptions extends Pick<UserConfig, 'tsconfig' | 'entry' | 
  * @public
  */
 export async function defineConfig(options: PackageOptions = {}): Promise<UserConfig> {
-  const {entry} = options
+  // `dts` and `define` are passed through to tsdown as-is. When left undefined, tsdown keeps its
+  // default behavior (`dts` is auto-detected from `package.json`, `define` replaces nothing).
+  const {entry, dts, define} = options
   const tsconfig = options.tsconfig ?? 'tsconfig.json'
   const platform = options.platform ?? 'neutral'
   const reactCompiler = options.reactCompiler ?? false
@@ -255,6 +260,8 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
   } as const satisfies UserConfig['exports']
 
   return defineTsdownConfig({
+    define,
+    dts,
     entry,
     exports,
     format,

--- a/packages/@sanity/tsdown-config/test/fixtures/react-19-library/tsdown.config.ts
+++ b/packages/@sanity/tsdown-config/test/fixtures/react-19-library/tsdown.config.ts
@@ -1,12 +1,9 @@
 import {defineConfig} from '@sanity/tsdown-config'
 
-// @TODO add support for passing `define` options to `@sanity/tsdown-config`
-export default {
-  ...(await defineConfig({
-    tsconfig: 'tsconfig.dist.json',
-    format: ['esm', 'cjs'],
-    platform: 'neutral',
-    reactCompiler: {target: '19'},
-  })),
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  format: ['esm', 'cjs'],
+  platform: 'neutral',
+  reactCompiler: {target: '19'},
   define: {'process.env.NODE_ENV': JSON.stringify('production')},
-} as any
+})

--- a/packages/@sanity/tsdown-config/test/options.test.ts
+++ b/packages/@sanity/tsdown-config/test/options.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, test} from 'vitest'
+import {defineConfig} from '../src/index.ts'
+
+describe('dts option', () => {
+  test('is undefined by default, so tsdown auto-detects it from package.json', async () => {
+    expect((await defineConfig()).dts).toBeUndefined()
+  })
+
+  test('is passed through to tsdown as-is', async () => {
+    expect((await defineConfig({dts: false})).dts).toBe(false)
+    expect((await defineConfig({dts: true})).dts).toBe(true)
+    expect((await defineConfig({dts: {tsgo: true}})).dts).toEqual({tsgo: true})
+    expect((await defineConfig({dts: {sourcemap: true, oxc: false}})).dts).toEqual({
+      sourcemap: true,
+      oxc: false,
+    })
+  })
+})
+
+describe('define option', () => {
+  test('is undefined by default', async () => {
+    expect((await defineConfig()).define).toBeUndefined()
+  })
+
+  test('is passed through to tsdown as-is', async () => {
+    const define = {'process.env.NODE_ENV': JSON.stringify('production')}
+    expect((await defineConfig({define})).define).toEqual(define)
+  })
+})

--- a/packages/@sanity/tsdown-config/test/react.test.ts
+++ b/packages/@sanity/tsdown-config/test/react.test.ts
@@ -48,4 +48,18 @@ describe('react-19-library', () => {
     expect(distIndexCjs).toContain('require("react/compiler-runtime")')
     expect(distIndexCjs).toContain('react.memo_cache_sentinel')
   })
+
+  test('replaces `define` globals at build time', async () => {
+    const [distIndexJs, distIndexCjs] = await Promise.all([
+      readFile(path.join(fixtureDir, 'dist/index.js'), 'utf-8'),
+      readFile(path.join(fixtureDir, 'dist/index.cjs'), 'utf-8'),
+    ])
+
+    // The fixture sets `define: {'process.env.NODE_ENV': JSON.stringify('production')}`, so the
+    // `process.env.NODE_ENV === 'development'` branch is evaluated and eliminated at build time
+    for (const output of [distIndexJs, distIndexCjs]) {
+      expect(output).not.toContain('process.env.NODE_ENV')
+      expect(output).not.toContain('Foo')
+    }
+  })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `dts` and `define` to `PackageOptions` in `@sanity/tsdown-config`, passed through to tsdown as-is (picked from tsdown's `UserConfig`, so the types and docs are inherited).

- `dts` customizes `.d.ts` generation, e.g. `dts: {tsgo: true}` to generate types with `@typescript/native-preview` — the same feature as the `tsgo` option in `@sanity/pkg-utils`. Left undefined, tsdown keeps auto-detecting it from `package.json`.
- `define` replaces global identifiers with constant expressions at build time — the same feature as the `define` option in `@sanity/pkg-utils`.

## Changes

- `src/index.ts`: `PackageOptions` now extends `Pick<UserConfig, 'tsconfig' | 'entry' | 'format' | 'dts' | 'define'>` and forwards both options to `defineTsdownConfig`.
- The `react-19-library` fixture previously spread a manual `define` on top of the returned config with an `as any` cast and a `@TODO add support for passing define options` comment; it now uses the supported option. The committed fixture dist output is byte-identical.
- New `test/options.test.ts` covers the pass-through (including `dts: {tsgo: true}`) and the undefined defaults; `test/react.test.ts` gains a fixture assertion that `define` replaced `process.env.NODE_ENV` and the dead branch was eliminated.
- README sections and a `minor` changeset for both options.

## Testing

- `pnpm --filter @sanity/tsdown-config typecheck`, root `pnpm typecheck`, and `pnpm lint` pass.
- `vitest run --project '@sanity/tsdown-config'`: 23 tests pass across 5 files.
- Smoke-tested `dts: {tsgo: true}` end-to-end on the react fixture: `rolldown-plugin-dts` picks it up (prints its "The `tsgo` option is experimental" notice and generates the declarations via tsgo).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed2424d8-c042-404a-b2db-16f014fe2a50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed2424d8-c042-404a-b2db-16f014fe2a50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

