### PR TITLE
feat(tsdown-config): enable `transpileTemplateLiterals` for `styledComponents` by default

### DIFF
--- a/.changeset/eighty-jokes-tease.md
+++ b/.changeset/eighty-jokes-tease.md
@@ -1,0 +1,9 @@
+---
+'@sanity/tsdown-config': minor
+---
+
+Enable `transpileTemplateLiterals` by default in the `styledComponents` transform, matching the `@sanity/pkg-utils` default.
+
+Tagged template literals like `` styled.button`...` `` are now transpiled to plain call expressions (`styled.button(["..."])`) in the build output, the same shape `babel: {styledComponents: true}` in `@sanity/pkg-utils` produces. Pure annotations are only defined for plain call expressions, not tagged template expressions (see [rollup#4035](https://github.com/rollup/rollup/issues/4035)), so this shape is a prerequisite for tree-shaking unused styled components. Note that oxc doesn't yet add the `/*#__PURE__*/` annotation to the transpiled call expression itself (it only annotates initializers that are already plain call expressions in the source), so unused styled components aren't dropped yet until that's supported upstream.
+
+To restore the previous output, set `styledComponents: {transpileTemplateLiterals: false}` in `tsdown.config.ts`.

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -24,7 +24,13 @@ export interface StyledComponentsOptions {
   meaninglessFileNames?: string[]
   /** @defaultValue true */
   minify?: boolean
-  /** @defaultValue false */
+  /**
+   * Transpiles `styled.button`...`` to `styled.button(["..."])` so that the `pure` option can
+   * annotate a plain call expression, as pure annotations on tagged template expressions aren't
+   * supported by bundlers (https://github.com/rollup/rollup/issues/4035). Without it unused
+   * styled components can't be tree-shaken.
+   * @defaultValue true
+   */
   transpileTemplateLiterals?: boolean
   namespace?: string
   /** @defaultValue true */
@@ -103,12 +109,17 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
             // `fileName` is unnecessary, as the way we use styled-components in Sanity is usually by wrapping
             // `@sanity/ui` primitives, not declaring new ones like "const Button = styled.button``"
             fileName: false,
-            // Native template literals take less space than this transpilation, and unlike
-            // `babel-plugin-styled-components`, oxc doesn't add a `@__PURE__` annotation to the
-            // transpiled call expression either, so enabling it wouldn't improve tree-shaking
-            transpileTemplateLiterals: false,
-            // Helps dead code elimination and tree-shaking, although oxc only annotates plain call
-            // expressions so far, not tagged template expressions (https://github.com/rollup/rollup/issues/4035)
+            // Transpile `styled.button`...`` to `styled.button(["..."])`, the same output shape as
+            // `babel: {styledComponents: true}` in `@sanity/pkg-utils`. Pure annotations are only
+            // defined for plain call expressions, not tagged template expressions
+            // (https://github.com/rollup/rollup/issues/4035), so this shape is a prerequisite for
+            // tree-shaking unused styled components.
+            transpileTemplateLiterals: true,
+            // Helps dead code elimination and tree-shaking. Note that unlike
+            // `babel-plugin-styled-components`, oxc doesn't yet annotate the call expression
+            // produced by `transpileTemplateLiterals` (it only annotates initializers that are
+            // already plain call expressions in the source), so the annotation is currently
+            // missing from transpiled output until that's supported upstream.
             pure: true,
             // Disabled, as tsdown tends to be used for npm publishing, while other tooling,
             // like `sanity dev`, `next dev`, etc are used for testing

--- a/packages/@sanity/tsdown-config/test/styled-components.test.ts
+++ b/packages/@sanity/tsdown-config/test/styled-components.test.ts
@@ -25,7 +25,7 @@ describe('styledComponents option', () => {
   test('applies the same defaults as `babel: {styledComponents: true}` in @sanity/pkg-utils', async () => {
     expect(getStyledComponentsTransform(await defineConfig({styledComponents: true}))).toEqual({
       fileName: false,
-      transpileTemplateLiterals: false,
+      transpileTemplateLiterals: true,
       pure: true,
       cssProp: false,
     })
@@ -38,7 +38,7 @@ describe('styledComponents option', () => {
       ),
     ).toEqual({
       fileName: true,
-      transpileTemplateLiterals: false,
+      transpileTemplateLiterals: true,
       pure: false,
       cssProp: false,
       namespace: 'my-lib',
@@ -58,8 +58,11 @@ describe('styled-components-library', () => {
       // both are added by the transform just like `babel-plugin-styled-components` does
       expect(output).toContain('displayName: "StyledButton"')
       expect(output).toMatch(/componentId: "sc-/)
-      // The CSS inside the tagged template literal is minified
-      expect(output).toContain('`cursor:pointer;border-radius:2px;padding:0;`')
+      // The tagged template literal is transpiled to a plain call expression (with minified CSS),
+      // the same output shape as `babel: {styledComponents: true}` in `@sanity/pkg-utils`, so pure
+      // annotations can apply to it (they aren't supported on tagged template expressions:
+      // https://github.com/rollup/rollup/issues/4035)
+      expect(output).toContain('(["cursor:pointer;border-radius:2px;padding:0;"])')
     }
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Flips the `transpileTemplateLiterals` default from `false` to `true` in the `styledComponents` transform, matching the `@sanity/pkg-utils` default from #2955.

Tagged template literals like `` styled.button`...` `` are now transpiled to plain call expressions in the build output, the same shape `babel: {styledComponents: true}` in `@sanity/pkg-utils` produces:

```js
const StyledButton = styled.button.withConfig({
  displayName: "StyledButton",
  componentId: "sc-to14at-0"
})(["cursor:pointer;border-radius:2px;padding:0;"]);
```

Pure annotations are only defined for plain call expressions, not tagged template expressions (see [rollup#4035](https://github.com/rollup/rollup/issues/4035)), so this shape is a prerequisite for tree-shaking unused styled components.

One caveat, documented in the code comments and changeset: unlike `babel-plugin-styled-components`, oxc's port doesn't yet add the `/*#__PURE__*/` annotation to the call expression produced by its own `transpileTemplateLiterals` transform ([its `pure` handling](https://github.com/oxc-project/oxc/blob/main/crates/oxc_transformer/src/plugins/styled_components.rs) runs on `enter_variable_declarator`, before the tagged template is transpiled, so it only annotates initializers that are already plain call expressions in the source). Verified against `oxc-transform@0.138.0`: the transpiled output has no pure annotation, so unused styled components aren't dropped yet. Once oxc supports it upstream, the output shape from this change makes the annotation effective, with no further changes needed here.

To restore the previous output, set `styledComponents: {transpileTemplateLiterals: false}` in `tsdown.config.ts`.

Test plan:
- Updated the defaults/merge assertions and the fixture output assertion (tagged template → transpiled call form) in `styled-components.test.ts`
- Full workspace suite passes: 20 test files, 199 tests passed / 15 skipped, no type errors
- `pnpm lint`, `pnpm build`, and package `typecheck` pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c5a92ff-1dc4-40f8-b8f2-ad0e8392eb59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c5a92ff-1dc4-40f8-b8f2-ad0e8392eb59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

