### PR TITLE
feat(tsdown-config): emit shared chunks into `_chunks-*` folders like pkg-utils

### DIFF
--- a/.changeset/tsdown-config-chunk-folders.md
+++ b/.changeset/tsdown-config-chunk-folders.md
@@ -1,0 +1,7 @@
+---
+"@sanity/tsdown-config": minor
+---
+
+Emit shared (non-entry) chunks into `_chunks-es`, `_chunks-cjs` and `_chunks-dts` folders, following the same naming convention as `@sanity/pkg-utils`, instead of placing them at the root of `dist` next to the entries.
+
+A chunk could otherwise take an entry's filename: code shared between two entries forms a chunk that rolldown may name after one of the entries (e.g. `theme`). The JS output deduplicates such filename collisions in favor of the entry, but the d.ts output could resolve them the other way around, handing the entry's `.d.ts` filename to the chunk - which exports everything under minified aliases like `buildTheme as x` - so every named import from that entry failed to type-check with `TS2460` (see [sanity-io/ui#2262](https://github.com/sanity-io/ui/issues/2262)). With chunks emitted into their own folders they can never collide with entry filenames.

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -1,5 +1,10 @@
 import type {PluginOptions as ReactCompilerPluginOptions} from 'babel-plugin-react-compiler'
-import {defineConfig as defineTsdownConfig, type Rolldown, type UserConfig} from 'tsdown'
+import {
+  defineConfig as defineTsdownConfig,
+  type NormalizedFormat,
+  type Rolldown,
+  type UserConfig,
+} from 'tsdown'
 import type {PackageVanillaExtractOptions} from './vanillaExtract.ts'
 
 export type {PackageVanillaExtractOptions}
@@ -83,6 +88,36 @@ export interface PackageOptions extends Pick<
 }
 
 /**
+ * Emits shared (non-entry) chunks into subfolders per output flavor, following the same naming
+ * convention as `@sanity/pkg-utils` (`_chunks-es`, `_chunks-cjs` and `_chunks-dts`), instead of
+ * rolldown's default of placing chunks at the root of the output directory next to the entries.
+ * A chunk can otherwise be named like an entry (e.g. code shared between `index` and `theme`
+ * entries forms a chunk that rolldown also names `theme`): the JS output deduplicates such
+ * filename collisions in favor of the entry, but the d.ts output can resolve them the other way
+ * around, handing `theme.d.ts` to the chunk - which re-exports everything under minified aliases -
+ * so every named import from the `theme` entry fails to type-check with TS2460
+ * (https://github.com/sanity-io/ui/issues/2262).
+ */
+function resolveChunkFileNames(
+  defaultOutputOptions: Rolldown.OutputOptions,
+  format: NormalizedFormat,
+): Rolldown.OutputOptions['chunkFileNames'] {
+  return (chunk) => {
+    // tsdown's default is a `[name]` template string carrying the resolved output extension for
+    // the current format and package type (e.g. `[name].mjs`), so reuse it for the file names
+    const template =
+      (typeof defaultOutputOptions.chunkFileNames === 'function'
+        ? defaultOutputOptions.chunkFileNames(chunk)
+        : defaultOutputOptions.chunkFileNames) ?? '[name].js'
+    // `rolldown-plugin-dts` names d.ts chunks with a `.d` suffix and later rewrites the rendered
+    // JS filename to the matching d.ts extension (e.g. `_chunks-dts/[name].mjs` renders
+    // `_chunks-dts/theme.mjs`, which becomes `_chunks-dts/theme.d.mts`)
+    const folder = chunk.name.endsWith('.d') ? '_chunks-dts' : `_chunks-${format}`
+    return `${folder}/${template}`
+  }
+}
+
+/**
  * @public
  */
 export async function defineConfig(options: PackageOptions = {}): Promise<UserConfig> {
@@ -125,11 +160,16 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
     }),
   } as const satisfies UserConfig['inputOptions']
 
-  const baseOutputOptions = {
-    hoistTransitiveImports: false,
-  } as const satisfies UserConfig['outputOptions']
+  const resolveBaseOutputOptions = (
+    defaultOptions: Rolldown.OutputOptions,
+    outputFormat: NormalizedFormat,
+  ) =>
+    ({
+      hoistTransitiveImports: false,
+      chunkFileNames: resolveChunkFileNames(defaultOptions, outputFormat),
+    }) satisfies Rolldown.OutputOptions
 
-  let outputOptions: UserConfig['outputOptions'] = baseOutputOptions
+  let outputOptions: UserConfig['outputOptions'] = resolveBaseOutputOptions
   let treeshake: UserConfig['treeshake']
   let customExports: ((exportsMap: Record<string, unknown>) => Record<string, unknown>) | undefined
 
@@ -219,8 +259,8 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
       ? `${readPackageName(process.cwd())}/${cssName}`
       : undefined
 
-    outputOptions = (_options, outputFormat, context) => ({
-      ...baseOutputOptions,
+    outputOptions = (defaultOptions, outputFormat, context) => ({
+      ...resolveBaseOutputOptions(defaultOptions, outputFormat),
       // Emit the extracted CSS (and its sourcemap) with a stable name at the root of the tsdown
       // default `outDir` ('dist', not configurable yet) instead of rolldown's default
       // `assets/[name]-[hash][extname]`, so it can back the conditional `./<css>` export.

--- a/packages/@sanity/tsdown-config/test/fixtures/multi-entry-library/package.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/multi-entry-library/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@fixtures/multi-entry-library",
+  "version": "0.0.0-development",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "source": "./src/exports/index.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./theme": {
+      "source": "./src/exports/theme.ts",
+      "import": "./dist/theme.js",
+      "require": "./dist/theme.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.cts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "import": "./dist/index.js",
+        "require": "./dist/index.cjs"
+      },
+      "./theme": {
+        "import": "./dist/theme.js",
+        "require": "./dist/theme.cjs"
+      },
+      "./package.json": "./package.json"
+    }
+  }
+}

--- a/packages/@sanity/tsdown-config/test/fixtures/multi-entry-library/src/exports/index.ts
+++ b/packages/@sanity/tsdown-config/test/fixtures/multi-entry-library/src/exports/index.ts
@@ -1,0 +1,3 @@
+export {buildTheme, type ThemeConfig} from '../theme'
+
+export const VERSION: string = '0.0.0-development'

--- a/packages/@sanity/tsdown-config/test/fixtures/multi-entry-library/src/exports/theme.ts
+++ b/packages/@sanity/tsdown-config/test/fixtures/multi-entry-library/src/exports/theme.ts
@@ -1,0 +1,1 @@
+export * from '../theme'

--- a/packages/@sanity/tsdown-config/test/fixtures/multi-entry-library/src/theme.ts
+++ b/packages/@sanity/tsdown-config/test/fixtures/multi-entry-library/src/theme.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared between the `index` and `theme` entries, mirroring `@sanity/ui`, where code shared
+ * between entries forms a chunk that rolldown also names `theme`, colliding with the `theme`
+ * entry filename (https://github.com/sanity-io/ui/issues/2262).
+ */
+export interface ThemeConfig {
+  scheme?: 'light' | 'dark'
+}
+
+export function buildTheme(config: ThemeConfig = {}): Required<ThemeConfig> {
+  return {scheme: config.scheme ?? 'light'}
+}

--- a/packages/@sanity/tsdown-config/test/fixtures/multi-entry-library/tsconfig.dist.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/multi-entry-library/tsconfig.dist.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["@sanity/tsconfig/strictest", "@sanity/tsconfig/isolated-declarations"],
+  "include": ["./src"],
+  "compilerOptions": {
+    "rootDir": "."
+  }
+}

--- a/packages/@sanity/tsdown-config/test/fixtures/multi-entry-library/tsdown.config.ts
+++ b/packages/@sanity/tsdown-config/test/fixtures/multi-entry-library/tsdown.config.ts
@@ -1,0 +1,10 @@
+import {defineConfig} from '@sanity/tsdown-config'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  format: ['esm', 'cjs'],
+  entry: {
+    index: './src/exports/index.ts',
+    theme: './src/exports/theme.ts',
+  },
+})

--- a/packages/@sanity/tsdown-config/test/multi-entry.test.ts
+++ b/packages/@sanity/tsdown-config/test/multi-entry.test.ts
@@ -1,0 +1,81 @@
+import {readdir, readFile} from 'node:fs/promises'
+import {createRequire} from 'node:module'
+import path from 'node:path'
+import {fileURLToPath, pathToFileURL} from 'node:url'
+import {describe, expect, test} from 'vitest'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const fixtureDir = path.resolve(__dirname, 'fixtures/multi-entry-library')
+
+describe('multi-entry-library', () => {
+  test('emits shared chunks into `_chunks-*` folders, like `@sanity/pkg-utils`', async () => {
+    const topLevel = await readdir(path.join(fixtureDir, 'dist'))
+
+    // Only entry files (and the chunk folders) live at the root of `dist`, so a shared chunk can
+    // never take an entry's filename
+    expect(topLevel.filter((file) => !file.endsWith('.map')).toSorted()).toEqual([
+      '_chunks-cjs',
+      '_chunks-dts',
+      '_chunks-es',
+      'index.cjs',
+      'index.d.cts',
+      'index.d.ts',
+      'index.js',
+      'theme.cjs',
+      'theme.d.cts',
+      'theme.d.ts',
+      'theme.js',
+    ])
+
+    // The code shared between the `index` and `theme` entries forms a chunk that rolldown also
+    // names `theme`, which lands in the format-specific chunk folders
+    const [esChunks, cjsChunks, dtsChunks] = await Promise.all([
+      readdir(path.join(fixtureDir, 'dist/_chunks-es')),
+      readdir(path.join(fixtureDir, 'dist/_chunks-cjs')),
+      readdir(path.join(fixtureDir, 'dist/_chunks-dts')),
+    ])
+    expect(esChunks).toContain('theme.js')
+    expect(cjsChunks).toContain('theme.cjs')
+    expect(dtsChunks).toContain('theme.d.ts')
+    expect(dtsChunks).toContain('theme.d.cts')
+  })
+
+  test('entries reference the shared chunk in the chunk folders', async () => {
+    const [distIndexJs, distThemeJs, distThemeCjs] = await Promise.all([
+      readFile(path.join(fixtureDir, 'dist/index.js'), 'utf-8'),
+      readFile(path.join(fixtureDir, 'dist/theme.js'), 'utf-8'),
+      readFile(path.join(fixtureDir, 'dist/theme.cjs'), 'utf-8'),
+    ])
+
+    expect(distIndexJs).toContain('from "./_chunks-es/theme.js"')
+    expect(distThemeJs).toContain('from "./_chunks-es/theme.js"')
+    expect(distThemeCjs).toContain('require("./_chunks-cjs/theme.cjs")')
+  })
+
+  test('entry d.ts files keep their named exports (sanity-io/ui#2262)', async () => {
+    const [distThemeDts, distThemeDcts] = await Promise.all([
+      readFile(path.join(fixtureDir, 'dist/theme.d.ts'), 'utf-8'),
+      readFile(path.join(fixtureDir, 'dist/theme.d.cts'), 'utf-8'),
+    ])
+
+    // Without the `_chunks-*` folders the shared chunk - which exports everything under minified
+    // aliases like `buildTheme as n` - could win the `theme.d.ts` filename over the `theme` entry,
+    // breaking every named import from the entry with TS2460
+    expect(distThemeDts).toContain('from "./_chunks-dts/theme.js"')
+    expect(distThemeDts).toContain('export { ThemeConfig, buildTheme }')
+    expect(distThemeDts).not.toContain('buildTheme as')
+
+    expect(distThemeDcts).toContain('from "./_chunks-dts/theme.cjs"')
+    expect(distThemeDcts).toContain('export { ThemeConfig, buildTheme }')
+    expect(distThemeDcts).not.toContain('buildTheme as')
+  })
+
+  test('the built entries resolve their chunks at runtime', async () => {
+    const themeEsm = await import(pathToFileURL(path.join(fixtureDir, 'dist/theme.js')).href)
+    expect(themeEsm.buildTheme({scheme: 'dark'})).toEqual({scheme: 'dark'})
+
+    const require = createRequire(import.meta.url)
+    const themeCjs = require(path.join(fixtureDir, 'dist/theme.cjs'))
+    expect(themeCjs.buildTheme({})).toEqual({scheme: 'light'})
+  })
+})

--- a/packages/@sanity/tsdown-config/test/options.test.ts
+++ b/packages/@sanity/tsdown-config/test/options.test.ts
@@ -1,3 +1,4 @@
+import type {NormalizedFormat, Rolldown, UserConfig} from 'tsdown'
 import {describe, expect, test} from 'vitest'
 import {defineConfig} from '../src/index.ts'
 
@@ -25,5 +26,50 @@ describe('define option', () => {
   test('is passed through to tsdown as-is', async () => {
     const define = {'process.env.NODE_ENV': JSON.stringify('production')}
     expect((await defineConfig({define})).define).toEqual(define)
+  })
+})
+
+async function renderChunkFileName(
+  config: UserConfig,
+  defaultChunkFileNames: string,
+  format: NormalizedFormat,
+  chunkName: string,
+) {
+  const {outputOptions} = config
+  if (typeof outputOptions !== 'function') throw new Error('expected outputOptions function')
+
+  const resolved = await outputOptions({chunkFileNames: defaultChunkFileNames}, format, {
+    cjsDts: false,
+  })
+  if (!resolved) throw new Error('expected output options')
+
+  const {chunkFileNames} = resolved
+  if (typeof chunkFileNames !== 'function') throw new Error('expected chunkFileNames function')
+
+  return chunkFileNames({name: chunkName} as Rolldown.PreRenderedChunk)
+}
+
+describe('chunk file names', () => {
+  test('emits shared chunks into `_chunks-*` folders, like `@sanity/pkg-utils`', async () => {
+    const config = await defineConfig()
+
+    // JS chunks are grouped per output format, reusing the `[name]` template with the output
+    // extension that tsdown resolved for the format and package type
+    expect(await renderChunkFileName(config, '[name].mjs', 'es', 'theme')).toBe(
+      '_chunks-es/[name].mjs',
+    )
+    expect(await renderChunkFileName(config, '[name].js', 'cjs', 'theme')).toBe(
+      '_chunks-cjs/[name].js',
+    )
+
+    // `rolldown-plugin-dts` names d.ts chunks with a `.d` suffix and rewrites the rendered JS
+    // filename to the matching d.ts extension (e.g. `_chunks-dts/theme.mjs` becomes
+    // `_chunks-dts/theme.d.mts`)
+    expect(await renderChunkFileName(config, '[name].mjs', 'es', 'theme.d')).toBe(
+      '_chunks-dts/[name].mjs',
+    )
+    expect(await renderChunkFileName(config, '[name].js', 'cjs', 'theme.d')).toBe(
+      '_chunks-dts/[name].js',
+    )
   })
 })

--- a/packages/@sanity/tsdown-config/test/vanilla-extract.test.ts
+++ b/packages/@sanity/tsdown-config/test/vanilla-extract.test.ts
@@ -101,7 +101,16 @@ describe('vanillaExtract option', () => {
     const config = await defineConfig()
 
     expect(getPluginNames(config)).toEqual([])
-    expect(config.outputOptions).toEqual({hoistTransitiveImports: false})
+
+    const {outputOptions} = config
+    if (typeof outputOptions !== 'function') {
+      expect.unreachable('expected `outputOptions` to be a function')
+    }
+    // Without vanilla-extract there's no `assetFileNames`/`intro` wiring, only the base options
+    expect(await outputOptions({}, 'es', {cjsDts: false})).toEqual({
+      hoistTransitiveImports: false,
+      chunkFileNames: expect.any(Function),
+    })
     expect(config.exports).not.toHaveProperty('customExports')
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -837,6 +837,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../../../playground/dummy-side-effects
 
+  packages/@sanity/tsdown-config/test/fixtures/multi-entry-library: {}
+
   packages/@sanity/tsdown-config/test/fixtures/react-19-library:
     devDependencies:
       '@types/react':


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to [sanity-io/ui#2275](https://github.com/sanity-io/ui/pull/2275): `@sanity/tsdown-config` now uses the same chunk naming convention as `@sanity/pkg-utils`, so downstream packages don't need to override `outputOptions.chunkFileNames` themselves.

## Problem

`defineConfig` sets `hash: false`, so tsdown emitted shared (non-entry) chunks as `[name].<ext>` at the root of `dist`, right next to the entries. A chunk can then take an entry's filename: code shared between two entries forms a chunk that rolldown may name after one of the entries (in `@sanity/ui`, the code shared between the `index` and `theme` entries forms a chunk that rolldown also names `theme`). The JS output deduplicates the collision in favor of the entry (`theme.mjs` + `theme2.mjs`), but the d.ts output could resolve it the other way around: the shared chunk — which exports everything under minified aliases like `buildTheme as x` — was written to the entry's `theme.d.ts` filename, so every named import from `@sanity/ui/theme` failed to type-check with `TS2460` ([sanity-io/ui#2262](https://github.com/sanity-io/ui/issues/2262)).

## Fix

`defineConfig` now always resolves `outputOptions` with a `chunkFileNames` function that mirrors the `@sanity/pkg-utils` defaults (`_chunks-[format]` from `resolveRollupConfig`, `_chunks-dts` from `resolveRolldownConfig`):

- JS chunks are grouped per format: `_chunks-es/`, `_chunks-cjs/`
- d.ts chunks (chunk names ending in `.d`, per `rolldown-plugin-dts`) go to `_chunks-dts/`
- tsdown's default `[name].<ext>` template is reused, so the output extensions still follow the package type and format (`.js`/`.mjs`/`.cjs`, `.d.ts`/`.d.mts`/`.d.cts`)

Entries keep their stable top-level filenames, and since chunks now live in their own folders they can never collide with an entry filename. For the `multi-entry-library` fixture (two entries sharing a `theme` module, reproducing the `@sanity/ui` layout):

```
dist/index.js   dist/index.cjs   dist/index.d.ts   dist/index.d.cts
dist/theme.js   dist/theme.cjs   dist/theme.d.ts   dist/theme.d.cts
dist/_chunks-es/theme.js
dist/_chunks-cjs/theme.cjs
dist/_chunks-dts/theme.d.ts   dist/_chunks-dts/theme.d.cts
```

`dist/theme.d.ts` is now the entry facade with proper named exports:

```ts
import { n as buildTheme, t as ThemeConfig } from "./_chunks-dts/theme.js";
export { ThemeConfig, buildTheme };
```

## Tests

- New `multi-entry-library` fixture reproduces the sanity-io/ui#2262 collision: before this change it emitted `theme.js`/`theme2.js` and handed `theme.d.ts` to the aliased chunk; the new `multi-entry.test.ts` asserts the `_chunks-*` layout, that entry d.ts files keep their named exports, and that the built entries resolve their chunks at runtime (ESM + CJS).
- Unit tests in `options.test.ts` pin the folder routing of the `chunkFileNames` function (`_chunks-es`/`_chunks-cjs` for JS, `_chunks-dts` for `.d` chunks).
- Consumer-side verification of the packed fixture tarball, before/after: `tsc` with `moduleResolution: bundler` failed with `TS2460` on `import {buildTheme, type ThemeConfig} from '@fixtures/multi-entry-library/theme'` before, and now passes with both `bundler` and `node16`; runtime smoke tests (`node` ESM + CJS) pass.
- `pnpm test` (209 passed, 15 skipped, no type errors) · `pnpm typecheck` · `pnpm lint` · `pnpm knip` all pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f37ef-4661-70f0-a43d-c25ee52270e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f37ef-4661-70f0-a43d-c25ee52270e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

