### PR TITLE
feat!: remove deprecated `legacyExports` and `ae-forgotten-export` config options

### DIFF
--- a/.changeset/remove-deprecated-config-options.md
+++ b/.changeset/remove-deprecated-config-options.md
@@ -1,0 +1,10 @@
+---
+'@sanity/pkg-utils': major
+---
+
+feat: remove the deprecated `legacyExports` and `extract.rules['ae-forgotten-export']` config options
+
+**BREAKING**: the `legacyExports` and `extract.rules['ae-forgotten-export']` properties are removed from `PkgConfigOptions`. Both stopped doing anything in v7.0.0 and have since been typed `never` with an `@deprecated` notice, so any config that still type-checked cannot be affected — only the tombstone properties themselves are gone. If your `package.config.ts` still mentions them, simply delete those lines:
+
+- `legacyExports` — dual `commonjs`/`esm` packages are expressed through `exports` conditions instead.
+- `extract.rules['ae-forgotten-export']` — obsolete since TypeScript 5.5, the rule is always off ([microsoft/TypeScript#42873](https://github.com/microsoft/TypeScript/issues/42873)).

--- a/packages/@sanity/pkg-utils/src/node/core/config/types.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/config/types.ts
@@ -171,10 +171,6 @@ export interface PkgConfigOptions {
     bundledPackages?: PkgConfigProperty<string[]>
     customTags?: TSDocCustomTag[]
     rules?: {
-      /**
-       * @deprecated as it's no longer needed since TypeScript 5.5 https://github.com/microsoft/TypeScript/issues/42873
-       */
-      'ae-forgotten-export'?: never
       'ae-incompatible-release-tags'?: PkgRuleLevel
       'ae-internal-missing-underscore'?: PkgRuleLevel
       'ae-missing-release-tag'?: PkgRuleLevel
@@ -207,10 +203,6 @@ export interface PkgConfigOptions {
    * Defaults to `"react"`
    */
   jsxImportSource?: string
-  /**
-   * @deprecated no longer supported
-   */
-  legacyExports?: never
   minify?: boolean
   /** @alpha */
   rollup?: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

With a new major of `@sanity/pkg-utils` already in flight (#2978), this removes the only two deprecated members left in the public API — both are `never`-typed tombstone properties on `PkgConfigOptions`:

- `legacyExports` (`@deprecated no longer supported`) — functionality removed in v7.0.0 (#1315)
- `extract.rules['ae-forgotten-export']` (`@deprecated as it's no longer needed since TypeScript 5.5`) — functionality removed in v7.0.0 (#1311); the rule remains hardcoded to `none` in `getExtractMessagesConfig.ts`, only the config type key is dropped

Since both were typed `never`, no config that currently type-checks can be affected: any `package.config.ts` still setting them already fails compilation today. After this change the error message simply becomes TypeScript's standard excess-property error instead of the tombstone's deprecation notice — four majors (v7–v10) feels like plenty of runway for that hint.

The rest of the workspace (`@sanity/parse-package-json`, `@sanity/tsconfig`, `@sanity/tsdown-config`) has no deprecated exports.

## Changes

- Removed the two tombstone properties from `PkgConfigOptions` in `src/node/core/config/types.ts`
- Added a `major` changeset with migration notes

## Verification

- `pnpm build` (includes pkg-utils `check:pkg` self-check)
- `pnpm typecheck`
- `pnpm lint --deny-warnings`
- `pnpm knip`
- `pnpm playground:typecheck`
- `pnpm test` (full suite)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4b73-441d-70fb-aede-072de468af8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4b73-441d-70fb-aede-072de468af8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

