### PR TITLE
fix: remove no-op `hoistTransitiveImports` from tsdown-config

### DIFF
--- a/.changeset/tricky-hoops-repeat.md
+++ b/.changeset/tricky-hoops-repeat.md
@@ -1,0 +1,5 @@
+---
+'@sanity/tsdown-config': patch
+---
+
+Remove `outputOptions.hoistTransitiveImports: false`, the option is not implemented in rolldown and has no effect

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -166,7 +166,6 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
     outputFormat: NormalizedFormat,
   ) =>
     ({
-      hoistTransitiveImports: false,
       chunkFileNames: resolveChunkFileNames(defaultOptions, outputFormat),
     }) satisfies Rolldown.OutputOptions
 

--- a/packages/@sanity/tsdown-config/test/vanilla-extract.test.ts
+++ b/packages/@sanity/tsdown-config/test/vanilla-extract.test.ts
@@ -108,7 +108,6 @@ describe('vanillaExtract option', () => {
     }
     // Without vanilla-extract there's no `assetFileNames`/`intro` wiring, only the base options
     expect(await outputOptions({}, 'es', {cjsDts: false})).toEqual({
-      hoistTransitiveImports: false,
       chunkFileNames: expect.any(Function),
     })
     expect(config.exports).not.toHaveProperty('customExports')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

`outputOptions.hoistTransitiveImports: false` has no function in tsdown: rolldown declares the option in its `OutputOptions` type but documents it as "not implemented yet" (`@hidden`), and it is validated but never passed to the native bindings. Rolldown also never hoists transitive imports in the first place, so the option is a no-op either way.

This removes it from `@sanity/tsdown-config`'s base output options (added in #2344), updates the matching test expectation, and adds a patch changeset.

The `hoistTransitiveImports: false` in `@sanity/pkg-utils`' rollup task is intentionally left alone, since Rollup does implement the option there.

### What to review

- `packages/@sanity/tsdown-config/src/index.ts`: the one-line removal
- `packages/@sanity/tsdown-config/test/vanilla-extract.test.ts`: expectation updated to match

### Testing

- `pnpm build`, `pnpm lint --deny-warnings`, and the full `pnpm test` suite (21 files, 208 tests) pass locally
- Rebuilt the test fixtures with and without the change to confirm the emitted output is byte-identical
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6851a2e0-b12d-4a33-93af-b0fb96b3b1e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6851a2e0-b12d-4a33-93af-b0fb96b3b1e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

