### PR TITLE
docs(tsdown-config): show how to annotate the config when using isolated declarations

### DIFF
--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -128,6 +128,38 @@ export default defineConfig({
 })
 ```
 
+## Isolated declarations
+
+If you're using the [`@sanity/tsconfig/isolated-declarations`](https://github.com/sanity-io/pkg-utils/tree/main/packages/%40sanity/tsconfig#isolated-declarations-tsconfigjson)
+preset — which makes tsdown generate the `.d.ts` files with oxc's fast isolated declarations
+transform — annotate the default export of `tsdown.config.ts` with `satisfies Promise<UserConfig>`:
+
+```ts
+import {defineConfig} from '@sanity/tsdown-config'
+import type {UserConfig} from 'tsdown'
+
+export default defineConfig() satisfies Promise<UserConfig>
+```
+
+Without the annotation, type-checking `tsdown.config.ts` with the `@sanity/tsconfig` presets (they
+enable `declaration`) fails with TS2883 in pnpm projects: the inferred type of the default export
+can only be named through `@sanity/tsdown-config`'s own copy of `tsdown`, which isn't portable.
+`satisfies Promise<UserConfig>` names the type through your own `tsdown` dependency instead.
+
+Keep the `isolated-declarations` preset scoped to the tsconfig that tsdown builds with (e.g. a
+`tsconfig.dist.json` that only includes `./src`). If `isolatedDeclarations` covers
+`tsdown.config.ts` itself, the default export can't be inferred at all (TS9037), and the config has
+to move into an explicitly annotated variable instead:
+
+```ts
+import {defineConfig} from '@sanity/tsdown-config'
+import type {UserConfig} from 'tsdown'
+
+const config: Promise<UserConfig> = defineConfig()
+
+export default config
+```
+
 ## define
 
 tsdown's `define` option is also passed through as-is. It replaces global identifiers with constant


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an "Isolated declarations" section to the `@sanity/tsdown-config` README documenting the recommended `tsdown.config.ts` shape when the [`@sanity/tsconfig/isolated-declarations`](https://github.com/sanity-io/pkg-utils/tree/main/packages/%40sanity/tsconfig#isolated-declarations-tsconfigjson) preset is in play:

```ts
import {defineConfig} from '@sanity/tsdown-config'
import type {UserConfig} from 'tsdown'

export default defineConfig() satisfies Promise<UserConfig>
```

This is the same pattern already used across `sanity-io/plugins` (and the annotated-variable variant in `sanity-io/icons`).

## Why

- Without the annotation, type-checking `tsdown.config.ts` with the `@sanity/tsconfig` presets (which enable `declaration`) fails in pnpm projects with **TS2883** ("The inferred type of 'default' cannot be named without a reference to 'UserConfig' from '.pnpm/tsdown@…'"): the inferred default export type can only be named through `@sanity/tsdown-config`'s own copy of `tsdown`. The `satisfies Promise<UserConfig>` annotation lets TypeScript name the type through the consumer's own `tsdown` dependency instead.
- The section also documents the **TS9037** trap: if `isolatedDeclarations` covers `tsdown.config.ts` itself (instead of staying scoped to the dist tsconfig), a default-exported expression can't be inferred at all — `satisfies` included — so the config must move into an explicitly annotated variable (`const config: Promise<UserConfig> = defineConfig()`), which is documented with a second snippet.

## Verification

Reproduced against the published `@sanity/tsdown-config@0.13.1` in a standalone pnpm package with `@sanity/tsconfig/strictest` covering `tsdown.config.ts`:

- no annotation → TS2883 with both `typescript@6.0.3` and `typescript@7.0.2` (no error with npm's flat `node_modules`, so it's called out as pnpm-specific)
- `satisfies Promise<UserConfig>` → clean type-check, and `tsdown` builds fine
- with `isolatedDeclarations` covering the config file: `satisfies` still errors with TS9037 on TS 5.9.3 / 6.0.3 / 7.0.2 / 7.1.0-dev, while the annotated-variable form type-checks clean

`pnpm prettier --check` passes on the updated README. Docs-only change, so no changeset (matching repo history for README-only updates).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb37e8c8-85b6-4721-9af9-9f7f51aeb694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb37e8c8-85b6-4721-9af9-9f7f51aeb694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

