### PR TITLE
chore(deps): allow immediate Rolldown toolchain updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,11 @@
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {
+      "description": "Update the core Rolldown toolchain without the default release-age delay",
+      "matchPackageNames": ["tsdown", "rolldown", "rolldown-plugin-dts"],
+      "minimumReleaseAge": null
+    },
+    {
       "description": "Dependency updates to other package jsons than the root should always use the chore scope as they aren't published to npm",
       "matchFileNames": ["playground/**/package.json"],
       "semanticCommitType": "chore",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,10 +52,11 @@ minimumReleaseAgeExclude:
   # shipped, so the supply-chain release-age delay does not apply; pin the latest to keep the
   # cross-framework matrix building against current releases.
   - '@astrojs/react'
-  # TypeScript 7 (the Go-native compiler) and the toolchain releases that add support for it,
-  # including the yuku AST toolchain that rolldown-plugin-dts 0.27 replaced babel with.
+  # TypeScript 7 (the Go-native compiler) and related toolchain releases that need to be
+  # consumed immediately, including the yuku AST toolchain used by rolldown-plugin-dts.
   - typescript
   - tsdown
+  - rolldown
   - rolldown-plugin-dts
   - yuku-ast
   - yuku-parser


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- exempt `rolldown` from pnpm's three-day minimum release age, alongside the existing `tsdown` and `rolldown-plugin-dts` exemptions
- disable Renovate's release-age delay for `tsdown`, `rolldown`, and `rolldown-plugin-dts`

## Testing
- `renovate-config-validator --strict`
- `pnpm config get minimumReleaseAgeExclude`
- Prettier check for `.github/renovate.json` and `pnpm-workspace.yaml`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3194d994-5993-4761-b8be-2918a93526c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3194d994-5993-4761-b8be-2918a93526c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

