### PR TITLE
fix(tsdown-config): stop pinning the tsdown peer to an exact version

### DIFF
--- a/.changeset/relax-tsdown-peer-range.md
+++ b/.changeset/relax-tsdown-peer-range.md
@@ -1,0 +1,5 @@
+---
+'@sanity/tsdown-config': patch
+---
+
+Relax the `tsdown` peer dependency from an exact pin (`0.22.5`) to a range (`^0.22.5`), so newer `tsdown` patch releases like `0.22.7` no longer trigger unresolved peer dependency warnings on install.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,11 +31,7 @@
       "semanticCommitType": "fix"
     },
     {
-      "matchDepTypes": ["peerDependencies"],
-      "matchPackageNames": ["tsdown"],
-      "rangeStrategy": "bump"
-    },
-    {
+      "description": "Never narrow the tsdown peer range: the shared preset widens peerDependencies, so in-range releases leave the range untouched instead of pinning consumers to an exact version",
       "matchDepTypes": ["peerDependencies"],
       "matchPackageNames": ["tsdown"],
       "matchUpdateTypes": ["major"],

--- a/packages/@sanity/tsdown-config/package.json
+++ b/packages/@sanity/tsdown-config/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "babel-plugin-react-compiler": "*",
-    "tsdown": "0.22.5",
+    "tsdown": "^0.22.5",
     "typescript": "6.x || 7.x"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`@sanity/tsdown-config@0.14.0` declares `tsdown: "0.22.5"` (an exact pin) as a peer dependency, so installing tsdown `0.22.7` next to it logs an unresolved peer warning — as reported for both this repo and downstream plugin repos.

## Root cause

The pin was never a deliberate choice — it's the result of two interacting changes:

- #2828 intentionally kept the peer range at `0.22.x` and scoped the renovate `rangeStrategy: "bump"` rule for tsdown peers to `matchUpdateTypes: ["major"]`.
- #2835 fixed the resulting "packageRules cannot combine both matchUpdateTypes and rangeStrategy" config error by splitting the rule — but the split left an **unconditional** `bump` rule for tsdown peers, silently reverting the intent of #2828.

Since then renovate has been narrowing the peer on every tsdown release: `0.22.x` → `0.22.3` (#2987) → `0.22.5` (#3015), and the pending `renovate/tsdown-0.x` branch pins `0.22.7`.

## Fix

- Relax the peer to `tsdown: "^0.22.5"`. `0.22.5` is the honest floor: it's the first tsdown release with TypeScript 7 support, matching this package's `typescript: "6.x || 7.x"` peer, and it's consistent with the peer range `@sanity/vanilla-extract-tsdown-plugin` already uses.
- Remove the unconditional `bump` packageRule so the shared `sanity-io/renovate-config:strategy` preset (which sets `rangeStrategy: "widen"` for all `peerDependencies`) applies again. In-range tsdown releases now leave the peer range untouched instead of pinning it; the `matchUpdateTypes: ["major"]` + `semanticCommitType: "fix"` rule is kept (with a description) so out-of-range updates still cut a release.
- Add a patch changeset for `@sanity/tsdown-config`.

Audited the other published packages: `@sanity/vanilla-extract-tsdown-plugin` (`tsdown: "^0.22.5"`) and `@sanity/pkg-utils` (`babel-plugin-react-compiler: "*"`, `typescript: "6.x || 7.x"`) already use ranges; playground/fixture packages are private.

## Verification

- `pnpm install` — lockfile unchanged, no peer warnings
- `pnpm build` — all 5 packages build
- `pnpm --filter @sanity/tsdown-config test` — 51 tests pass
- `pnpm --filter @sanity/vanilla-extract-tsdown-plugin test` — 23 tests pass
- `renovate-config-validator .github/renovate.json` — config validates successfully
- `prettier --check` on the changed files passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5fc9-dc7a-770c-864d-830f9e423953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5fc9-dc7a-770c-864d-830f9e423953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

