### PR TITLE
feat(tsdown-config): expose sourcemap and deps so monorepos can drop mergeConfig

### DIFF
--- a/.changeset/expose-tsdown-config-options.md
+++ b/.changeset/expose-tsdown-config-options.md
@@ -1,0 +1,5 @@
+---
+'@sanity/tsdown-config': minor
+---
+
+Expose tsdown's `sourcemap` and `deps` options on `PackageOptions`, default `sourcemap` to `true` (matching `@sanity/pkg-utils`), and when `platform` is `'neutral'` mark `node:` built-ins external and restore `module`/`main` resolve fallbacks so monorepo wrappers no longer need `mergeConfig` for those

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -178,6 +178,43 @@ export default defineConfig({
 })
 ```
 
+## sourcemap
+
+tsdown's [`sourcemap` option](https://tsdown.dev/options/output#sourcemap) is forwarded with a
+`true` default (the same as `@sanity/pkg-utils`). tsdown itself defaults to `false` and does not
+read `sourceMap` from the tsconfig:
+
+```ts
+import {defineConfig} from '@sanity/tsdown-config'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  sourcemap: false,
+})
+```
+
+## deps
+
+tsdown's [`deps` option](https://tsdown.dev/options/dependencies) is forwarded. When `platform` is
+`'neutral'` (the default), `neverBundle` always includes `/^node:/` so node built-ins stay
+external, and userland `neverBundle` entries are appended rather than replacing that default
+(tsdown's `mergeConfig` would replace the array):
+
+```ts
+import {defineConfig} from '@sanity/tsdown-config'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  // Resulting neverBundle: [/^node:/, /^my-package(\/|$)/]
+  deps: {neverBundle: [/^my-package(\/|$)/]},
+})
+```
+
+`'neutral'` also restores `inputOptions.resolve.mainFields: ['module', 'main']` for inlined
+dependencies that ship no `exports` map. Prefer it over `'node'` for packages that also run in
+the browser - `'node'` makes CommonJS-interop emit a module-scope
+`createRequire(import.meta.url)` for inlined CJS deps, which crashes browser-bundled consumers.
+
 ## target
 
 tsdown's [`target` option](https://tsdown.dev/options/target) is also passed through as-is. It

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -64,6 +64,15 @@ export interface PackageOptions extends Pick<
 > {
   /**
    * @defaultValue 'neutral'
+   *
+   * When left at `'neutral'` (the default), two resolution tweaks compensate for rolldown's
+   * strict neutral defaults: `deps.neverBundle` includes `/^node:/` (node built-ins stay external
+   * so neutral does not warn about them as unresolvable; only node runtimes execute those code
+   * paths), and `inputOptions.resolve.mainFields` falls back to `['module', 'main']` for inlined
+   * dependencies that ship no `exports` map (e.g. `rxjs-etc/operators`). Prefer `'neutral'` over
+   * `'node'` for packages that also run in the browser - `'node'` makes CommonJS-interop emit a
+   * module-scope `createRequire(import.meta.url)` for inlined CJS deps, which crashes
+   * browser-bundled consumers.
    */
   platform?: UserConfig['platform']
   /**
@@ -81,6 +90,19 @@ export interface PackageOptions extends Pick<
    * `{enabled: 'local-only'}` otherwise.
    */
   exports?: UserConfig['exports']
+  /**
+   * Whether to generate source map files. The same default as the `sourcemap` option in
+   * `@sanity/pkg-utils` - tsdown itself defaults to `false` and does not read `sourceMap` from
+   * the tsconfig.
+   * @defaultValue true
+   */
+  sourcemap?: UserConfig['sourcemap']
+  /**
+   * tsdown's `deps` option. When `platform` is `'neutral'` (the default), `neverBundle` always
+   * includes `/^node:/` and userland `neverBundle` entries are appended (tsdown's `mergeConfig`
+   * would replace the array). Other `deps` fields pass through as-is.
+   */
+  deps?: UserConfig['deps']
   /**
    * Runs `babel-plugin-react-compiler` on the source files before they are bundled, so published
    * components are memoized automatically. Pass `true` to use the defaults, or an options object
@@ -122,15 +144,21 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
   // syntax downleveling).
   const {entry, tsconfig, dts, define, target} = options
   const platform = options.platform ?? 'neutral'
+  const sourcemap = options.sourcemap ?? true
   const reactCompiler = options.reactCompiler ?? false
   const styledComponents = options.styledComponents ?? false
   const report = {gzip: false} as const satisfies UserConfig['report']
   const publint = true
   const format = options.format ?? 'esm'
+  // When `platform` is `'neutral'`, restore the conventional `module`/`main` fallback that
+  // rolldown's strict neutral defaults drop - needed for inlined deps without an `exports` map.
   const inputOptions = {
     // https://github.com/rolldown/rolldown/blob/main/packages/rolldown/src/options/docs/preserve-entry-signatures.md#strict
     preserveEntrySignatures: 'strict',
     experimental: {attachDebugInfo: 'none'},
+    ...(platform === 'neutral' && {
+      resolve: {mainFields: ['module', 'main']},
+    }),
     ...(styledComponents !== false && {
       transform: {
         plugins: {
@@ -154,7 +182,32 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
         },
       },
     }),
-  } as const satisfies UserConfig['inputOptions']
+  } satisfies UserConfig['inputOptions']
+
+  // `neverBundle` is concatenated (not `mergeConfig`'d) so per-package externals add to the
+  // `/^node:/` default for `platform: 'neutral'` instead of replacing it. Rolldown's
+  // `ExternalOption` array form is `Array<string | RegExp>` only; a function override is composed.
+  const userNeverBundle = options.deps?.neverBundle
+  const nodeBuiltinExternal = platform === 'neutral' ? /^node:/ : undefined
+  const neverBundle: NonNullable<UserConfig['deps']>['neverBundle'] =
+    userNeverBundle == null
+      ? nodeBuiltinExternal && [nodeBuiltinExternal]
+      : nodeBuiltinExternal == null
+        ? userNeverBundle
+        : typeof userNeverBundle === 'function'
+          ? (id, importer, isResolved) =>
+              nodeBuiltinExternal.test(id) || userNeverBundle(id, importer, isResolved)
+          : [
+              nodeBuiltinExternal,
+              ...(Array.isArray(userNeverBundle) ? userNeverBundle : [userNeverBundle]),
+            ]
+  const deps: UserConfig['deps'] =
+    options.deps === undefined && neverBundle === undefined
+      ? undefined
+      : {
+          ...options.deps,
+          ...(neverBundle === undefined ? {} : {neverBundle}),
+        }
 
   // `outputOptions` is left to tsdown's defaults - notably chunk filenames keep tsdown's hashed
   // default (unless userland sets `hash`), which prevents chunk/entry filename collisions
@@ -213,6 +266,7 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
 
   return defineTsdownConfig({
     define,
+    deps,
     dts,
     entry,
     exports,
@@ -222,6 +276,7 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
     plugins,
     publint,
     report,
+    sourcemap,
     target,
     tsconfig,
     minify: {compress: true, codegen: false, mangle: false},

--- a/packages/@sanity/tsdown-config/test/options.test.ts
+++ b/packages/@sanity/tsdown-config/test/options.test.ts
@@ -56,6 +56,66 @@ describe('tsconfig option', () => {
   })
 })
 
+describe('sourcemap option', () => {
+  test('defaults to true, matching @sanity/pkg-utils', async () => {
+    // tsdown itself defaults to false and does not read `sourceMap` from the tsconfig
+    expect((await defineConfig()).sourcemap).toBe(true)
+  })
+
+  test('is passed through to tsdown as-is', async () => {
+    expect((await defineConfig({sourcemap: false})).sourcemap).toBe(false)
+    expect((await defineConfig({sourcemap: 'inline'})).sourcemap).toBe('inline')
+  })
+})
+
+describe('deps option', () => {
+  test('defaults to neverBundle `/^node:/` when platform is neutral', async () => {
+    expect((await defineConfig()).deps).toEqual({neverBundle: [/^node:/]})
+    expect((await defineConfig({platform: 'neutral'})).deps).toEqual({neverBundle: [/^node:/]})
+  })
+
+  test('does not add `/^node:/` when platform is not neutral', async () => {
+    expect((await defineConfig({platform: 'node'})).deps).toBeUndefined()
+    expect(
+      (await defineConfig({platform: 'node', deps: {skipNodeModulesBundle: true}})).deps,
+    ).toEqual({skipNodeModulesBundle: true})
+  })
+
+  test('appends userland neverBundle entries to the `/^node:/` default', async () => {
+    // tsdown's `mergeConfig` would replace the array; concatenate so per-package externals
+    // (e.g. self-references like `/^sanity(\\/|$)/`) add to the node builtins instead
+    expect(
+      (await defineConfig({deps: {neverBundle: [/^sanity(\/|$)/]}})).deps,
+    ).toEqual({neverBundle: [/^node:/, /^sanity(\/|$)/]})
+    expect(
+      (
+        await defineConfig({
+          deps: {neverBundle: [/^sanity(\/|$)/], skipNodeModulesBundle: true},
+        })
+      ).deps,
+    ).toEqual({
+      neverBundle: [/^node:/, /^sanity(\/|$)/],
+      skipNodeModulesBundle: true,
+    })
+  })
+})
+
+describe('neutral platform resolution', () => {
+  test('restores module/main mainFields for inlined deps without an exports map', async () => {
+    const {inputOptions} = await defineConfig()
+    expect(inputOptions && typeof inputOptions !== 'function' && inputOptions.resolve).toEqual({
+      mainFields: ['module', 'main'],
+    })
+  })
+
+  test('leaves mainFields alone when platform is not neutral', async () => {
+    const {inputOptions} = await defineConfig({platform: 'node'})
+    expect(
+      inputOptions && typeof inputOptions !== 'function' ? inputOptions.resolve : undefined,
+    ).toBeUndefined()
+  })
+})
+
 describe('unexposed options', () => {
   test('lean on tsdown defaults, customizable in userland through `mergeConfig`', async () => {
     // Options not in `PackageOptions` (e.g. `hash`, with its collision-preventing hashed chunk

--- a/packages/@sanity/tsdown-config/test/options.test.ts
+++ b/packages/@sanity/tsdown-config/test/options.test.ts
@@ -98,6 +98,24 @@ describe('deps option', () => {
       skipNodeModulesBundle: true,
     })
   })
+
+  test('composes a userland neverBundle function with the `/^node:/` default', async () => {
+    // Rolldown's ExternalOption array form is string|RegExp only, so a function override is
+    // OR'd with the node builtin check instead of being pushed into an array
+    const neverBundle = (
+      await defineConfig({
+        deps: {
+          neverBundle: (id) => id === 'sanity/_singletons' || id.startsWith('sanity/'),
+        },
+      })
+    ).deps?.neverBundle
+    expect(typeof neverBundle).toBe('function')
+    if (typeof neverBundle !== 'function') throw new Error('expected a function')
+
+    expect(neverBundle('node:fs', undefined, false)).toBe(true)
+    expect(neverBundle('sanity/_singletons', undefined, false)).toBe(true)
+    expect(neverBundle('lodash', undefined, false)).toBe(false)
+  })
 })
 
 describe('neutral platform resolution', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Exposes the options the Sanity monorepo wrapper was reaching for via `mergeConfig` ([`@repo/tsdown.config`](https://github.com/sanity-io/sanity/blob/cursor/replace-pkg-utils-with-tsdown-97c2/packages/@repo/tsdown.config/src/index.ts)), and bakes the `platform: 'neutral'` resolution tweaks into `@sanity/tsdown-config` itself:

- **`sourcemap`** — forwarded, default `true` (same as `@sanity/pkg-utils`; tsdown defaults to `false` and ignores tsconfig `sourceMap`)
- **`deps`** — forwarded; with `platform: 'neutral'`, `neverBundle` always includes `/^node:/`, and userland entries are **appended** (tsdown's `mergeConfig` would replace the array)
- **`inputOptions.resolve.mainFields: ['module', 'main']`** — set automatically for `platform: 'neutral'` so inlined deps without an `exports` map still resolve

With this, the monorepo wrapper can become a thin pass-through (no `mergeConfig`):

```ts
export async function defineConfig(options: PackageOptions = {}) {
  return defineTsdownConfig({
    tsconfig: 'tsconfig.lib.json',
    dts: {tsgo: true},
    exports: {devExports: 'monorepo', bin: false},
    ...options,
    define: {__DEV__: 'false', ...options.define},
  })
}
```

And packages like `sanity` can keep self-references external with:

```ts
deps: {neverBundle: [/^sanity(\/|$)/]}
// → neverBundle: [/^node:/, /^sanity(\/|$)/]
```

### Testing

- Unit coverage in `options.test.ts` for sourcemap defaults, deps neverBundle append semantics, and neutral `mainFields`
- `tsc --noEmit -p tsconfig.dist.json` and oxlint clean for the changed source
- Fixture integration builds need the package `.ts` source loader (`unrun`/tsx) available in the environment; those failures look environmental and unrelated to this change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6305-75d2-7955-ba6d-ffeda70feea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6305-75d2-7955-ba6d-ffeda70feea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

