### PR TITLE
feat(tsdown-config): expose outDir option

### DIFF
--- a/.changeset/expose-outdir-tsdown-config.md
+++ b/.changeset/expose-outdir-tsdown-config.md
@@ -1,0 +1,5 @@
+---
+'@sanity/tsdown-config': minor
+---
+
+Expose tsdown's `outDir` option on `PackageOptions` so packages can write to a non-`dist` directory without `mergeConfig`

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -132,6 +132,20 @@ export default defineConfig({
 })
 ```
 
+## outDir
+
+tsdown's [`outDir` option](https://tsdown.dev/options/output#outdir) is passed through as-is.
+When left undefined, tsdown writes to `dist` (the same default as `@sanity/pkg-utils`):
+
+```ts
+import {defineConfig} from '@sanity/tsdown-config'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  outDir: 'lib',
+})
+```
+
 ## Isolated declarations
 
 If you're using the [`@sanity/tsconfig/isolated-declarations`](https://github.com/sanity-io/pkg-utils/tree/main/packages/%40sanity/tsconfig#isolated-declarations-tsconfigjson)

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -60,7 +60,7 @@ export type ReactCompilerOptions = Partial<ReactCompilerPluginOptions>
  */
 export interface PackageOptions extends Pick<
   UserConfig,
-  'tsconfig' | 'entry' | 'format' | 'dts' | 'define' | 'target'
+  'tsconfig' | 'entry' | 'format' | 'dts' | 'define' | 'target' | 'outDir'
 > {
   /**
    * @defaultValue 'neutral'
@@ -138,11 +138,11 @@ export interface PackageOptions extends Pick<
  * @public
  */
 export async function defineConfig(options: PackageOptions = {}): Promise<UserConfig> {
-  // `tsconfig`, `entry`, `dts`, `define` and `target` are passed through to tsdown as-is. When
-  // left undefined, tsdown keeps its default behavior (`tsconfig` is auto-detected from the
-  // project, `dts` from `package.json`, `define` replaces nothing, and `target` applies no
-  // syntax downleveling).
-  const {entry, tsconfig, dts, define, target} = options
+  // `tsconfig`, `entry`, `dts`, `define`, `target` and `outDir` are passed through to tsdown
+  // as-is. When left undefined, tsdown keeps its default behavior (`tsconfig` is auto-detected
+  // from the project, `dts` from `package.json`, `define` replaces nothing, `target` applies no
+  // syntax downleveling, and `outDir` defaults to `'dist'`).
+  const {entry, tsconfig, dts, define, target, outDir} = options
   const platform = options.platform ?? 'neutral'
   const sourcemap = options.sourcemap ?? true
   const reactCompiler = options.reactCompiler ?? false
@@ -272,6 +272,7 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
     exports,
     format,
     inputOptions,
+    outDir,
     platform,
     plugins,
     publint,

--- a/packages/@sanity/tsdown-config/test/options.test.ts
+++ b/packages/@sanity/tsdown-config/test/options.test.ts
@@ -56,6 +56,16 @@ describe('tsconfig option', () => {
   })
 })
 
+describe('outDir option', () => {
+  test('is undefined by default, so tsdown writes to dist', async () => {
+    expect((await defineConfig()).outDir).toBeUndefined()
+  })
+
+  test('is passed through to tsdown as-is', async () => {
+    expect((await defineConfig({outDir: 'lib'})).outDir).toBe('lib')
+  })
+})
+
 describe('sourcemap option', () => {
   test('defaults to true, matching @sanity/pkg-utils', async () => {
     // tsdown itself defaults to false and does not read `sourceMap` from the tsconfig


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Expose tsdown's `outDir` on `@sanity/tsdown-config`'s `PackageOptions`, matching the existing pass-through for `tsconfig`, `dts`, `define`, and `target`.

Packages that write somewhere other than `dist` (e.g. `lib`) can set `outDir` directly instead of wrapping with `mergeConfig`.

When left undefined, tsdown still defaults to `dist`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e2b372c-9724-4dfd-b679-279ba81a6177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e2b372c-9724-4dfd-b679-279ba81a6177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

