### PR TITLE
feat: add Vanilla Extract performance benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ screenshots
 .tanstack
 .vinxi
 build
+
+# Local performance benchmark artifacts
+benchmarks/vanilla-extract/.generated
+benchmarks/vanilla-extract/results

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,10 @@ pnpm --filter @benchmarks/vanilla-extract install-browser # once, for the HMR su
 pnpm benchmark:vanilla-extract
 ```
 
-Run it on an idle machine on Node 24 and update all result tables — library build and Vite build
-variants (baseline/minify/target/minify+target), dev HMR, hook-filter stress timings, and the
-hook-entry diagnostic (also written to `benchmarks/vanilla-extract/results/vite-hook-counts.json`).
+Run it on an idle machine on Node 24 and update all result tables — the library-build variant
+matrix (baseline/minify/target/minify+target), the Vite build baseline, dev HMR, hook-filter
+stress timings, and the hook-entry diagnostic (also written to
+`benchmarks/vanilla-extract/results/vite-hook-counts.json`).
 `pnpm --filter @benchmarks/vanilla-extract smoke` validates every build configuration first
 without collecting timings. See `benchmarks/vanilla-extract/README.md` for fixture-size and
 sample-count overrides.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,30 @@ or pnpm/deno/bun are "command not found"), run `nvm use 24` (or open a fresh log
 for that session — `nvm`'s "current" version is sticky per-shell once explicitly set and won't
 retroactively follow later `nvm alias default` changes.
 
+### Vanilla Extract benchmarks must stay current
+
+`benchmarks/vanilla-extract` is an opt-in performance suite comparing the
+`@sanity/vanilla-extract-*` plugins against the official `@vanilla-extract/*` plugins, and its
+README publishes the latest measured results (which the plugin READMEs link to). **Whenever you
+bump any `vanilla-extract` dependency (`@vanilla-extract/*` packages, or the pinned
+`@vanilla-extract/rollup-plugin`/`@vanilla-extract/vite-plugin` dev dependencies of the benchmark
+workspace), or change any of the `@sanity/vanilla-extract-rolldown-plugin`,
+`@sanity/vanilla-extract-tsdown-plugin`, or `@sanity/vanilla-extract-vite-plugin` packages in any
+way, re-run the full suite and update the "Latest results" section of
+`benchmarks/vanilla-extract/README.md`** (tables, run date, and the environment/version line):
+
+```sh
+pnpm --filter @benchmarks/vanilla-extract install-browser # once, for the HMR suite
+pnpm benchmark:vanilla-extract
+```
+
+Run it on an idle machine on Node 24 and update all result tables — library build and Vite build
+variants (baseline/minify/target/minify+target), dev HMR, hook-filter stress timings, and the
+hook-entry diagnostic (also written to `benchmarks/vanilla-extract/results/vite-hook-counts.json`).
+`pnpm --filter @benchmarks/vanilla-extract smoke` validates every build configuration first
+without collecting timings. See `benchmarks/vanilla-extract/README.md` for fixture-size and
+sample-count overrides.
+
 ### Testing notes
 
 - `pnpm test` (root) runs a `pretest` hook that cleans+rebuilds `@sanity/pkg-utils` and cleans the

--- a/benchmarks/vanilla-extract/README.md
+++ b/benchmarks/vanilla-extract/README.md
@@ -35,6 +35,64 @@ include an `inset` shorthand so the smoke suite can verify that downleveling act
 Each benchmark process lazy-loads only the plugin under test — the competing implementation is
 never imported into the same process, so module-level state cannot cross-contaminate runs.
 
+## Latest results
+
+Keep this section current: re-run the full suite and update the tables whenever the
+`vanilla-extract` dependencies are bumped or any of the `@sanity/vanilla-extract-*` plugins
+change (see [AGENTS.md](../../AGENTS.md)).
+
+Last run: 2026-07-15, full default suite (`pnpm benchmark:vanilla-extract`) on Node.js 24.18.0,
+Linux x64, Intel Xeon; Rollup 4.62.2, Rolldown 1.1.5, Vite 8.1.4, Vitest 4.1.10. Values are mean
+wall-clock milliseconds from that runner and are machine-specific — compare ratios, not absolute
+numbers.
+
+### Library build, 500 TS + 100 CSS modules (5 samples each)
+
+| Variant                  | Rollup + `@vanilla-extract/rollup-plugin` | Rolldown + `@sanity/vanilla-extract-rolldown-plugin` | Relative result    |
+| ------------------------ | ----------------------------------------: | ---------------------------------------------------: | ------------------ |
+| No minify, no target     |                                 582.22 ms |                                             353.50 ms | Sanity 1.65x faster |
+| Minify                   |                                 592.13 ms |                                             351.60 ms | Sanity 1.68x faster |
+| Target chrome61          |                                 575.51 ms |                                             350.17 ms | Sanity 1.64x faster |
+| Minify + target chrome61 |                                 582.83 ms |                                             346.02 ms | Sanity 1.68x faster |
+
+### Vite build, 500 TS + 100 CSS modules (5 samples each)
+
+| Variant                  | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result    |
+| ------------------------ | -----------------------------: | ------------------------------------: | ------------------ |
+| No minify, no target     |                      722.79 ms |                              550.93 ms | Sanity 1.31x faster |
+| Minify                   |                      716.06 ms |                              548.49 ms | Sanity 1.31x faster |
+| Target chrome61          |                      728.38 ms |                              555.78 ms | Sanity 1.31x faster |
+| Minify + target chrome61 |                      726.69 ms |                              565.97 ms | Sanity 1.28x faster |
+
+Minify and target costs are dominated by identical Vite-side work in this comparison, so the gap
+stays stable across variants; in the library builds each plugin's own `lightningcss` handling is
+what is being compared.
+
+### Vite dev HMR (10 samples each)
+
+| Scenario                                | Official plugin | Sanity plugin | Relative result                       |
+| --------------------------------------- | --------------: | ------------: | ------------------------------------- |
+| Single `.css.ts` leaf edit              |        18.61 ms |      18.27 ms | Effectively tied; Sanity 1.02x faster |
+| Shared theme edit, 100 style importers |       155.06 ms |     163.99 ms | Official 1.06x faster                 |
+
+### Hook-filter stress, `vite build` with 1 CSS module (3 samples each)
+
+| Unrelated modules | Official plugin | Sanity plugin | Relative result    |
+| ----------------: | --------------: | ------------: | ------------------ |
+|                 0 |       435.52 ms |     301.75 ms | Sanity 1.44x faster |
+|             1,000 |       450.91 ms |     294.72 ms | Sanity 1.53x faster |
+|             5,000 |       647.04 ms |     442.98 ms | Sanity 1.46x faster |
+
+The untimed hook diagnostic shows why: the official plugin's unfiltered hooks enter JavaScript
+once per module, while the Sanity plugin's native hook filters reject unrelated ids before the
+Rust ↔ JS boundary.
+
+| Unrelated modules | Official `load` / `transform` entries | Sanity `load` / `transform` entries |
+| ----------------: | ------------------------------------: | ----------------------------------: |
+|                 0 |                                 6 / 8 |                               1 / 1 |
+|             1,000 |                         1,006 / 1,008 |                               1 / 1 |
+|             5,000 |                         5,006 / 5,008 |                               1 / 1 |
+
 The Vite hook-filter suite also holds the number of Vanilla Extract files constant while
 increasing the number of reachable, unrelated TypeScript modules. Its untimed diagnostic counts
 actual JavaScript entries into each plugin's `resolveId`, `load`, and `transform` hooks. This makes

--- a/benchmarks/vanilla-extract/README.md
+++ b/benchmarks/vanilla-extract/README.md
@@ -22,6 +22,19 @@ Vite 8 compares:
 - Vite dev HMR for a direct `.css.ts` edit
 - Vite dev HMR for a shared theme edit that invalidates every `.css.ts` importer
 
+Every build comparison runs the full variant matrix: baseline (no minify, no target), CSS
+minification, syntax downleveling via `target: 'chrome61'`, and minify + target combined. The
+Sanity Rolldown plugin handles minify/target through its own `lightningcss` options; the official
+Rollup plugin has no such options, so those variants add the `lightningcss` post-pass that
+real-world official pipelines (like `@sanity/pkg-utils`'s `optimizeCss`) use — complete pipeline
+against complete pipeline. In the Vite comparison, minify (`oxc` + `lightningcss`) and target
+apply through Vite's own build options, identically for both plugins. The generated styles
+include an `inset` shorthand so the smoke suite can verify that downleveling actually happened
+(chrome61 predates `inset`).
+
+Each benchmark process lazy-loads only the plugin under test — the competing implementation is
+never imported into the same process, so module-level state cannot cross-contaminate runs.
+
 The Vite hook-filter suite also holds the number of Vanilla Extract files constant while
 increasing the number of reachable, unrelated TypeScript modules. Its untimed diagnostic counts
 actual JavaScript entries into each plugin's `resolveId`, `load`, and `transform` hooks. This makes

--- a/benchmarks/vanilla-extract/README.md
+++ b/benchmarks/vanilla-extract/README.md
@@ -51,9 +51,24 @@ Keep this section current: re-run the full suite and update the tables whenever 
 change (see [AGENTS.md](../../AGENTS.md)).
 
 Last run: 2026-07-15 (after the `bundle-css.js` shim rename, #3043), full default suite
-(`pnpm benchmark:vanilla-extract`) on Node.js 24.18.0, Linux x64, Intel Xeon; Rollup 4.62.2,
-Rolldown 1.1.5, Vite 8.1.4, Vitest 4.1.10. Values are mean wall-clock milliseconds from that
-runner and are machine-specific — compare ratios, not absolute numbers.
+(`pnpm benchmark:vanilla-extract`) on Node.js 24.18.0, Linux x64, Intel Xeon, **4 cores**;
+Rollup 4.62.2, Rolldown 1.1.5, Vite 8.1.4, Vitest 4.1.10. Values are mean wall-clock
+milliseconds from that runner and are machine-specific — compare ratios, not absolute numbers.
+
+### Core count shifts the build ratios
+
+Rolldown parallelizes its work across cores in Rust, while Rollup's JavaScript pipeline is
+largely single-threaded — so the more cores the machine has, the faster the Rolldown side gets
+relative to Rollup, and the tables below (from a 4-core runner) understate the gap on typical
+developer hardware. The versions table printed with every run includes the core count so results
+stay comparable.
+
+For reference, the same suite on an Apple M4 Max (16 cores, darwin-arm64) measured the library
+build at 2.68x (baseline) and up to ~4x (minify) in favor of Rolldown + the Sanity plugin —
+against 1.63–1.70x on the 4-core runner — while the Vite build ratio stayed put at ~1.30x
+(Vite's pipeline dominates there, identically for both plugins). The high-variance rows of that
+run (rme up to ±70% on the Rollup side) mean the exact multiplier is fuzzy, but the direction is
+consistent: more cores widen the library-build gap.
 
 ### Library build, 500 TS + 100 CSS modules (5 samples each)
 

--- a/benchmarks/vanilla-extract/README.md
+++ b/benchmarks/vanilla-extract/README.md
@@ -31,7 +31,7 @@ visible independently of wall-clock noise.
 
 ## Running
 
-Install dependencies at the repository root, then run:
+Use Node.js 24, install dependencies at the repository root, then run:
 
 ```sh
 pnpm benchmark:vanilla-extract
@@ -97,6 +97,7 @@ All values are optional:
 | `VE_BENCH_STRESS_ITERATIONS` |                  `3` | Samples per hook-filter build case                  |
 | `VE_BENCH_HMR_ITERATIONS`    |                 `10` | Samples per HMR case                                |
 | `VE_BENCH_WARMUP_ITERATIONS` |                  `1` | Untimed warmup samples per case                     |
+| `VE_BENCH_HMR_SETTLE`        |                `250` | Untimed milliseconds between source edits           |
 | `VE_BENCH_HMR_TIMEOUT`       |              `30000` | Milliseconds before an HMR sample fails             |
 
 For a quick wiring check:

--- a/benchmarks/vanilla-extract/README.md
+++ b/benchmarks/vanilla-extract/README.md
@@ -29,15 +29,17 @@ the Rust-to-JavaScript boundary described in
 [vanilla-extract#1641](https://github.com/vanilla-extract-css/vanilla-extract/issues/1641)
 visible independently of wall-clock noise.
 
-Every build comparison runs the full variant matrix: baseline (no minify, no target), CSS
+The library-build comparison runs a variant matrix: baseline (no minify, no target), CSS
 minification, syntax downleveling via `target: 'chrome61'`, and minify + target combined. The
 Sanity Rolldown plugin handles minify/target through its own `lightningcss` options; the official
 Rollup plugin has no such options, so those variants add the `lightningcss` post-pass that
 real-world official pipelines (like `@sanity/pkg-utils`'s `optimizeCss`) use — complete pipeline
-against complete pipeline. In the Vite comparison, minify (`oxc` + `lightningcss`) and target
-apply through Vite's own build options, identically for both plugins. The generated styles
-include an `inset` shorthand so the smoke suite can verify that downleveling actually happened
-(chrome61 predates `inset`).
+against complete pipeline. The generated styles include an `inset` shorthand so the smoke suite
+can verify that downleveling actually happened (chrome61 predates `inset`).
+
+The Vite build comparison intentionally skips those variants: Vite handles minify and target
+itself, identically for either plugin, so varying them would only add identical work to both
+sides of the comparison.
 
 Each benchmark process lazy-loads only the plugin under test — the competing implementation is
 never imported into the same process, so module-level state cannot cross-contaminate runs.
@@ -64,16 +66,9 @@ runner and are machine-specific — compare ratios, not absolute numbers.
 
 ### Vite build, 500 TS + 100 CSS modules (5 samples each)
 
-| Variant                  | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result     |
-| ------------------------ | -----------------------------: | ------------------------------------: | ------------------- |
-| No minify, no target     |                      792.66 ms |                             601.33 ms | Sanity 1.32x faster |
-| Minify                   |                      790.95 ms |                             601.92 ms | Sanity 1.31x faster |
-| Target chrome61          |                      800.50 ms |                             608.73 ms | Sanity 1.32x faster |
-| Minify + target chrome61 |                      838.17 ms |                             629.58 ms | Sanity 1.33x faster |
-
-Minify and target costs are dominated by identical Vite-side work in this comparison, so the gap
-stays stable across variants; in the library builds each plugin's own `lightningcss` handling is
-what is being compared.
+| `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result     |
+| -----------------------------: | ------------------------------------: | ------------------- |
+|                      792.66 ms |                             601.33 ms | Sanity 1.32x faster |
 
 ### Vite dev HMR (10 samples each)
 

--- a/benchmarks/vanilla-extract/README.md
+++ b/benchmarks/vanilla-extract/README.md
@@ -1,0 +1,115 @@
+# Vanilla Extract benchmarks
+
+Opt-in performance comparisons for the Vanilla Extract integrations maintained in this
+repository. The workspace uses Vitest 4's Tinybench-backed `bench` API for fixed-sample
+measurements and Playwright for browser-observed Vite HMR.
+
+The benchmarks are intentionally not part of the normal test suite or CI. Run them on an idle,
+consistent machine and compare results produced with the same lockfile, Node version, fixture
+sizes, and sample counts.
+
+## Matrix
+
+Library builds compare each plugin on its intended bundler:
+
+- Rollup with `@vanilla-extract/rollup-plugin`
+- Rolldown with `@sanity/vanilla-extract-rolldown-plugin`
+
+Vite 8 compares:
+
+- `vite build` with `@vanilla-extract/vite-plugin`
+- `vite build` with `@sanity/vanilla-extract-vite-plugin`
+- Vite dev HMR for a direct `.css.ts` edit
+- Vite dev HMR for a shared theme edit that invalidates every `.css.ts` importer
+
+The Vite hook-filter suite also holds the number of Vanilla Extract files constant while
+increasing the number of reachable, unrelated TypeScript modules. Its untimed diagnostic counts
+actual JavaScript entries into each plugin's `resolveId`, `load`, and `transform` hooks. This makes
+the Rust-to-JavaScript boundary described in
+[vanilla-extract#1641](https://github.com/vanilla-extract-css/vanilla-extract/issues/1641)
+visible independently of wall-clock noise.
+
+## Running
+
+Install dependencies at the repository root, then run:
+
+```sh
+pnpm benchmark:vanilla-extract
+```
+
+Run one group:
+
+```sh
+pnpm benchmark:build
+pnpm benchmark:vite-build
+pnpm benchmark:vite-hooks
+pnpm benchmark:vite-hmr
+```
+
+HMR requires a one-time Chromium install:
+
+```sh
+pnpm --filter @benchmarks/vanilla-extract install-browser
+```
+
+Check every build configuration without collecting timing samples:
+
+```sh
+pnpm --filter @benchmarks/vanilla-extract smoke
+```
+
+Each benchmark command rebuilds the local Sanity plugins and regenerates fixtures before
+starting. It also prints the exact runtime, CPU, bundler, and plugin versions.
+
+## What is timed
+
+Build samples invoke the real local CLI binary in a fresh Node process and write output to disk.
+Removing the previous output and validating the next output happen outside the timed region.
+Minification, declarations, and sourcemaps are disabled; all cases use ESM output and short
+identifiers over the same generated source graph.
+
+HMR servers and browser pages are started and primed before sampling. A sample begins with an
+actual source-file write and ends only after both conditions are true in Chromium:
+
+1. Vite's client has emitted `vite:afterUpdate`.
+2. The probe element's computed style contains the new value.
+
+An unexpected page reload or a stale style causes the sample to fail instead of recording a
+misleading duration.
+
+The hook-filter stress suite reports absolute build time and handler-entry counts. Rolldown's
+default `[PLUGIN_TIMINGS]` warning is surfaced when emitted, but it is not an assertion: the
+warning requires a build longer than three seconds, a plugin longer than one second, and
+plugin-dominated execution, so whether it appears depends on the host.
+
+## Configuration
+
+All values are optional:
+
+| Variable                     |              Default | Purpose                                             |
+| ---------------------------- | -------------------: | --------------------------------------------------- |
+| `VE_BENCH_MODULES`           |                `500` | Ordinary modules in the representative graph        |
+| `VE_BENCH_STYLES`            |                `100` | `.css.ts` modules in the representative graph       |
+| `VE_BENCH_HMR_MODULES`       | representative value | Ordinary modules loaded by each HMR server          |
+| `VE_BENCH_HMR_STYLES`        | representative value | `.css.ts` importers invalidated by shared-theme HMR |
+| `VE_BENCH_STRESS_SIZES`      |        `0,1000,5000` | Ordinary-module counts in the hook-filter sweep     |
+| `VE_BENCH_BUILD_ITERATIONS`  |                  `5` | Samples per normal build case                       |
+| `VE_BENCH_STRESS_ITERATIONS` |                  `3` | Samples per hook-filter build case                  |
+| `VE_BENCH_HMR_ITERATIONS`    |                 `10` | Samples per HMR case                                |
+| `VE_BENCH_WARMUP_ITERATIONS` |                  `1` | Untimed warmup samples per case                     |
+| `VE_BENCH_HMR_TIMEOUT`       |              `30000` | Milliseconds before an HMR sample fails             |
+
+For a quick wiring check:
+
+```sh
+VE_BENCH_MODULES=10 \
+VE_BENCH_STYLES=3 \
+VE_BENCH_STRESS_SIZES=0,20 \
+VE_BENCH_BUILD_ITERATIONS=1 \
+VE_BENCH_STRESS_ITERATIONS=1 \
+VE_BENCH_HMR_ITERATIONS=1 \
+pnpm benchmark:vanilla-extract
+```
+
+Generated fixtures and build outputs live in `.generated/`. Hook diagnostics are written to
+`results/vite-hook-counts.json`. Both directories are ignored by Git.

--- a/benchmarks/vanilla-extract/README.md
+++ b/benchmarks/vanilla-extract/README.md
@@ -22,6 +22,13 @@ Vite 8 compares:
 - Vite dev HMR for a direct `.css.ts` edit
 - Vite dev HMR for a shared theme edit that invalidates every `.css.ts` importer
 
+The Vite hook-filter suite also holds the number of Vanilla Extract files constant while
+increasing the number of reachable, unrelated TypeScript modules. Its untimed diagnostic counts
+actual JavaScript entries into each plugin's `resolveId`, `load`, and `transform` hooks. This makes
+the Rust-to-JavaScript boundary described in
+[vanilla-extract#1641](https://github.com/vanilla-extract-css/vanilla-extract/issues/1641)
+visible independently of wall-clock noise.
+
 Every build comparison runs the full variant matrix: baseline (no minify, no target), CSS
 minification, syntax downleveling via `target: 'chrome61'`, and minify + target combined. The
 Sanity Rolldown plugin handles minify/target through its own `lightningcss` options; the official
@@ -41,28 +48,28 @@ Keep this section current: re-run the full suite and update the tables whenever 
 `vanilla-extract` dependencies are bumped or any of the `@sanity/vanilla-extract-*` plugins
 change (see [AGENTS.md](../../AGENTS.md)).
 
-Last run: 2026-07-15, full default suite (`pnpm benchmark:vanilla-extract`) on Node.js 24.18.0,
-Linux x64, Intel Xeon; Rollup 4.62.2, Rolldown 1.1.5, Vite 8.1.4, Vitest 4.1.10. Values are mean
-wall-clock milliseconds from that runner and are machine-specific — compare ratios, not absolute
-numbers.
+Last run: 2026-07-15 (after the `bundle-css.js` shim rename, #3043), full default suite
+(`pnpm benchmark:vanilla-extract`) on Node.js 24.18.0, Linux x64, Intel Xeon; Rollup 4.62.2,
+Rolldown 1.1.5, Vite 8.1.4, Vitest 4.1.10. Values are mean wall-clock milliseconds from that
+runner and are machine-specific — compare ratios, not absolute numbers.
 
 ### Library build, 500 TS + 100 CSS modules (5 samples each)
 
-| Variant                  | Rollup + `@vanilla-extract/rollup-plugin` | Rolldown + `@sanity/vanilla-extract-rolldown-plugin` | Relative result    |
-| ------------------------ | ----------------------------------------: | ---------------------------------------------------: | ------------------ |
-| No minify, no target     |                                 582.22 ms |                                             353.50 ms | Sanity 1.65x faster |
-| Minify                   |                                 592.13 ms |                                             351.60 ms | Sanity 1.68x faster |
-| Target chrome61          |                                 575.51 ms |                                             350.17 ms | Sanity 1.64x faster |
-| Minify + target chrome61 |                                 582.83 ms |                                             346.02 ms | Sanity 1.68x faster |
+| Variant                  | Rollup + `@vanilla-extract/rollup-plugin` | Rolldown + `@sanity/vanilla-extract-rolldown-plugin` | Relative result     |
+| ------------------------ | ----------------------------------------: | ---------------------------------------------------: | ------------------- |
+| No minify, no target     |                                 591.80 ms |                                            363.19 ms | Sanity 1.63x faster |
+| Minify                   |                                 622.98 ms |                                            371.94 ms | Sanity 1.67x faster |
+| Target chrome61          |                                 642.70 ms |                                            376.96 ms | Sanity 1.70x faster |
+| Minify + target chrome61 |                                 653.61 ms |                                            385.33 ms | Sanity 1.70x faster |
 
 ### Vite build, 500 TS + 100 CSS modules (5 samples each)
 
-| Variant                  | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result    |
-| ------------------------ | -----------------------------: | ------------------------------------: | ------------------ |
-| No minify, no target     |                      722.79 ms |                              550.93 ms | Sanity 1.31x faster |
-| Minify                   |                      716.06 ms |                              548.49 ms | Sanity 1.31x faster |
-| Target chrome61          |                      728.38 ms |                              555.78 ms | Sanity 1.31x faster |
-| Minify + target chrome61 |                      726.69 ms |                              565.97 ms | Sanity 1.28x faster |
+| Variant                  | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result     |
+| ------------------------ | -----------------------------: | ------------------------------------: | ------------------- |
+| No minify, no target     |                      792.66 ms |                             601.33 ms | Sanity 1.32x faster |
+| Minify                   |                      790.95 ms |                             601.92 ms | Sanity 1.31x faster |
+| Target chrome61          |                      800.50 ms |                             608.73 ms | Sanity 1.32x faster |
+| Minify + target chrome61 |                      838.17 ms |                             629.58 ms | Sanity 1.33x faster |
 
 Minify and target costs are dominated by identical Vite-side work in this comparison, so the gap
 stays stable across variants; in the library builds each plugin's own `lightningcss` handling is
@@ -70,18 +77,18 @@ what is being compared.
 
 ### Vite dev HMR (10 samples each)
 
-| Scenario                                | Official plugin | Sanity plugin | Relative result                       |
-| --------------------------------------- | --------------: | ------------: | ------------------------------------- |
-| Single `.css.ts` leaf edit              |        18.61 ms |      18.27 ms | Effectively tied; Sanity 1.02x faster |
-| Shared theme edit, 100 style importers |       155.06 ms |     163.99 ms | Official 1.06x faster                 |
+| Scenario                               | Official plugin | Sanity plugin | Relative result       |
+| -------------------------------------- | --------------: | ------------: | --------------------- |
+| Single `.css.ts` leaf edit             |        27.18 ms |      25.73 ms | Sanity 1.06x faster   |
+| Shared theme edit, 100 style importers |       178.44 ms |     195.64 ms | Official 1.10x faster |
 
 ### Hook-filter stress, `vite build` with 1 CSS module (3 samples each)
 
-| Unrelated modules | Official plugin | Sanity plugin | Relative result    |
-| ----------------: | --------------: | ------------: | ------------------ |
-|                 0 |       435.52 ms |     301.75 ms | Sanity 1.44x faster |
-|             1,000 |       450.91 ms |     294.72 ms | Sanity 1.53x faster |
-|             5,000 |       647.04 ms |     442.98 ms | Sanity 1.46x faster |
+| Unrelated modules | Official plugin | Sanity plugin | Relative result     |
+| ----------------: | --------------: | ------------: | ------------------- |
+|                 0 |       463.89 ms |     311.57 ms | Sanity 1.49x faster |
+|             1,000 |       508.41 ms |     331.32 ms | Sanity 1.53x faster |
+|             5,000 |       761.97 ms |     535.87 ms | Sanity 1.42x faster |
 
 The untimed hook diagnostic shows why: the official plugin's unfiltered hooks enter JavaScript
 once per module, while the Sanity plugin's native hook filters reject unrelated ids before the
@@ -92,13 +99,6 @@ Rust ↔ JS boundary.
 |                 0 |                                 6 / 8 |                               1 / 1 |
 |             1,000 |                         1,006 / 1,008 |                               1 / 1 |
 |             5,000 |                         5,006 / 5,008 |                               1 / 1 |
-
-The Vite hook-filter suite also holds the number of Vanilla Extract files constant while
-increasing the number of reachable, unrelated TypeScript modules. Its untimed diagnostic counts
-actual JavaScript entries into each plugin's `resolveId`, `load`, and `transform` hooks. This makes
-the Rust-to-JavaScript boundary described in
-[vanilla-extract#1641](https://github.com/vanilla-extract-css/vanilla-extract/issues/1641)
-visible independently of wall-clock noise.
 
 ## Running
 

--- a/benchmarks/vanilla-extract/bench/build.bench.ts
+++ b/benchmarks/vanilla-extract/bench/build.bench.ts
@@ -1,0 +1,29 @@
+import path from 'node:path'
+import {bench, describe} from 'vitest'
+import {runRolldownBuild, runRollupBuild} from './helpers/commands.ts'
+import {coldBuildOptions} from './helpers/options.ts'
+import {assertLibraryOutput} from './helpers/output.ts'
+import {fixturePath, generatedRoot, loadFixtureManifest} from './helpers/paths.ts'
+
+const manifest = await loadFixtureManifest()
+const fixtureRoot = fixturePath(manifest.representative)
+
+describe(`library build (${manifest.representative.plainModules} TS + ${manifest.representative.styleModules} CSS modules)`, () => {
+  const rollupOutput = path.join(generatedRoot, 'output/build-rollup')
+  bench(
+    'Rollup + @vanilla-extract/rollup-plugin',
+    async () => {
+      await runRollupBuild(fixtureRoot, rollupOutput)
+    },
+    coldBuildOptions('build', rollupOutput, () => assertLibraryOutput(rollupOutput)),
+  )
+
+  const rolldownOutput = path.join(generatedRoot, 'output/build-rolldown')
+  bench(
+    'Rolldown + @sanity/vanilla-extract-rolldown-plugin',
+    async () => {
+      await runRolldownBuild(fixtureRoot, rolldownOutput)
+    },
+    coldBuildOptions('build', rolldownOutput, () => assertLibraryOutput(rolldownOutput)),
+  )
+})

--- a/benchmarks/vanilla-extract/bench/build.bench.ts
+++ b/benchmarks/vanilla-extract/bench/build.bench.ts
@@ -4,26 +4,29 @@ import {runRolldownBuild, runRollupBuild} from './helpers/commands.ts'
 import {coldBuildOptions} from './helpers/options.ts'
 import {assertLibraryOutputSync} from './helpers/output.ts'
 import {fixturePath, generatedRoot, loadFixtureManifest} from './helpers/paths.ts'
+import {buildVariants} from './helpers/variants.ts'
 
 const manifest = await loadFixtureManifest()
 const fixtureRoot = fixturePath(manifest.representative)
 
-describe(`library build (${manifest.representative.plainModules} TS + ${manifest.representative.styleModules} CSS modules)`, () => {
-  const rollupOutput = path.join(generatedRoot, 'output/build-rollup')
-  bench(
-    'Rollup + @vanilla-extract/rollup-plugin',
-    async () => {
-      await runRollupBuild(fixtureRoot, rollupOutput)
-    },
-    coldBuildOptions('build', rollupOutput, () => assertLibraryOutputSync(rollupOutput)),
-  )
+for (const variant of buildVariants) {
+  describe(`library build, ${variant.label} (${manifest.representative.plainModules} TS + ${manifest.representative.styleModules} CSS modules)`, () => {
+    const rollupOutput = path.join(generatedRoot, `output/build-rollup-${variant.slug}`)
+    bench(
+      'Rollup + @vanilla-extract/rollup-plugin',
+      async () => {
+        await runRollupBuild(fixtureRoot, rollupOutput, variant)
+      },
+      coldBuildOptions('build', rollupOutput, () => assertLibraryOutputSync(rollupOutput)),
+    )
 
-  const rolldownOutput = path.join(generatedRoot, 'output/build-rolldown')
-  bench(
-    'Rolldown + @sanity/vanilla-extract-rolldown-plugin',
-    async () => {
-      await runRolldownBuild(fixtureRoot, rolldownOutput)
-    },
-    coldBuildOptions('build', rolldownOutput, () => assertLibraryOutputSync(rolldownOutput)),
-  )
-})
+    const rolldownOutput = path.join(generatedRoot, `output/build-rolldown-${variant.slug}`)
+    bench(
+      'Rolldown + @sanity/vanilla-extract-rolldown-plugin',
+      async () => {
+        await runRolldownBuild(fixtureRoot, rolldownOutput, variant)
+      },
+      coldBuildOptions('build', rolldownOutput, () => assertLibraryOutputSync(rolldownOutput)),
+    )
+  })
+}

--- a/benchmarks/vanilla-extract/bench/build.bench.ts
+++ b/benchmarks/vanilla-extract/bench/build.bench.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import {bench, describe} from 'vitest'
 import {runRolldownBuild, runRollupBuild} from './helpers/commands.ts'
 import {coldBuildOptions} from './helpers/options.ts'
-import {assertLibraryOutput} from './helpers/output.ts'
+import {assertLibraryOutputSync} from './helpers/output.ts'
 import {fixturePath, generatedRoot, loadFixtureManifest} from './helpers/paths.ts'
 
 const manifest = await loadFixtureManifest()
@@ -15,7 +15,7 @@ describe(`library build (${manifest.representative.plainModules} TS + ${manifest
     async () => {
       await runRollupBuild(fixtureRoot, rollupOutput)
     },
-    coldBuildOptions('build', rollupOutput, () => assertLibraryOutput(rollupOutput)),
+    coldBuildOptions('build', rollupOutput, () => assertLibraryOutputSync(rollupOutput)),
   )
 
   const rolldownOutput = path.join(generatedRoot, 'output/build-rolldown')
@@ -24,6 +24,6 @@ describe(`library build (${manifest.representative.plainModules} TS + ${manifest
     async () => {
       await runRolldownBuild(fixtureRoot, rolldownOutput)
     },
-    coldBuildOptions('build', rolldownOutput, () => assertLibraryOutput(rolldownOutput)),
+    coldBuildOptions('build', rolldownOutput, () => assertLibraryOutputSync(rolldownOutput)),
   )
 })

--- a/benchmarks/vanilla-extract/bench/helpers/commands.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/commands.ts
@@ -3,6 +3,7 @@ import {readFileSync} from 'node:fs'
 import {createRequire} from 'node:module'
 import path from 'node:path'
 import {benchmarkRoot, configPaths} from './paths.ts'
+import type {BuildVariant} from './variants.ts'
 
 const require = createRequire(import.meta.url)
 
@@ -85,34 +86,42 @@ async function runPackageBin(
   return {stderr, stdout}
 }
 
-function buildEnvironment(fixtureRoot: string, outputDirectory: string): NodeJS.ProcessEnv {
+function buildEnvironment(
+  fixtureRoot: string,
+  outputDirectory: string,
+  variant?: BuildVariant,
+): NodeJS.ProcessEnv {
   return {
     VE_BENCH_FIXTURE_ROOT: fixtureRoot,
+    VE_BENCH_MINIFY: variant?.minify ? '1' : '0',
     VE_BENCH_OUTPUT_DIR: outputDirectory,
+    VE_BENCH_TARGET: variant?.target ? variant.target : '',
   }
 }
 
 export function runRollupBuild(
   fixtureRoot: string,
   outputDirectory: string,
+  variant?: BuildVariant,
 ): Promise<CommandResult> {
   return runPackageBin(
     'rollup',
     'rollup',
     ['--config', configPaths.rollup, '--silent'],
-    buildEnvironment(fixtureRoot, outputDirectory),
+    buildEnvironment(fixtureRoot, outputDirectory, variant),
   )
 }
 
 export function runRolldownBuild(
   fixtureRoot: string,
   outputDirectory: string,
+  variant?: BuildVariant,
 ): Promise<CommandResult> {
   return runPackageBin(
     'rolldown',
     'rolldown',
     ['--config', configPaths.rolldown],
-    buildEnvironment(fixtureRoot, outputDirectory),
+    buildEnvironment(fixtureRoot, outputDirectory, variant),
   )
 }
 
@@ -120,11 +129,11 @@ export function runViteBuild(
   fixtureRoot: string,
   outputDirectory: string,
   plugin: VitePluginKind,
-  showWarnings = false,
+  options: {showWarnings?: boolean; variant?: BuildVariant} = {},
 ): Promise<CommandResult> {
   return runPackageBin('vite', 'vite', ['build', '--config', configPaths.vite], {
-    ...buildEnvironment(fixtureRoot, outputDirectory),
-    VE_BENCH_LOG_LEVEL: showWarnings ? 'warn' : 'silent',
+    ...buildEnvironment(fixtureRoot, outputDirectory, options.variant),
+    VE_BENCH_LOG_LEVEL: options.showWarnings ? 'warn' : 'silent',
     VE_BENCH_PLUGIN: plugin,
   })
 }

--- a/benchmarks/vanilla-extract/bench/helpers/commands.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/commands.ts
@@ -6,8 +6,8 @@ import {benchmarkRoot, configPaths} from './paths.ts'
 
 const require = createRequire(import.meta.url)
 
-interface PackageManifest {
-  bin?: string | Record<string, string>
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
 }
 
 export interface CommandResult {
@@ -19,8 +19,18 @@ export type VitePluginKind = 'official' | 'sanity'
 
 function resolvePackageBin(packageName: string, binName: string): string {
   const packageJsonPath = require.resolve(`${packageName}/package.json`)
-  const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as PackageManifest
-  const relativeBin = typeof manifest.bin === 'string' ? manifest.bin : manifest.bin?.[binName]
+  const manifest: unknown = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+  if (!isRecord(manifest)) {
+    throw new Error(`Invalid package manifest at ${packageJsonPath}`)
+  }
+
+  const bin = manifest['bin']
+  const relativeBin =
+    typeof bin === 'string'
+      ? bin
+      : isRecord(bin) && typeof bin[binName] === 'string'
+        ? bin[binName]
+        : undefined
 
   if (!relativeBin) {
     throw new Error(`Could not resolve the ${binName} binary from ${packageJsonPath}`)

--- a/benchmarks/vanilla-extract/bench/helpers/commands.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/commands.ts
@@ -1,0 +1,120 @@
+import {spawn} from 'node:child_process'
+import {readFileSync} from 'node:fs'
+import {createRequire} from 'node:module'
+import path from 'node:path'
+import {benchmarkRoot, configPaths} from './paths.ts'
+
+const require = createRequire(import.meta.url)
+
+interface PackageManifest {
+  bin?: string | Record<string, string>
+}
+
+export interface CommandResult {
+  stderr: string
+  stdout: string
+}
+
+export type VitePluginKind = 'official' | 'sanity'
+
+function resolvePackageBin(packageName: string, binName: string): string {
+  const packageJsonPath = require.resolve(`${packageName}/package.json`)
+  const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as PackageManifest
+  const relativeBin = typeof manifest.bin === 'string' ? manifest.bin : manifest.bin?.[binName]
+
+  if (!relativeBin) {
+    throw new Error(`Could not resolve the ${binName} binary from ${packageJsonPath}`)
+  }
+  return path.resolve(path.dirname(packageJsonPath), relativeBin)
+}
+
+async function runPackageBin(
+  packageName: string,
+  binName: string,
+  arguments_: string[],
+  environment: NodeJS.ProcessEnv,
+): Promise<CommandResult> {
+  const binPath = resolvePackageBin(packageName, binName)
+  const child = spawn(process.execPath, [binPath, ...arguments_], {
+    cwd: benchmarkRoot,
+    env: {
+      ...process.env,
+      FORCE_COLOR: '0',
+      NO_COLOR: '1',
+      NODE_ENV: 'production',
+      ...environment,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  let stderr = ''
+  let stdout = ''
+  child.stderr.setEncoding('utf8')
+  child.stdout.setEncoding('utf8')
+  child.stderr.on('data', (chunk: string) => {
+    stderr += chunk
+  })
+  child.stdout.on('data', (chunk: string) => {
+    stdout += chunk
+  })
+
+  const code = await new Promise<number>((resolve, reject) => {
+    child.on('error', reject)
+    child.on('exit', (exitCode, signal) => {
+      if (exitCode === null) {
+        reject(new Error(`${binName} exited after signal ${signal ?? 'unknown'}`))
+        return
+      }
+      resolve(exitCode)
+    })
+  })
+
+  if (code !== 0) {
+    throw new Error(`${binName} exited with code ${code}\n${stdout}\n${stderr}`.trim())
+  }
+  return {stderr, stdout}
+}
+
+function buildEnvironment(fixtureRoot: string, outputDirectory: string): NodeJS.ProcessEnv {
+  return {
+    VE_BENCH_FIXTURE_ROOT: fixtureRoot,
+    VE_BENCH_OUTPUT_DIR: outputDirectory,
+  }
+}
+
+export function runRollupBuild(
+  fixtureRoot: string,
+  outputDirectory: string,
+): Promise<CommandResult> {
+  return runPackageBin(
+    'rollup',
+    'rollup',
+    ['--config', configPaths.rollup, '--silent'],
+    buildEnvironment(fixtureRoot, outputDirectory),
+  )
+}
+
+export function runRolldownBuild(
+  fixtureRoot: string,
+  outputDirectory: string,
+): Promise<CommandResult> {
+  return runPackageBin(
+    'rolldown',
+    'rolldown',
+    ['--config', configPaths.rolldown],
+    buildEnvironment(fixtureRoot, outputDirectory),
+  )
+}
+
+export function runViteBuild(
+  fixtureRoot: string,
+  outputDirectory: string,
+  plugin: VitePluginKind,
+  showWarnings = false,
+): Promise<CommandResult> {
+  return runPackageBin('vite', 'vite', ['build', '--config', configPaths.vite], {
+    ...buildEnvironment(fixtureRoot, outputDirectory),
+    VE_BENCH_LOG_LEVEL: showWarnings ? 'warn' : 'silent',
+    VE_BENCH_PLUGIN: plugin,
+  })
+}

--- a/benchmarks/vanilla-extract/bench/helpers/commands.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/commands.ts
@@ -129,10 +129,10 @@ export function runViteBuild(
   fixtureRoot: string,
   outputDirectory: string,
   plugin: VitePluginKind,
-  options: {showWarnings?: boolean; variant?: BuildVariant} = {},
+  options: {showWarnings?: boolean} = {},
 ): Promise<CommandResult> {
   return runPackageBin('vite', 'vite', ['build', '--config', configPaths.vite], {
-    ...buildEnvironment(fixtureRoot, outputDirectory, options.variant),
+    ...buildEnvironment(fixtureRoot, outputDirectory),
     VE_BENCH_LOG_LEVEL: options.showWarnings ? 'warn' : 'silent',
     VE_BENCH_PLUGIN: plugin,
   })

--- a/benchmarks/vanilla-extract/bench/helpers/hmr.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/hmr.ts
@@ -20,21 +20,13 @@ interface BrowserRuntime {
   updates: number
 }
 
-interface PendingUpdate {
-  contents: string
-  expectedColor: string
-  filePath: string
-  nextIndex: number
-  previousUpdates: number
-  scenario: HmrScenario
-}
-
 export interface HmrCase {
   context: BrowserContext
-  currentIndex: Record<HmrScenario, number>
+  currentIndex: Record<HmrScenario, 0 | 1>
+  currentSource: Record<HmrScenario, string>
   fixture: FixtureDescription
+  lastUpdates: number
   page: Page
-  pendingUpdate?: PendingUpdate
   plugin: VitePluginKind
   server: ViteDevServer
 }
@@ -103,12 +95,20 @@ export async function startHmrCase(
     )
 
     const runtime = await readBrowserRuntime(page)
-    assert.equal(runtime?.loads, 1, `${plugin} should load the page exactly once`)
+    assert(runtime, `${plugin} browser runtime did not initialize`)
+    assert.equal(runtime.loads, 1, `${plugin} should load the page exactly once`)
+    const sourceRoot = path.join(root, 'src')
+    const currentSource = {
+      leaf: await readFile(path.join(sourceRoot, 'styles/style-00000.css.ts'), 'utf8'),
+      shared: await readFile(path.join(sourceRoot, 'theme.ts'), 'utf8'),
+    }
 
     return {
       context,
       currentIndex: {leaf: 0, shared: 0},
+      currentSource,
       fixture,
+      lastUpdates: runtime.updates,
       page,
       plugin,
       server,
@@ -120,15 +120,11 @@ export async function startHmrCase(
   }
 }
 
-export async function prepareHmrUpdate(testCase: HmrCase, scenario: HmrScenario): Promise<void> {
-  const runtime = await readBrowserRuntime(testCase.page)
-  assert(runtime?.ready, `${testCase.plugin} browser runtime is not ready`)
-  assert.equal(runtime.loads, 1, `${testCase.plugin} unexpectedly reloaded the page`)
-
+export async function runHmrUpdate(testCase: HmrCase, scenario: HmrScenario): Promise<void> {
   const currentIndex = testCase.currentIndex[scenario]
   const nextIndex = currentIndex === 0 ? 1 : 0
   const filePath = scenarioFilePath(testCase, scenario)
-  const source = await readFile(filePath, 'utf8')
+  const source = testCase.currentSource[scenario]
   const currentColor = colors[scenario][currentIndex]
   const expectedColor = colors[scenario][nextIndex]
   assert(
@@ -136,27 +132,15 @@ export async function prepareHmrUpdate(testCase: HmrCase, scenario: HmrScenario)
     `Expected ${filePath} to contain the current ${scenario} color ${currentColor}`,
   )
 
-  testCase.pendingUpdate = {
-    contents: source.replace(currentColor, expectedColor),
-    expectedColor,
-    filePath,
-    nextIndex,
-    previousUpdates: runtime.updates,
-    scenario,
-  }
-}
-
-export async function runPreparedHmrUpdate(testCase: HmrCase): Promise<void> {
-  const pending = testCase.pendingUpdate
-  if (!pending) throw new Error(`No prepared HMR update for ${testCase.plugin}`)
-  testCase.pendingUpdate = undefined
-  testCase.currentIndex[pending.scenario] = pending.nextIndex
-
-  await writeFile(pending.filePath, pending.contents)
+  const contents = source.replace(currentColor, expectedColor)
+  const previousUpdates = testCase.lastUpdates
+  testCase.currentIndex[scenario] = nextIndex
+  testCase.currentSource[scenario] = contents
+  await writeFile(filePath, contents)
 
   try {
-    await testCase.page.waitForFunction(
-      ({expectedColor, previousUpdates, scenario}) => {
+    const completion = await testCase.page.waitForFunction(
+      (update) => {
         const benchmarkWindow = window as typeof window & {
           __vanillaExtractBenchmark?: BrowserRuntime
         }
@@ -165,32 +149,40 @@ export async function runPreparedHmrUpdate(testCase: HmrCase): Promise<void> {
         if (!runtime || !(probe instanceof HTMLElement)) return false
 
         const style = getComputedStyle(probe)
-        const actualColor = scenario === 'leaf' ? style.backgroundColor : style.color
-        return (
-          runtime.loads === 1 && runtime.updates > previousUpdates && actualColor === expectedColor
-        )
+        const actualColor = update.scenario === 'leaf' ? style.backgroundColor : style.color
+        return runtime.loads === 1 &&
+          runtime.updates > update.previousUpdates &&
+          actualColor === update.expectedColor
+          ? runtime.updates
+          : false
       },
       {
-        expectedColor: pending.expectedColor,
-        previousUpdates: pending.previousUpdates,
-        scenario: pending.scenario,
+        expectedColor,
+        previousUpdates,
+        scenario,
       },
       {
         polling: 10,
         timeout: Number.parseInt(process.env['VE_BENCH_HMR_TIMEOUT'] ?? '30000', 10),
       },
     )
+    const updates = await completion.jsonValue()
+    await completion.dispose()
+    if (typeof updates !== 'number') {
+      throw new Error(`Expected an HMR update count for ${testCase.plugin}`)
+    }
+    testCase.lastUpdates = updates
   } catch (error) {
     const runtime = await readBrowserRuntime(testCase.page).catch(() => undefined)
     const actualColor = await testCase.page
       .locator('#probe')
-      .evaluate((probe, scenario) => {
+      .evaluate((probe, requestedScenario) => {
         const style = getComputedStyle(probe)
-        return scenario === 'leaf' ? style.backgroundColor : style.color
-      }, pending.scenario)
+        return requestedScenario === 'leaf' ? style.backgroundColor : style.color
+      }, scenario)
       .catch(() => 'unavailable')
     throw new Error(
-      `${testCase.plugin} ${pending.scenario} HMR did not settle: expected ${pending.expectedColor}, received ${actualColor}, runtime=${JSON.stringify(runtime)}`,
+      `${testCase.plugin} ${scenario} HMR did not settle: expected ${expectedColor}, received ${actualColor}, runtime=${JSON.stringify(runtime)}`,
       {cause: error},
     )
   }
@@ -198,8 +190,7 @@ export async function runPreparedHmrUpdate(testCase: HmrCase): Promise<void> {
 
 export async function primeHmrCase(testCase: HmrCase): Promise<void> {
   for (const scenario of ['leaf', 'shared'] as const) {
-    await prepareHmrUpdate(testCase, scenario)
-    await runPreparedHmrUpdate(testCase)
+    await runHmrUpdate(testCase, scenario)
   }
 }
 

--- a/benchmarks/vanilla-extract/bench/helpers/hmr.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/hmr.ts
@@ -61,7 +61,7 @@ export async function startHmrCase(
     clearScreen: false,
     configFile: false,
     logLevel: 'silent',
-    plugins: createVitePlugins(plugin),
+    plugins: await createVitePlugins(plugin),
     server: {
       host: '127.0.0.1',
       port: 0,

--- a/benchmarks/vanilla-extract/bench/helpers/hmr.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/hmr.ts
@@ -1,0 +1,209 @@
+import assert from 'node:assert/strict'
+import {readFile, writeFile} from 'node:fs/promises'
+import path from 'node:path'
+import type {Browser, BrowserContext, Page} from 'playwright'
+import {createServer, type ViteDevServer} from 'vite'
+import type {VitePluginKind} from './commands.ts'
+import {fixturePath, type FixtureDescription} from './paths.ts'
+import {createVitePlugins} from './plugins.ts'
+
+export type HmrScenario = 'leaf' | 'shared'
+
+const colors = {
+  leaf: ['rgb(10, 20, 30)', 'rgb(30, 20, 10)'],
+  shared: ['rgb(1, 2, 3)', 'rgb(3, 2, 1)'],
+} as const
+
+interface BrowserRuntime {
+  loads: number
+  ready: boolean
+  updates: number
+}
+
+interface PendingUpdate {
+  contents: string
+  expectedColor: string
+  filePath: string
+  nextIndex: number
+  previousUpdates: number
+  scenario: HmrScenario
+}
+
+export interface HmrCase {
+  context: BrowserContext
+  currentIndex: Record<HmrScenario, number>
+  fixture: FixtureDescription
+  page: Page
+  pendingUpdate?: PendingUpdate
+  plugin: VitePluginKind
+  server: ViteDevServer
+}
+
+function readBrowserRuntime(page: Page): Promise<BrowserRuntime | undefined> {
+  return page.evaluate(() => {
+    const benchmarkWindow = window as typeof window & {
+      __vanillaExtractBenchmark?: BrowserRuntime
+    }
+    const runtime = benchmarkWindow.__vanillaExtractBenchmark
+    return runtime ? {...runtime} : undefined
+  })
+}
+
+function scenarioFilePath(testCase: HmrCase, scenario: HmrScenario): string {
+  const sourceRoot = path.join(fixturePath(testCase.fixture), 'src')
+  return scenario === 'leaf'
+    ? path.join(sourceRoot, 'styles/style-00000.css.ts')
+    : path.join(sourceRoot, 'theme.ts')
+}
+
+export async function startHmrCase(
+  browser: Browser,
+  fixture: FixtureDescription,
+  plugin: VitePluginKind,
+): Promise<HmrCase> {
+  const root = fixturePath(fixture)
+  const server = await createServer({
+    root,
+    appType: 'spa',
+    cacheDir: path.join(root, `.vite-hmr-${plugin}`),
+    clearScreen: false,
+    configFile: false,
+    logLevel: 'silent',
+    plugins: createVitePlugins(plugin),
+    server: {
+      host: '127.0.0.1',
+      port: 0,
+      strictPort: false,
+    },
+  })
+
+  let context: BrowserContext | undefined
+  try {
+    await server.listen()
+    const address = server.httpServer?.address()
+    if (!address || typeof address === 'string') {
+      throw new Error(`Could not determine the Vite dev server port for ${plugin}`)
+    }
+
+    context = await browser.newContext()
+    const page = await context.newPage()
+    await page.goto(`http://127.0.0.1:${address.port}`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 60_000,
+    })
+    await page.waitForFunction(
+      () => {
+        const benchmarkWindow = window as typeof window & {
+          __vanillaExtractBenchmark?: BrowserRuntime
+        }
+        return benchmarkWindow.__vanillaExtractBenchmark?.ready === true
+      },
+      undefined,
+      {timeout: 60_000},
+    )
+
+    const runtime = await readBrowserRuntime(page)
+    assert.equal(runtime?.loads, 1, `${plugin} should load the page exactly once`)
+
+    return {
+      context,
+      currentIndex: {leaf: 0, shared: 0},
+      fixture,
+      page,
+      plugin,
+      server,
+    }
+  } catch (error) {
+    await context?.close()
+    await server.close()
+    throw error
+  }
+}
+
+export async function prepareHmrUpdate(testCase: HmrCase, scenario: HmrScenario): Promise<void> {
+  const runtime = await readBrowserRuntime(testCase.page)
+  assert(runtime?.ready, `${testCase.plugin} browser runtime is not ready`)
+  assert.equal(runtime.loads, 1, `${testCase.plugin} unexpectedly reloaded the page`)
+
+  const currentIndex = testCase.currentIndex[scenario]
+  const nextIndex = currentIndex === 0 ? 1 : 0
+  const filePath = scenarioFilePath(testCase, scenario)
+  const source = await readFile(filePath, 'utf8')
+  const currentColor = colors[scenario][currentIndex]
+  const expectedColor = colors[scenario][nextIndex]
+  assert(
+    source.includes(currentColor),
+    `Expected ${filePath} to contain the current ${scenario} color ${currentColor}`,
+  )
+
+  testCase.pendingUpdate = {
+    contents: source.replace(currentColor, expectedColor),
+    expectedColor,
+    filePath,
+    nextIndex,
+    previousUpdates: runtime.updates,
+    scenario,
+  }
+}
+
+export async function runPreparedHmrUpdate(testCase: HmrCase): Promise<void> {
+  const pending = testCase.pendingUpdate
+  if (!pending) throw new Error(`No prepared HMR update for ${testCase.plugin}`)
+  testCase.pendingUpdate = undefined
+  testCase.currentIndex[pending.scenario] = pending.nextIndex
+
+  await writeFile(pending.filePath, pending.contents)
+
+  try {
+    await testCase.page.waitForFunction(
+      ({expectedColor, previousUpdates, scenario}) => {
+        const benchmarkWindow = window as typeof window & {
+          __vanillaExtractBenchmark?: BrowserRuntime
+        }
+        const runtime = benchmarkWindow.__vanillaExtractBenchmark
+        const probe = document.querySelector('#probe')
+        if (!runtime || !(probe instanceof HTMLElement)) return false
+
+        const style = getComputedStyle(probe)
+        const actualColor = scenario === 'leaf' ? style.backgroundColor : style.color
+        return (
+          runtime.loads === 1 && runtime.updates > previousUpdates && actualColor === expectedColor
+        )
+      },
+      {
+        expectedColor: pending.expectedColor,
+        previousUpdates: pending.previousUpdates,
+        scenario: pending.scenario,
+      },
+      {
+        polling: 10,
+        timeout: Number.parseInt(process.env['VE_BENCH_HMR_TIMEOUT'] ?? '30000', 10),
+      },
+    )
+  } catch (error) {
+    const runtime = await readBrowserRuntime(testCase.page).catch(() => undefined)
+    const actualColor = await testCase.page
+      .locator('#probe')
+      .evaluate((probe, scenario) => {
+        const style = getComputedStyle(probe)
+        return scenario === 'leaf' ? style.backgroundColor : style.color
+      }, pending.scenario)
+      .catch(() => 'unavailable')
+    throw new Error(
+      `${testCase.plugin} ${pending.scenario} HMR did not settle: expected ${pending.expectedColor}, received ${actualColor}, runtime=${JSON.stringify(runtime)}`,
+      {cause: error},
+    )
+  }
+}
+
+export async function primeHmrCase(testCase: HmrCase): Promise<void> {
+  for (const scenario of ['leaf', 'shared'] as const) {
+    await prepareHmrUpdate(testCase, scenario)
+    await runPreparedHmrUpdate(testCase)
+  }
+}
+
+export async function stopHmrCase(testCase: HmrCase): Promise<void> {
+  await testCase.context.close()
+  await testCase.server.close()
+}

--- a/benchmarks/vanilla-extract/bench/helpers/hook-diagnostics.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/hook-diagnostics.ts
@@ -1,0 +1,110 @@
+import {mkdir, rm, writeFile} from 'node:fs/promises'
+import path from 'node:path'
+import {build, type Plugin} from 'vite'
+import type {VitePluginKind} from './commands.ts'
+import {fixturePath, resultsRoot, type FixtureDescription} from './paths.ts'
+import {createVitePlugins} from './plugins.ts'
+
+const hookNames = ['resolveId', 'load', 'transform'] as const
+type HookName = (typeof hookNames)[number]
+type HookCounts = Record<HookName, number>
+
+export interface HookDiagnosticResult extends HookCounts {
+  plainModules: number
+  plugin: VitePluginKind
+  styleModules: number
+}
+
+type UnknownFunction = (this: unknown, ...arguments_: unknown[]) => unknown
+
+function instrumentHook(plugin: Plugin, hookName: HookName, counts: HookCounts): Plugin {
+  const source = plugin as unknown as Record<string, unknown>
+  const hook = source[hookName]
+  if (!hook) return plugin
+
+  const clone = {...source}
+  if (typeof hook === 'function') {
+    const handler = hook as UnknownFunction
+    clone[hookName] = function (this: unknown, ...arguments_: unknown[]) {
+      counts[hookName] += 1
+      return Reflect.apply(handler, this, arguments_)
+    }
+  } else if (typeof hook === 'object' && 'handler' in hook) {
+    const objectHook = hook as Record<string, unknown>
+    const handler = objectHook['handler']
+    if (typeof handler !== 'function') return plugin
+
+    clone[hookName] = {
+      ...objectHook,
+      handler(this: unknown, ...arguments_: unknown[]) {
+        counts[hookName] += 1
+        return Reflect.apply(handler as UnknownFunction, this, arguments_)
+      },
+    }
+  }
+
+  return clone as unknown as Plugin
+}
+
+function instrumentPlugins(plugins: Plugin[], counts: HookCounts): Plugin[] {
+  return plugins.map((plugin) =>
+    hookNames.reduce(
+      (instrumented, hookName) => instrumentHook(instrumented, hookName, counts),
+      plugin,
+    ),
+  )
+}
+
+async function collectHookCounts(
+  fixture: FixtureDescription,
+  plugin: VitePluginKind,
+): Promise<HookDiagnosticResult> {
+  const counts: HookCounts = {load: 0, resolveId: 0, transform: 0}
+  const root = fixturePath(fixture)
+  const cacheDirectory = path.join(root, `.vite-diagnostic-${plugin}`)
+  await rm(cacheDirectory, {recursive: true, force: true})
+
+  await build({
+    root,
+    cacheDir: cacheDirectory,
+    clearScreen: false,
+    configFile: false,
+    logLevel: 'silent',
+    plugins: instrumentPlugins(createVitePlugins(plugin), counts),
+    build: {
+      copyPublicDir: false,
+      cssMinify: false,
+      minify: false,
+      reportCompressedSize: false,
+      sourcemap: false,
+      write: false,
+    },
+  })
+
+  return {
+    ...counts,
+    plainModules: fixture.plainModules,
+    plugin,
+    styleModules: fixture.styleModules,
+  }
+}
+
+export async function runHookDiagnostics(
+  fixtures: FixtureDescription[],
+): Promise<HookDiagnosticResult[]> {
+  const results: HookDiagnosticResult[] = []
+  for (const fixture of fixtures) {
+    for (const plugin of ['official', 'sanity'] as const) {
+      results.push(await collectHookCounts(fixture, plugin))
+    }
+  }
+
+  console.log('JavaScript plugin hook entries (untimed diagnostic)')
+  console.table(results)
+  await mkdir(resultsRoot, {recursive: true})
+  await writeFile(
+    path.join(resultsRoot, 'vite-hook-counts.json'),
+    `${JSON.stringify(results, null, 2)}\n`,
+  )
+  return results
+}

--- a/benchmarks/vanilla-extract/bench/helpers/hook-diagnostics.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/hook-diagnostics.ts
@@ -86,7 +86,7 @@ async function collectHookCounts(
     clearScreen: false,
     configFile: false,
     logLevel: 'silent',
-    plugins: instrumentPlugins(createVitePlugins(plugin), counts),
+    plugins: instrumentPlugins(await createVitePlugins(plugin), counts),
     build: {
       copyPublicDir: false,
       cssMinify: false,

--- a/benchmarks/vanilla-extract/bench/helpers/hook-diagnostics.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/hook-diagnostics.ts
@@ -15,44 +15,60 @@ export interface HookDiagnosticResult extends HookCounts {
   styleModules: number
 }
 
-type UnknownFunction = (this: unknown, ...arguments_: unknown[]) => unknown
-
-function instrumentHook(plugin: Plugin, hookName: HookName, counts: HookCounts): Plugin {
-  const source = plugin as unknown as Record<string, unknown>
-  const hook = source[hookName]
-  if (!hook) return plugin
-
-  const clone = {...source}
-  if (typeof hook === 'function') {
-    const handler = hook as UnknownFunction
-    clone[hookName] = function (this: unknown, ...arguments_: unknown[]) {
-      counts[hookName] += 1
-      return Reflect.apply(handler, this, arguments_)
+function instrumentPlugin(plugin: Plugin, counts: HookCounts): Plugin {
+  const resolveId = plugin.resolveId
+  if (typeof resolveId === 'function') {
+    const wrapped: typeof resolveId = function (...arguments_) {
+      counts.resolveId += 1
+      return resolveId.apply(this, arguments_)
     }
-  } else if (typeof hook === 'object' && 'handler' in hook) {
-    const objectHook = hook as Record<string, unknown>
-    const handler = objectHook['handler']
-    if (typeof handler !== 'function') return plugin
-
-    clone[hookName] = {
-      ...objectHook,
-      handler(this: unknown, ...arguments_: unknown[]) {
-        counts[hookName] += 1
-        return Reflect.apply(handler as UnknownFunction, this, arguments_)
-      },
+    plugin.resolveId = wrapped
+  } else if (resolveId) {
+    const {handler} = resolveId
+    const wrapped: typeof handler = function (...arguments_) {
+      counts.resolveId += 1
+      return handler.apply(this, arguments_)
     }
+    plugin.resolveId = {...resolveId, handler: wrapped}
   }
 
-  return clone as unknown as Plugin
+  const load = plugin.load
+  if (typeof load === 'function') {
+    const wrapped: typeof load = function (...arguments_) {
+      counts.load += 1
+      return load.apply(this, arguments_)
+    }
+    plugin.load = wrapped
+  } else if (load) {
+    const {handler} = load
+    const wrapped: typeof handler = function (...arguments_) {
+      counts.load += 1
+      return handler.apply(this, arguments_)
+    }
+    plugin.load = {...load, handler: wrapped}
+  }
+
+  const transform = plugin.transform
+  if (typeof transform === 'function') {
+    const wrapped: typeof transform = function (...arguments_) {
+      counts.transform += 1
+      return transform.apply(this, arguments_)
+    }
+    plugin.transform = wrapped
+  } else if (transform) {
+    const {handler} = transform
+    const wrapped: typeof handler = function (...arguments_) {
+      counts.transform += 1
+      return handler.apply(this, arguments_)
+    }
+    plugin.transform = {...transform, handler: wrapped}
+  }
+
+  return plugin
 }
 
 function instrumentPlugins(plugins: Plugin[], counts: HookCounts): Plugin[] {
-  return plugins.map((plugin) =>
-    hookNames.reduce(
-      (instrumented, hookName) => instrumentHook(instrumented, hookName, counts),
-      plugin,
-    ),
-  )
+  return plugins.map((plugin) => instrumentPlugin(plugin, counts))
 }
 
 async function collectHookCounts(
@@ -99,7 +115,9 @@ export async function runHookDiagnostics(
     }
   }
 
+  // eslint-disable-next-line no-console
   console.log('JavaScript plugin hook entries (untimed diagnostic)')
+  // eslint-disable-next-line no-console
   console.table(results)
   await mkdir(resultsRoot, {recursive: true})
   await writeFile(

--- a/benchmarks/vanilla-extract/bench/helpers/options.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/options.ts
@@ -1,0 +1,51 @@
+import {rm} from 'node:fs/promises'
+import type {BenchOptions} from 'vitest'
+
+type BenchmarkKind = 'build' | 'hmr' | 'stress'
+
+const defaultIterations: Record<BenchmarkKind, number> = {
+  build: 5,
+  hmr: 10,
+  stress: 3,
+}
+
+const environmentNames: Record<BenchmarkKind, string> = {
+  build: 'VE_BENCH_BUILD_ITERATIONS',
+  hmr: 'VE_BENCH_HMR_ITERATIONS',
+  stress: 'VE_BENCH_STRESS_ITERATIONS',
+}
+
+function readPositiveInteger(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (raw === undefined) return fallback
+
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer, received ${raw}`)
+  }
+  return parsed
+}
+
+export function fixedBenchmarkOptions(
+  kind: BenchmarkKind,
+  overrides: Pick<BenchOptions, 'setup' | 'teardown'> = {},
+): BenchOptions {
+  return {
+    iterations: readPositiveInteger(environmentNames[kind], defaultIterations[kind]),
+    time: 0,
+    warmupIterations: readPositiveInteger('VE_BENCH_WARMUP_ITERATIONS', 1),
+    warmupTime: 0,
+    ...overrides,
+  }
+}
+
+export function coldBuildOptions(
+  kind: Extract<BenchmarkKind, 'build' | 'stress'>,
+  outputDirectory: string,
+  teardown: () => Promise<void>,
+): BenchOptions {
+  return fixedBenchmarkOptions(kind, {
+    setup: () => rm(outputDirectory, {recursive: true, force: true}),
+    teardown,
+  })
+}

--- a/benchmarks/vanilla-extract/bench/helpers/options.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/options.ts
@@ -28,11 +28,12 @@ function readPositiveInteger(name: string, fallback: number): number {
 
 export function fixedBenchmarkOptions(
   kind: BenchmarkKind,
-  overrides: Pick<BenchOptions, 'setup' | 'teardown'> = {},
+  overrides: Pick<BenchOptions, 'now' | 'setup' | 'teardown'> = {},
 ): BenchOptions {
   return {
     iterations: readPositiveInteger(environmentNames[kind], defaultIterations[kind]),
     time: 0,
+    throws: true,
     warmupIterations: readPositiveInteger('VE_BENCH_WARMUP_ITERATIONS', 1),
     warmupTime: 0,
     ...overrides,
@@ -42,7 +43,7 @@ export function fixedBenchmarkOptions(
 export function coldBuildOptions(
   kind: Extract<BenchmarkKind, 'build' | 'stress'>,
   outputDirectory: string,
-  teardown: () => Promise<void>,
+  teardown: () => void | Promise<void>,
 ): BenchOptions {
   return fixedBenchmarkOptions(kind, {
     setup: () => rm(outputDirectory, {recursive: true, force: true}),

--- a/benchmarks/vanilla-extract/bench/helpers/output.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/output.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import {readdir, readFile} from 'node:fs/promises'
+import path from 'node:path'
+import {pathToFileURL} from 'node:url'
+
+const cssMarker = /rgb\(\s*1\s*,\s*2\s*,\s*3\s*\)|#010203/i
+
+async function listFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, {withFileTypes: true})
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(directory, entry.name)
+      return entry.isDirectory() ? listFiles(entryPath) : [entryPath]
+    }),
+  )
+  return files.flat()
+}
+
+async function assertCssOutput(outputDirectory: string): Promise<void> {
+  const files = await listFiles(outputDirectory)
+  const cssFiles = files.filter((filePath) => filePath.endsWith('.css'))
+  assert(cssFiles.length > 0, `Expected CSS output in ${outputDirectory}`)
+
+  const css = (await Promise.all(cssFiles.map((filePath) => readFile(filePath, 'utf8')))).join('\n')
+  assert(
+    cssMarker.test(css),
+    `Expected the shared color marker in CSS output at ${outputDirectory}`,
+  )
+}
+
+export async function assertLibraryOutput(outputDirectory: string): Promise<void> {
+  await assertCssOutput(outputDirectory)
+
+  const entryPath = path.join(outputDirectory, 'index.mjs')
+  const entry = (await import(`${pathToFileURL(entryPath).href}?t=${Date.now()}`)) as {
+    getBenchmarkClassName?: unknown
+    plainTotal?: unknown
+  }
+  assert.equal(
+    typeof entry.getBenchmarkClassName,
+    'function',
+    `Expected getBenchmarkClassName export in ${entryPath}`,
+  )
+  assert.equal(typeof entry.plainTotal, 'number', `Expected plainTotal export in ${entryPath}`)
+  assert(
+    (entry.getBenchmarkClassName as () => string)().length > 0,
+    `Expected a generated class name from ${entryPath}`,
+  )
+}
+
+export async function assertViteOutput(outputDirectory: string): Promise<void> {
+  await assertCssOutput(outputDirectory)
+
+  const files = await listFiles(outputDirectory)
+  assert(
+    files.some((filePath) => filePath.endsWith('.js')),
+    `Expected JavaScript output in ${outputDirectory}`,
+  )
+  assert(
+    files.some((filePath) => path.basename(filePath) === 'index.html'),
+    `Expected index.html output in ${outputDirectory}`,
+  )
+}

--- a/benchmarks/vanilla-extract/bench/helpers/output.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/output.ts
@@ -40,6 +40,12 @@ async function assertCssOutput(outputDirectory: string): Promise<void> {
   )
 }
 
+export function readCssOutputSync(outputDirectory: string): string {
+  const cssFiles = listFilesSync(outputDirectory).filter((filePath) => filePath.endsWith('.css'))
+  assert(cssFiles.length > 0, `Expected CSS output in ${outputDirectory}`)
+  return cssFiles.map((filePath) => readFileSync(filePath, 'utf8')).join('\n')
+}
+
 function assertCssOutputSync(outputDirectory: string): void {
   const files = listFilesSync(outputDirectory)
   const cssFiles = files.filter((filePath) => filePath.endsWith('.css'))

--- a/benchmarks/vanilla-extract/bench/helpers/output.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/output.ts
@@ -1,9 +1,14 @@
 import assert from 'node:assert/strict'
+import {readdirSync, readFileSync} from 'node:fs'
 import {readdir, readFile} from 'node:fs/promises'
 import path from 'node:path'
 import {pathToFileURL} from 'node:url'
 
 const cssMarker = /rgb\(\s*1\s*,\s*2\s*,\s*3\s*\)|#010203/i
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
 
 async function listFiles(directory: string): Promise<string[]> {
   const entries = await readdir(directory, {withFileTypes: true})
@@ -14,6 +19,13 @@ async function listFiles(directory: string): Promise<string[]> {
     }),
   )
   return files.flat()
+}
+
+function listFilesSync(directory: string): string[] {
+  return readdirSync(directory, {withFileTypes: true}).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name)
+    return entry.isDirectory() ? listFilesSync(entryPath) : [entryPath]
+  })
 }
 
 async function assertCssOutput(outputDirectory: string): Promise<void> {
@@ -28,22 +40,32 @@ async function assertCssOutput(outputDirectory: string): Promise<void> {
   )
 }
 
+function assertCssOutputSync(outputDirectory: string): void {
+  const files = listFilesSync(outputDirectory)
+  const cssFiles = files.filter((filePath) => filePath.endsWith('.css'))
+  assert(cssFiles.length > 0, `Expected CSS output in ${outputDirectory}`)
+
+  const css = cssFiles.map((filePath) => readFileSync(filePath, 'utf8')).join('\n')
+  assert(
+    cssMarker.test(css),
+    `Expected the shared color marker in CSS output at ${outputDirectory}`,
+  )
+}
+
 export async function assertLibraryOutput(outputDirectory: string): Promise<void> {
   await assertCssOutput(outputDirectory)
 
   const entryPath = path.join(outputDirectory, 'index.mjs')
-  const entry = (await import(`${pathToFileURL(entryPath).href}?t=${Date.now()}`)) as {
-    getBenchmarkClassName?: unknown
-    plainTotal?: unknown
+  const entry: unknown = await import(`${pathToFileURL(entryPath).href}?t=${Date.now()}`)
+  assert(isRecord(entry), `Expected an object module namespace from ${entryPath}`)
+  const getBenchmarkClassName = entry['getBenchmarkClassName']
+  if (typeof getBenchmarkClassName !== 'function') {
+    throw new Error(`Expected getBenchmarkClassName export in ${entryPath}`)
   }
-  assert.equal(
-    typeof entry.getBenchmarkClassName,
-    'function',
-    `Expected getBenchmarkClassName export in ${entryPath}`,
-  )
-  assert.equal(typeof entry.plainTotal, 'number', `Expected plainTotal export in ${entryPath}`)
+  assert.equal(typeof entry['plainTotal'], 'number', `Expected plainTotal export in ${entryPath}`)
+  const className: unknown = Reflect.apply(getBenchmarkClassName, undefined, [])
   assert(
-    (entry.getBenchmarkClassName as () => string)().length > 0,
+    typeof className === 'string' && className.length > 0,
     `Expected a generated class name from ${entryPath}`,
   )
 }
@@ -52,6 +74,29 @@ export async function assertViteOutput(outputDirectory: string): Promise<void> {
   await assertCssOutput(outputDirectory)
 
   const files = await listFiles(outputDirectory)
+  assert(
+    files.some((filePath) => filePath.endsWith('.js')),
+    `Expected JavaScript output in ${outputDirectory}`,
+  )
+  assert(
+    files.some((filePath) => path.basename(filePath) === 'index.html'),
+    `Expected index.html output in ${outputDirectory}`,
+  )
+}
+
+export function assertLibraryOutputSync(outputDirectory: string): void {
+  assertCssOutputSync(outputDirectory)
+
+  const entryPath = path.join(outputDirectory, 'index.mjs')
+  const source = readFileSync(entryPath, 'utf8')
+  assert.match(source, /getBenchmarkClassName/)
+  assert.match(source, /plainTotal/)
+}
+
+export function assertViteOutputSync(outputDirectory: string): void {
+  assertCssOutputSync(outputDirectory)
+
+  const files = listFilesSync(outputDirectory)
   assert(
     files.some((filePath) => filePath.endsWith('.js')),
     `Expected JavaScript output in ${outputDirectory}`,

--- a/benchmarks/vanilla-extract/bench/helpers/paths.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/paths.ts
@@ -1,0 +1,42 @@
+import {readFile} from 'node:fs/promises'
+import path from 'node:path'
+
+export const benchmarkRoot = path.resolve(import.meta.dirname, '../..')
+export const generatedRoot = path.join(benchmarkRoot, '.generated')
+export const resultsRoot = path.join(benchmarkRoot, 'results')
+
+export const configPaths = {
+  rolldown: path.join(benchmarkRoot, 'config/rolldown.config.mjs'),
+  rollup: path.join(benchmarkRoot, 'config/rollup.config.mjs'),
+  vite: path.join(benchmarkRoot, 'config/vite.config.mjs'),
+} as const
+
+export interface FixtureDescription {
+  directory: string
+  plainModules: number
+  styleModules: number
+}
+
+export interface FixtureManifest {
+  version: 1
+  representative: FixtureDescription
+  stress: FixtureDescription[]
+  hmr: {
+    official: FixtureDescription
+    sanity: FixtureDescription
+  }
+}
+
+export function fixturePath(fixture: FixtureDescription): string {
+  return path.join(generatedRoot, fixture.directory)
+}
+
+export async function loadFixtureManifest(): Promise<FixtureManifest> {
+  const manifestPath = path.join(generatedRoot, 'manifest.json')
+  const contents = await readFile(manifestPath, 'utf8')
+  const manifest = JSON.parse(contents) as Partial<FixtureManifest>
+  if (manifest.version !== 1 || !manifest.representative || !manifest.stress || !manifest.hmr) {
+    throw new Error(`Invalid fixture manifest at ${manifestPath}; run pnpm benchmark:prepare`)
+  }
+  return manifest as FixtureManifest
+}

--- a/benchmarks/vanilla-extract/bench/helpers/paths.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/paths.ts
@@ -27,6 +27,36 @@ export interface FixtureManifest {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isFixtureDescription(value: unknown): value is FixtureDescription {
+  return (
+    isRecord(value) &&
+    typeof value['directory'] === 'string' &&
+    typeof value['plainModules'] === 'number' &&
+    typeof value['styleModules'] === 'number'
+  )
+}
+
+function isFixtureManifest(value: unknown): value is FixtureManifest {
+  if (
+    !isRecord(value) ||
+    value['version'] !== 1 ||
+    !isFixtureDescription(value['representative']) ||
+    !Array.isArray(value['stress']) ||
+    !value['stress'].every(isFixtureDescription)
+  ) {
+    return false
+  }
+
+  const hmr = value['hmr']
+  return (
+    isRecord(hmr) && isFixtureDescription(hmr['official']) && isFixtureDescription(hmr['sanity'])
+  )
+}
+
 export function fixturePath(fixture: FixtureDescription): string {
   return path.join(generatedRoot, fixture.directory)
 }
@@ -34,9 +64,9 @@ export function fixturePath(fixture: FixtureDescription): string {
 export async function loadFixtureManifest(): Promise<FixtureManifest> {
   const manifestPath = path.join(generatedRoot, 'manifest.json')
   const contents = await readFile(manifestPath, 'utf8')
-  const manifest = JSON.parse(contents) as Partial<FixtureManifest>
-  if (manifest.version !== 1 || !manifest.representative || !manifest.stress || !manifest.hmr) {
+  const manifest: unknown = JSON.parse(contents)
+  if (!isFixtureManifest(manifest)) {
     throw new Error(`Invalid fixture manifest at ${manifestPath}; run pnpm benchmark:prepare`)
   }
-  return manifest as FixtureManifest
+  return manifest
 }

--- a/benchmarks/vanilla-extract/bench/helpers/plugins.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/plugins.ts
@@ -1,10 +1,15 @@
-import {vanillaExtractPlugin as sanityVanillaExtractPlugin} from '@sanity/vanilla-extract-vite-plugin'
-import {vanillaExtractPlugin as officialVanillaExtractPlugin} from '@vanilla-extract/vite-plugin'
 import type {Plugin} from 'vite'
 import type {VitePluginKind} from './commands.ts'
 
-export function createVitePlugins(plugin: VitePluginKind): Plugin[] {
-  return plugin === 'official'
-    ? officialVanillaExtractPlugin({identifiers: 'short'})
-    : sanityVanillaExtractPlugin({identifiers: 'short'})
+/**
+ * Lazily imports only the requested plugin package, so a benchmark process never evaluates
+ * (or initializes module-level state of) the competing implementation.
+ */
+export async function createVitePlugins(plugin: VitePluginKind): Promise<Plugin[]> {
+  if (plugin === 'official') {
+    const {vanillaExtractPlugin} = await import('@vanilla-extract/vite-plugin')
+    return vanillaExtractPlugin({identifiers: 'short'})
+  }
+  const {vanillaExtractPlugin} = await import('@sanity/vanilla-extract-vite-plugin')
+  return vanillaExtractPlugin({identifiers: 'short'})
 }

--- a/benchmarks/vanilla-extract/bench/helpers/plugins.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/plugins.ts
@@ -1,0 +1,10 @@
+import {vanillaExtractPlugin as sanityVanillaExtractPlugin} from '@sanity/vanilla-extract-vite-plugin'
+import {vanillaExtractPlugin as officialVanillaExtractPlugin} from '@vanilla-extract/vite-plugin'
+import type {Plugin} from 'vite'
+import type {VitePluginKind} from './commands.ts'
+
+export function createVitePlugins(plugin: VitePluginKind): Plugin[] {
+  return plugin === 'official'
+    ? officialVanillaExtractPlugin({identifiers: 'short'})
+    : sanityVanillaExtractPlugin({identifiers: 'short'})
+}

--- a/benchmarks/vanilla-extract/bench/helpers/variants.ts
+++ b/benchmarks/vanilla-extract/bench/helpers/variants.ts
@@ -1,0 +1,19 @@
+/**
+ * The build variant matrix: CSS minification and syntax downleveling (`target`) are toggled
+ * independently and combined, since both flow through different code paths in each plugin.
+ */
+export interface BuildVariant {
+  /** Stable slug used in output directory names. */
+  slug: string
+  /** Human-readable label used in benchmark names. */
+  label: string
+  minify: boolean
+  target: string | false
+}
+
+export const buildVariants: BuildVariant[] = [
+  {slug: 'baseline', label: 'no minify, no target', minify: false, target: false},
+  {slug: 'minify', label: 'minify', minify: true, target: false},
+  {slug: 'target', label: 'target chrome61', minify: false, target: 'chrome61'},
+  {slug: 'minify-target', label: 'minify + target chrome61', minify: true, target: 'chrome61'},
+]

--- a/benchmarks/vanilla-extract/bench/vite-build.bench.ts
+++ b/benchmarks/vanilla-extract/bench/vite-build.bench.ts
@@ -1,0 +1,25 @@
+import path from 'node:path'
+import {bench, describe} from 'vitest'
+import {runViteBuild} from './helpers/commands.ts'
+import {coldBuildOptions} from './helpers/options.ts'
+import {assertViteOutput} from './helpers/output.ts'
+import {fixturePath, generatedRoot, loadFixtureManifest} from './helpers/paths.ts'
+
+const manifest = await loadFixtureManifest()
+const fixtureRoot = fixturePath(manifest.representative)
+
+describe(`vite build (${manifest.representative.plainModules} TS + ${manifest.representative.styleModules} CSS modules)`, () => {
+  for (const plugin of ['official', 'sanity'] as const) {
+    const outputDirectory = path.join(generatedRoot, `output/vite-build-${plugin}`)
+    const packageName =
+      plugin === 'official' ? '@vanilla-extract/vite-plugin' : '@sanity/vanilla-extract-vite-plugin'
+
+    bench(
+      `Vite 8 + ${packageName}`,
+      async () => {
+        await runViteBuild(fixtureRoot, outputDirectory, plugin)
+      },
+      coldBuildOptions('build', outputDirectory, () => assertViteOutput(outputDirectory)),
+    )
+  }
+})

--- a/benchmarks/vanilla-extract/bench/vite-build.bench.ts
+++ b/benchmarks/vanilla-extract/bench/vite-build.bench.ts
@@ -4,30 +4,25 @@ import {runViteBuild} from './helpers/commands.ts'
 import {coldBuildOptions} from './helpers/options.ts'
 import {assertViteOutputSync} from './helpers/output.ts'
 import {fixturePath, generatedRoot, loadFixtureManifest} from './helpers/paths.ts'
-import {buildVariants} from './helpers/variants.ts'
 
 const manifest = await loadFixtureManifest()
 const fixtureRoot = fixturePath(manifest.representative)
 
-for (const variant of buildVariants) {
-  describe(`vite build, ${variant.label} (${manifest.representative.plainModules} TS + ${manifest.representative.styleModules} CSS modules)`, () => {
-    for (const plugin of ['official', 'sanity'] as const) {
-      const outputDirectory = path.join(
-        generatedRoot,
-        `output/vite-build-${variant.slug}-${plugin}`,
-      )
-      const packageName =
-        plugin === 'official'
-          ? '@vanilla-extract/vite-plugin'
-          : '@sanity/vanilla-extract-vite-plugin'
+// No minify/target variants here: in the Vite comparison those are handled by Vite itself,
+// identically for both plugins, so they would only add identical work to both sides. The
+// library-build benchmark covers the variant matrix where each plugin owns that work.
+describe(`vite build (${manifest.representative.plainModules} TS + ${manifest.representative.styleModules} CSS modules)`, () => {
+  for (const plugin of ['official', 'sanity'] as const) {
+    const outputDirectory = path.join(generatedRoot, `output/vite-build-${plugin}`)
+    const packageName =
+      plugin === 'official' ? '@vanilla-extract/vite-plugin' : '@sanity/vanilla-extract-vite-plugin'
 
-      bench(
-        `Vite 8 + ${packageName}`,
-        async () => {
-          await runViteBuild(fixtureRoot, outputDirectory, plugin, {variant})
-        },
-        coldBuildOptions('build', outputDirectory, () => assertViteOutputSync(outputDirectory)),
-      )
-    }
-  })
-}
+    bench(
+      `Vite 8 + ${packageName}`,
+      async () => {
+        await runViteBuild(fixtureRoot, outputDirectory, plugin)
+      },
+      coldBuildOptions('build', outputDirectory, () => assertViteOutputSync(outputDirectory)),
+    )
+  }
+})

--- a/benchmarks/vanilla-extract/bench/vite-build.bench.ts
+++ b/benchmarks/vanilla-extract/bench/vite-build.bench.ts
@@ -4,22 +4,30 @@ import {runViteBuild} from './helpers/commands.ts'
 import {coldBuildOptions} from './helpers/options.ts'
 import {assertViteOutputSync} from './helpers/output.ts'
 import {fixturePath, generatedRoot, loadFixtureManifest} from './helpers/paths.ts'
+import {buildVariants} from './helpers/variants.ts'
 
 const manifest = await loadFixtureManifest()
 const fixtureRoot = fixturePath(manifest.representative)
 
-describe(`vite build (${manifest.representative.plainModules} TS + ${manifest.representative.styleModules} CSS modules)`, () => {
-  for (const plugin of ['official', 'sanity'] as const) {
-    const outputDirectory = path.join(generatedRoot, `output/vite-build-${plugin}`)
-    const packageName =
-      plugin === 'official' ? '@vanilla-extract/vite-plugin' : '@sanity/vanilla-extract-vite-plugin'
+for (const variant of buildVariants) {
+  describe(`vite build, ${variant.label} (${manifest.representative.plainModules} TS + ${manifest.representative.styleModules} CSS modules)`, () => {
+    for (const plugin of ['official', 'sanity'] as const) {
+      const outputDirectory = path.join(
+        generatedRoot,
+        `output/vite-build-${variant.slug}-${plugin}`,
+      )
+      const packageName =
+        plugin === 'official'
+          ? '@vanilla-extract/vite-plugin'
+          : '@sanity/vanilla-extract-vite-plugin'
 
-    bench(
-      `Vite 8 + ${packageName}`,
-      async () => {
-        await runViteBuild(fixtureRoot, outputDirectory, plugin)
-      },
-      coldBuildOptions('build', outputDirectory, () => assertViteOutputSync(outputDirectory)),
-    )
-  }
-})
+      bench(
+        `Vite 8 + ${packageName}`,
+        async () => {
+          await runViteBuild(fixtureRoot, outputDirectory, plugin, {variant})
+        },
+        coldBuildOptions('build', outputDirectory, () => assertViteOutputSync(outputDirectory)),
+      )
+    }
+  })
+}

--- a/benchmarks/vanilla-extract/bench/vite-build.bench.ts
+++ b/benchmarks/vanilla-extract/bench/vite-build.bench.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import {bench, describe} from 'vitest'
 import {runViteBuild} from './helpers/commands.ts'
 import {coldBuildOptions} from './helpers/options.ts'
-import {assertViteOutput} from './helpers/output.ts'
+import {assertViteOutputSync} from './helpers/output.ts'
 import {fixturePath, generatedRoot, loadFixtureManifest} from './helpers/paths.ts'
 
 const manifest = await loadFixtureManifest()
@@ -19,7 +19,7 @@ describe(`vite build (${manifest.representative.plainModules} TS + ${manifest.re
       async () => {
         await runViteBuild(fixtureRoot, outputDirectory, plugin)
       },
-      coldBuildOptions('build', outputDirectory, () => assertViteOutput(outputDirectory)),
+      coldBuildOptions('build', outputDirectory, () => assertViteOutputSync(outputDirectory)),
     )
   }
 })

--- a/benchmarks/vanilla-extract/bench/vite-hmr.bench.ts
+++ b/benchmarks/vanilla-extract/bench/vite-hmr.bench.ts
@@ -1,10 +1,11 @@
+import {performance} from 'node:perf_hooks'
+import {setTimeout as delay} from 'node:timers/promises'
 import {chromium, type Browser} from 'playwright'
 import {afterAll, beforeAll, bench, describe} from 'vitest'
 import type {VitePluginKind} from './helpers/commands.ts'
 import {
-  prepareHmrUpdate,
   primeHmrCase,
-  runPreparedHmrUpdate,
+  runHmrUpdate,
   startHmrCase,
   stopHmrCase,
   type HmrCase,
@@ -50,11 +51,19 @@ function registerHmrBenchmark(
   scenario: HmrScenario,
   packageName: string,
 ): void {
+  let excludedDuration = 0
+  const settleMilliseconds = Number.parseInt(process.env['VE_BENCH_HMR_SETTLE'] ?? '250', 10)
+
   bench(
     packageName,
-    () => runPreparedHmrUpdate(getTestCase(plugin)),
+    async () => {
+      const settleStart = performance.now()
+      await delay(settleMilliseconds)
+      excludedDuration += performance.now() - settleStart
+      await runHmrUpdate(getTestCase(plugin), scenario)
+    },
     fixedBenchmarkOptions('hmr', {
-      setup: () => prepareHmrUpdate(getTestCase(plugin), scenario),
+      now: () => performance.now() - excludedDuration,
     }),
   )
 }

--- a/benchmarks/vanilla-extract/bench/vite-hmr.bench.ts
+++ b/benchmarks/vanilla-extract/bench/vite-hmr.bench.ts
@@ -1,0 +1,72 @@
+import {chromium, type Browser} from 'playwright'
+import {afterAll, beforeAll, bench, describe} from 'vitest'
+import type {VitePluginKind} from './helpers/commands.ts'
+import {
+  prepareHmrUpdate,
+  primeHmrCase,
+  runPreparedHmrUpdate,
+  startHmrCase,
+  stopHmrCase,
+  type HmrCase,
+  type HmrScenario,
+} from './helpers/hmr.ts'
+import {fixedBenchmarkOptions} from './helpers/options.ts'
+import {loadFixtureManifest} from './helpers/paths.ts'
+
+const manifest = await loadFixtureManifest()
+const testCases: Partial<Record<VitePluginKind, HmrCase>> = {}
+let browser: Browser | undefined
+
+function getTestCase(plugin: VitePluginKind): HmrCase {
+  const testCase = testCases[plugin]
+  if (!testCase) throw new Error(`HMR case for ${plugin} has not started`)
+  return testCase
+}
+
+beforeAll(async () => {
+  try {
+    browser = await chromium.launch({headless: true})
+  } catch (error) {
+    throw new Error(
+      'Chromium is required for the HMR benchmark. Run `pnpm --filter @benchmarks/vanilla-extract install-browser` first.',
+      {cause: error},
+    )
+  }
+
+  for (const plugin of ['official', 'sanity'] as const) {
+    const testCase = await startHmrCase(browser, manifest.hmr[plugin], plugin)
+    testCases[plugin] = testCase
+    await primeHmrCase(testCase)
+  }
+}, 180_000)
+
+afterAll(async () => {
+  await Promise.all(Object.values(testCases).map((testCase) => stopHmrCase(testCase)))
+  await browser?.close()
+}, 120_000)
+
+function registerHmrBenchmark(
+  plugin: VitePluginKind,
+  scenario: HmrScenario,
+  packageName: string,
+): void {
+  bench(
+    packageName,
+    () => runPreparedHmrUpdate(getTestCase(plugin)),
+    fixedBenchmarkOptions('hmr', {
+      setup: () => prepareHmrUpdate(getTestCase(plugin), scenario),
+    }),
+  )
+}
+
+for (const scenario of ['leaf', 'shared'] as const) {
+  const title =
+    scenario === 'leaf'
+      ? 'single .css.ts leaf edit'
+      : `shared theme edit (${manifest.hmr.official.styleModules} style importers)`
+
+  describe(title, () => {
+    registerHmrBenchmark('official', scenario, 'Vite 8 + @vanilla-extract/vite-plugin')
+    registerHmrBenchmark('sanity', scenario, 'Vite 8 + @sanity/vanilla-extract-vite-plugin')
+  })
+}

--- a/benchmarks/vanilla-extract/bench/vite-hook-filter.bench.ts
+++ b/benchmarks/vanilla-extract/bench/vite-hook-filter.bench.ts
@@ -1,0 +1,50 @@
+import path from 'node:path'
+import {beforeAll, bench, describe} from 'vitest'
+import {runViteBuild, type CommandResult} from './helpers/commands.ts'
+import {runHookDiagnostics} from './helpers/hook-diagnostics.ts'
+import {coldBuildOptions} from './helpers/options.ts'
+import {assertViteOutput} from './helpers/output.ts'
+import {fixturePath, generatedRoot, loadFixtureManifest} from './helpers/paths.ts'
+
+const manifest = await loadFixtureManifest()
+const surfacedWarnings = new Set<string>()
+
+beforeAll(async () => {
+  await runHookDiagnostics(manifest.stress)
+}, 300_000)
+
+function surfacePluginTimingWarning(name: string, result: CommandResult | undefined): void {
+  if (!result || surfacedWarnings.has(name)) return
+  const output = `${result.stdout}\n${result.stderr}`
+  if (!output.includes('[PLUGIN_TIMINGS]')) return
+
+  surfacedWarnings.add(name)
+  console.warn(`Rolldown plugin timing diagnostic for ${name}:\n${output.trim()}`)
+}
+
+for (const fixture of manifest.stress) {
+  describe(`${fixture.plainModules} unrelated TS modules`, () => {
+    for (const plugin of ['official', 'sanity'] as const) {
+      const name =
+        plugin === 'official'
+          ? '@vanilla-extract/vite-plugin'
+          : '@sanity/vanilla-extract-vite-plugin'
+      const outputDirectory = path.join(
+        generatedRoot,
+        `output/vite-hooks-${fixture.plainModules}-${plugin}`,
+      )
+      let lastResult: CommandResult | undefined
+
+      bench(
+        name,
+        async () => {
+          lastResult = await runViteBuild(fixturePath(fixture), outputDirectory, plugin, true)
+        },
+        coldBuildOptions('stress', outputDirectory, async () => {
+          await assertViteOutput(outputDirectory)
+          surfacePluginTimingWarning(`${fixture.plainModules}/${plugin}`, lastResult)
+        }),
+      )
+    }
+  })
+}

--- a/benchmarks/vanilla-extract/bench/vite-hook-filter.bench.ts
+++ b/benchmarks/vanilla-extract/bench/vite-hook-filter.bench.ts
@@ -39,7 +39,9 @@ for (const fixture of manifest.stress) {
       bench(
         name,
         async () => {
-          lastResult = await runViteBuild(fixturePath(fixture), outputDirectory, plugin, true)
+          lastResult = await runViteBuild(fixturePath(fixture), outputDirectory, plugin, {
+            showWarnings: true,
+          })
         },
         coldBuildOptions('stress', outputDirectory, () => {
           assertViteOutputSync(outputDirectory)

--- a/benchmarks/vanilla-extract/bench/vite-hook-filter.bench.ts
+++ b/benchmarks/vanilla-extract/bench/vite-hook-filter.bench.ts
@@ -3,7 +3,7 @@ import {beforeAll, bench, describe} from 'vitest'
 import {runViteBuild, type CommandResult} from './helpers/commands.ts'
 import {runHookDiagnostics} from './helpers/hook-diagnostics.ts'
 import {coldBuildOptions} from './helpers/options.ts'
-import {assertViteOutput} from './helpers/output.ts'
+import {assertViteOutputSync} from './helpers/output.ts'
 import {fixturePath, generatedRoot, loadFixtureManifest} from './helpers/paths.ts'
 
 const manifest = await loadFixtureManifest()
@@ -19,6 +19,7 @@ function surfacePluginTimingWarning(name: string, result: CommandResult | undefi
   if (!output.includes('[PLUGIN_TIMINGS]')) return
 
   surfacedWarnings.add(name)
+  // eslint-disable-next-line no-console
   console.warn(`Rolldown plugin timing diagnostic for ${name}:\n${output.trim()}`)
 }
 
@@ -40,8 +41,8 @@ for (const fixture of manifest.stress) {
         async () => {
           lastResult = await runViteBuild(fixturePath(fixture), outputDirectory, plugin, true)
         },
-        coldBuildOptions('stress', outputDirectory, async () => {
-          await assertViteOutput(outputDirectory)
+        coldBuildOptions('stress', outputDirectory, () => {
+          assertViteOutputSync(outputDirectory)
           surfacePluginTimingWarning(`${fixture.plainModules}/${plugin}`, lastResult)
         }),
       )

--- a/benchmarks/vanilla-extract/config/rolldown.config.mjs
+++ b/benchmarks/vanilla-extract/config/rolldown.config.mjs
@@ -1,6 +1,5 @@
 import path from 'node:path'
 import {defineConfig} from 'rolldown'
-import {vanillaExtractPlugin} from '../.generated/plugins/rolldown-plugin.mjs'
 
 function requiredEnvironmentPath(name) {
   const value = process.env[name]
@@ -10,6 +9,11 @@ function requiredEnvironmentPath(name) {
 
 const fixtureRoot = requiredEnvironmentPath('VE_BENCH_FIXTURE_ROOT')
 const outputDirectory = requiredEnvironmentPath('VE_BENCH_OUTPUT_DIR')
+const minify = process.env['VE_BENCH_MINIFY'] === '1'
+const target = process.env['VE_BENCH_TARGET'] || false
+
+// Lazy-loaded so this process only ever evaluates the plugin under test.
+const {vanillaExtractPlugin} = await import('../.generated/plugins/rolldown-plugin.mjs')
 
 export default defineConfig({
   input: path.join(fixtureRoot, 'src/library.ts'),
@@ -18,8 +22,8 @@ export default defineConfig({
     vanillaExtractPlugin({
       fileName: 'bundle.css',
       identifiers: 'short',
-      minify: false,
-      target: false,
+      minify,
+      target,
     }),
   ],
   output: {

--- a/benchmarks/vanilla-extract/config/rolldown.config.mjs
+++ b/benchmarks/vanilla-extract/config/rolldown.config.mjs
@@ -1,0 +1,32 @@
+import path from 'node:path'
+import {defineConfig} from 'rolldown'
+import {vanillaExtractPlugin} from '../../../packages/@sanity/vanilla-extract-rolldown-plugin/dist/index.mjs'
+
+function requiredEnvironmentPath(name) {
+  const value = process.env[name]
+  if (!value) throw new Error(`Missing ${name}`)
+  return path.resolve(value)
+}
+
+const fixtureRoot = requiredEnvironmentPath('VE_BENCH_FIXTURE_ROOT')
+const outputDirectory = requiredEnvironmentPath('VE_BENCH_OUTPUT_DIR')
+
+export default defineConfig({
+  input: path.join(fixtureRoot, 'src/library.ts'),
+  logLevel: 'silent',
+  plugins: [
+    vanillaExtractPlugin({
+      fileName: 'bundle.css',
+      identifiers: 'short',
+      minify: false,
+      target: false,
+    }),
+  ],
+  output: {
+    assetFileNames: '[name][extname]',
+    dir: outputDirectory,
+    entryFileNames: 'index.mjs',
+    format: 'esm',
+    sourcemap: false,
+  },
+})

--- a/benchmarks/vanilla-extract/config/rolldown.config.mjs
+++ b/benchmarks/vanilla-extract/config/rolldown.config.mjs
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import {defineConfig} from 'rolldown'
-import {vanillaExtractPlugin} from '../../../packages/@sanity/vanilla-extract-rolldown-plugin/dist/index.mjs'
+import {vanillaExtractPlugin} from '../.generated/plugins/rolldown-plugin.mjs'
 
 function requiredEnvironmentPath(name) {
   const value = process.env[name]

--- a/benchmarks/vanilla-extract/config/rollup.config.mjs
+++ b/benchmarks/vanilla-extract/config/rollup.config.mjs
@@ -1,5 +1,4 @@
 import path from 'node:path'
-import {vanillaExtractPlugin} from '@vanilla-extract/rollup-plugin'
 
 function requiredEnvironmentPath(name) {
   const value = process.env[name]
@@ -9,6 +8,40 @@ function requiredEnvironmentPath(name) {
 
 const fixtureRoot = requiredEnvironmentPath('VE_BENCH_FIXTURE_ROOT')
 const outputDirectory = requiredEnvironmentPath('VE_BENCH_OUTPUT_DIR')
+const minify = process.env['VE_BENCH_MINIFY'] === '1'
+const target = process.env['VE_BENCH_TARGET'] || false
+
+// Lazy-loaded so this process only ever evaluates the plugin under test.
+const {vanillaExtractPlugin} = await import('@vanilla-extract/rollup-plugin')
+
+/**
+ * The official rollup plugin's extract mode emits raw CSS with no minify/target support of its
+ * own, so real-world official pipelines (e.g. `@sanity/pkg-utils`'s `optimizeCss`) add a
+ * `lightningcss` pass over the emitted asset. This post-plugin replicates that so the minify and
+ * target variants compare complete pipelines, not a no-op against real work.
+ */
+async function createLightningcssPostPlugin() {
+  const {transform} = await import('lightningcss')
+  // esbuild-style `chrome61` in lightningcss target encoding (major version << 16)
+  const targets = target === 'chrome61' ? {chrome: 61 << 16} : undefined
+  if (target && !targets) throw new Error(`Unsupported VE_BENCH_TARGET: ${target}`)
+
+  return {
+    name: 'benchmark-lightningcss',
+    generateBundle(_options, bundle) {
+      for (const [fileName, output] of Object.entries(bundle)) {
+        if (output.type !== 'asset' || !fileName.endsWith('.css')) continue
+        const {code} = transform({
+          filename: fileName,
+          code: Buffer.from(output.source),
+          minify,
+          targets,
+        })
+        output.source = code.toString()
+      }
+    },
+  }
+}
 
 export default {
   input: path.join(fixtureRoot, 'src/library.ts'),
@@ -21,7 +54,8 @@ export default {
       },
       identifiers: 'short',
     }),
-  ],
+    (minify || target) && (await createLightningcssPostPlugin()),
+  ].filter(Boolean),
   output: {
     assetFileNames: '[name][extname]',
     dir: outputDirectory,

--- a/benchmarks/vanilla-extract/config/rollup.config.mjs
+++ b/benchmarks/vanilla-extract/config/rollup.config.mjs
@@ -1,0 +1,32 @@
+import path from 'node:path'
+import {vanillaExtractPlugin} from '@vanilla-extract/rollup-plugin'
+
+function requiredEnvironmentPath(name) {
+  const value = process.env[name]
+  if (!value) throw new Error(`Missing ${name}`)
+  return path.resolve(value)
+}
+
+const fixtureRoot = requiredEnvironmentPath('VE_BENCH_FIXTURE_ROOT')
+const outputDirectory = requiredEnvironmentPath('VE_BENCH_OUTPUT_DIR')
+
+export default {
+  input: path.join(fixtureRoot, 'src/library.ts'),
+  plugins: [
+    vanillaExtractPlugin({
+      cwd: fixtureRoot,
+      extract: {
+        name: 'bundle.css',
+        sourcemap: false,
+      },
+      identifiers: 'short',
+    }),
+  ],
+  output: {
+    assetFileNames: '[name][extname]',
+    dir: outputDirectory,
+    entryFileNames: 'index.mjs',
+    format: 'es',
+    sourcemap: false,
+  },
+}

--- a/benchmarks/vanilla-extract/config/vite.config.mjs
+++ b/benchmarks/vanilla-extract/config/vite.config.mjs
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import {vanillaExtractPlugin as officialVanillaExtractPlugin} from '@vanilla-extract/vite-plugin'
 import {defineConfig} from 'vite'
-import {vanillaExtractPlugin as sanityVanillaExtractPlugin} from '../../../packages/@sanity/vanilla-extract-vite-plugin/dist/index.mjs'
+import {vanillaExtractPlugin as sanityVanillaExtractPlugin} from '../.generated/plugins/vite-plugin.mjs'
 
 function requiredEnvironmentPath(name) {
   const value = process.env[name]

--- a/benchmarks/vanilla-extract/config/vite.config.mjs
+++ b/benchmarks/vanilla-extract/config/vite.config.mjs
@@ -1,0 +1,44 @@
+import path from 'node:path'
+import {vanillaExtractPlugin as officialVanillaExtractPlugin} from '@vanilla-extract/vite-plugin'
+import {defineConfig} from 'vite'
+import {vanillaExtractPlugin as sanityVanillaExtractPlugin} from '../../../packages/@sanity/vanilla-extract-vite-plugin/dist/index.mjs'
+
+function requiredEnvironmentPath(name) {
+  const value = process.env[name]
+  if (!value) throw new Error(`Missing ${name}`)
+  return path.resolve(value)
+}
+
+const fixtureRoot = requiredEnvironmentPath('VE_BENCH_FIXTURE_ROOT')
+const outputDirectory = requiredEnvironmentPath('VE_BENCH_OUTPUT_DIR')
+const plugin = process.env['VE_BENCH_PLUGIN']
+
+if (plugin !== 'official' && plugin !== 'sanity') {
+  throw new Error(`VE_BENCH_PLUGIN must be "official" or "sanity", received ${plugin}`)
+}
+
+export default defineConfig({
+  root: fixtureRoot,
+  cacheDir: path.join(outputDirectory, '.vite-cache'),
+  clearScreen: false,
+  logLevel: process.env['VE_BENCH_LOG_LEVEL'] === 'warn' ? 'warn' : 'silent',
+  plugins: [
+    plugin === 'official'
+      ? officialVanillaExtractPlugin({identifiers: 'short'})
+      : sanityVanillaExtractPlugin({identifiers: 'short'}),
+  ],
+  build: {
+    copyPublicDir: false,
+    cssMinify: false,
+    emptyOutDir: false,
+    minify: false,
+    outDir: outputDirectory,
+    reportCompressedSize: false,
+    rolldownOptions: {
+      checks: {
+        pluginTimings: true,
+      },
+    },
+    sourcemap: false,
+  },
+})

--- a/benchmarks/vanilla-extract/config/vite.config.mjs
+++ b/benchmarks/vanilla-extract/config/vite.config.mjs
@@ -10,8 +10,6 @@ function requiredEnvironmentPath(name) {
 const fixtureRoot = requiredEnvironmentPath('VE_BENCH_FIXTURE_ROOT')
 const outputDirectory = requiredEnvironmentPath('VE_BENCH_OUTPUT_DIR')
 const plugin = process.env['VE_BENCH_PLUGIN']
-const minify = process.env['VE_BENCH_MINIFY'] === '1'
-const target = process.env['VE_BENCH_TARGET'] || false
 
 if (plugin !== 'official' && plugin !== 'sanity') {
   throw new Error(`VE_BENCH_PLUGIN must be "official" or "sanity", received ${plugin}`)
@@ -23,6 +21,8 @@ const {vanillaExtractPlugin} =
     ? await import('@vanilla-extract/vite-plugin')
     : await import('../.generated/plugins/vite-plugin.mjs')
 
+// Minify and target are intentionally not varied here: Vite handles both itself, identically
+// for either plugin, so they'd only add identical work to both sides of the comparison.
 export default defineConfig({
   root: fixtureRoot,
   cacheDir: path.join(outputDirectory, '.vite-cache'),
@@ -31,11 +31,11 @@ export default defineConfig({
   plugins: [vanillaExtractPlugin({identifiers: 'short'})],
   build: {
     copyPublicDir: false,
-    // `esnext` disables Vite's default downleveling so the baseline really is transform-free
-    cssMinify: minify ? 'lightningcss' : false,
-    cssTarget: target || 'esnext',
+    // `esnext` disables Vite's default downleveling so the comparison is transform-free
+    cssMinify: false,
+    cssTarget: 'esnext',
     emptyOutDir: false,
-    minify: minify ? 'oxc' : false,
+    minify: false,
     outDir: outputDirectory,
     reportCompressedSize: false,
     rolldownOptions: {
@@ -44,6 +44,6 @@ export default defineConfig({
       },
     },
     sourcemap: false,
-    target: target || 'esnext',
+    target: 'esnext',
   },
 })

--- a/benchmarks/vanilla-extract/config/vite.config.mjs
+++ b/benchmarks/vanilla-extract/config/vite.config.mjs
@@ -1,7 +1,5 @@
 import path from 'node:path'
-import {vanillaExtractPlugin as officialVanillaExtractPlugin} from '@vanilla-extract/vite-plugin'
 import {defineConfig} from 'vite'
-import {vanillaExtractPlugin as sanityVanillaExtractPlugin} from '../.generated/plugins/vite-plugin.mjs'
 
 function requiredEnvironmentPath(name) {
   const value = process.env[name]
@@ -12,26 +10,32 @@ function requiredEnvironmentPath(name) {
 const fixtureRoot = requiredEnvironmentPath('VE_BENCH_FIXTURE_ROOT')
 const outputDirectory = requiredEnvironmentPath('VE_BENCH_OUTPUT_DIR')
 const plugin = process.env['VE_BENCH_PLUGIN']
+const minify = process.env['VE_BENCH_MINIFY'] === '1'
+const target = process.env['VE_BENCH_TARGET'] || false
 
 if (plugin !== 'official' && plugin !== 'sanity') {
   throw new Error(`VE_BENCH_PLUGIN must be "official" or "sanity", received ${plugin}`)
 }
+
+// Lazy-loaded so this process only ever evaluates the plugin under test.
+const {vanillaExtractPlugin} =
+  plugin === 'official'
+    ? await import('@vanilla-extract/vite-plugin')
+    : await import('../.generated/plugins/vite-plugin.mjs')
 
 export default defineConfig({
   root: fixtureRoot,
   cacheDir: path.join(outputDirectory, '.vite-cache'),
   clearScreen: false,
   logLevel: process.env['VE_BENCH_LOG_LEVEL'] === 'warn' ? 'warn' : 'silent',
-  plugins: [
-    plugin === 'official'
-      ? officialVanillaExtractPlugin({identifiers: 'short'})
-      : sanityVanillaExtractPlugin({identifiers: 'short'}),
-  ],
+  plugins: [vanillaExtractPlugin({identifiers: 'short'})],
   build: {
     copyPublicDir: false,
-    cssMinify: false,
+    // `esnext` disables Vite's default downleveling so the baseline really is transform-free
+    cssMinify: minify ? 'lightningcss' : false,
+    cssTarget: target || 'esnext',
     emptyOutDir: false,
-    minify: false,
+    minify: minify ? 'oxc' : false,
     outDir: outputDirectory,
     reportCompressedSize: false,
     rolldownOptions: {
@@ -40,5 +44,6 @@ export default defineConfig({
       },
     },
     sourcemap: false,
+    target: target || 'esnext',
   },
 })

--- a/benchmarks/vanilla-extract/package.json
+++ b/benchmarks/vanilla-extract/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@benchmarks/vanilla-extract",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "benchmark": "pnpm benchmark:prepare && pnpm benchmark:versions && vitest bench",
+    "benchmark:build": "pnpm benchmark:prepare && pnpm benchmark:versions && vitest bench bench/build.bench.ts",
+    "benchmark:prepare": "pnpm build:plugins && tsx scripts/generate-fixtures.ts",
+    "benchmark:versions": "tsx scripts/print-versions.ts",
+    "benchmark:vite-build": "pnpm benchmark:prepare && pnpm benchmark:versions && vitest bench bench/vite-build.bench.ts",
+    "benchmark:vite-hmr": "pnpm benchmark:prepare && pnpm benchmark:versions && vitest bench bench/vite-hmr.bench.ts",
+    "benchmark:vite-hooks": "pnpm benchmark:prepare && pnpm benchmark:versions && vitest bench bench/vite-hook-filter.bench.ts",
+    "build:plugins": "pnpm --filter @sanity/vanilla-extract-rolldown-plugin --filter @sanity/vanilla-extract-vite-plugin --parallel run build",
+    "install-browser": "playwright install chromium",
+    "smoke": "pnpm benchmark:prepare && vitest run test/smoke.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@sanity/tsconfig": "workspace:*",
+    "@sanity/vanilla-extract-rolldown-plugin": "workspace:*",
+    "@sanity/vanilla-extract-vite-plugin": "workspace:*",
+    "@types/node": "catalog:",
+    "@vanilla-extract/css": "^1.21.1",
+    "@vanilla-extract/rollup-plugin": "^1.5.4",
+    "@vanilla-extract/vite-plugin": "^5.2.4",
+    "playwright": "^1.61.1",
+    "rolldown": "^1.1.5",
+    "rollup": "^4.62.2",
+    "tsx": "^4.23.0",
+    "typescript": "catalog:",
+    "vite": "^8.1.4",
+    "vitest": "catalog:"
+  }
+}

--- a/benchmarks/vanilla-extract/package.json
+++ b/benchmarks/vanilla-extract/package.json
@@ -3,15 +3,17 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "benchmark": "pnpm benchmark:prepare && pnpm benchmark:versions && vitest bench",
     "benchmark:build": "pnpm benchmark:prepare && pnpm benchmark:versions && vitest bench bench/build.bench.ts",
-    "benchmark:prepare": "pnpm build:plugins && tsx scripts/generate-fixtures.ts",
+    "benchmark:prepare": "tsx scripts/generate-fixtures.ts && tsx scripts/build-local-plugins.ts",
     "benchmark:versions": "tsx scripts/print-versions.ts",
     "benchmark:vite-build": "pnpm benchmark:prepare && pnpm benchmark:versions && vitest bench bench/vite-build.bench.ts",
     "benchmark:vite-hmr": "pnpm benchmark:prepare && pnpm benchmark:versions && vitest bench bench/vite-hmr.bench.ts",
     "benchmark:vite-hooks": "pnpm benchmark:prepare && pnpm benchmark:versions && vitest bench bench/vite-hook-filter.bench.ts",
-    "build:plugins": "pnpm --filter @sanity/vanilla-extract-rolldown-plugin --filter @sanity/vanilla-extract-vite-plugin --parallel run build",
     "install-browser": "playwright install chromium",
     "smoke": "pnpm benchmark:prepare && vitest run test/smoke.test.ts",
     "typecheck": "tsc --noEmit"
@@ -22,8 +24,10 @@
     "@sanity/vanilla-extract-vite-plugin": "workspace:*",
     "@types/node": "catalog:",
     "@vanilla-extract/css": "^1.21.1",
+    "@vanilla-extract/integration": "^8.0.10",
     "@vanilla-extract/rollup-plugin": "^1.5.4",
     "@vanilla-extract/vite-plugin": "^5.2.4",
+    "lightningcss": "^1.32.0",
     "playwright": "^1.61.1",
     "rolldown": "^1.1.5",
     "rollup": "^4.62.2",

--- a/benchmarks/vanilla-extract/package.json
+++ b/benchmarks/vanilla-extract/package.json
@@ -3,9 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "engines": {
-    "node": ">=24"
-  },
   "scripts": {
     "benchmark": "pnpm benchmark:prepare && pnpm benchmark:versions && vitest bench",
     "benchmark:build": "pnpm benchmark:prepare && pnpm benchmark:versions && vitest bench bench/build.bench.ts",
@@ -35,5 +32,8 @@
     "typescript": "catalog:",
     "vite": "^8.1.4",
     "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=24"
   }
 }

--- a/benchmarks/vanilla-extract/scripts/build-local-plugins.ts
+++ b/benchmarks/vanilla-extract/scripts/build-local-plugins.ts
@@ -1,0 +1,48 @@
+import {mkdir, rm} from 'node:fs/promises'
+import path from 'node:path'
+import {rolldown} from 'rolldown'
+
+const repositoryRoot = path.resolve(import.meta.dirname, '../../..')
+const outputRoot = path.resolve(import.meta.dirname, '../.generated/plugins')
+
+const plugins = [
+  {
+    input: path.join(
+      repositoryRoot,
+      'packages/@sanity/vanilla-extract-rolldown-plugin/src/index.ts',
+    ),
+    output: 'rolldown-plugin.mjs',
+  },
+  {
+    input: path.join(repositoryRoot, 'packages/@sanity/vanilla-extract-vite-plugin/src/index.ts'),
+    output: 'vite-plugin.mjs',
+  },
+] as const
+
+function isBareImport(id: string): boolean {
+  return !id.startsWith('.') && !path.isAbsolute(id)
+}
+
+await rm(outputRoot, {recursive: true, force: true})
+await mkdir(outputRoot, {recursive: true})
+
+for (const plugin of plugins) {
+  const bundle = await rolldown({
+    input: plugin.input,
+    external: isBareImport,
+    logLevel: 'silent',
+  })
+  try {
+    await bundle.write({
+      dir: outputRoot,
+      entryFileNames: plugin.output,
+      format: 'esm',
+      sourcemap: false,
+    })
+  } finally {
+    await bundle.close()
+  }
+}
+
+// eslint-disable-next-line no-console
+console.log(`Built ${plugins.length} local benchmark plugin bundles`)

--- a/benchmarks/vanilla-extract/scripts/generate-fixtures.ts
+++ b/benchmarks/vanilla-extract/scripts/generate-fixtures.ts
@@ -1,0 +1,240 @@
+import {mkdir, rm, writeFile} from 'node:fs/promises'
+import path from 'node:path'
+
+const benchmarkRoot = path.resolve(import.meta.dirname, '..')
+const generatedRoot = path.join(benchmarkRoot, '.generated')
+const writeBatchSize = 128
+
+const sharedColor = 'rgb(1, 2, 3)'
+const initialLeafColor = 'rgb(10, 20, 30)'
+
+interface FixtureDefinition {
+  directory: string
+  plainModules: number
+  styleModules: number
+}
+
+interface FixtureManifest {
+  version: 1
+  representative: FixtureDefinition
+  stress: FixtureDefinition[]
+  hmr: {
+    official: FixtureDefinition
+    sanity: FixtureDefinition
+  }
+}
+
+function readInteger(name: string, fallback: number, minimum: number): number {
+  const value = process.env[name]
+  if (value === undefined) return fallback
+
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isSafeInteger(parsed) || parsed < minimum) {
+    throw new Error(
+      `${name} must be an integer greater than or equal to ${minimum}, received ${value}`,
+    )
+  }
+  return parsed
+}
+
+function readStressSizes(): number[] {
+  const raw = process.env['VE_BENCH_STRESS_SIZES'] ?? '0,1000,5000'
+  const sizes = raw.split(',').map((value) => {
+    const parsed = Number.parseInt(value.trim(), 10)
+    if (!Number.isSafeInteger(parsed) || parsed < 0) {
+      throw new Error(`VE_BENCH_STRESS_SIZES must contain non-negative integers, received ${raw}`)
+    }
+    return parsed
+  })
+
+  return [...new Set(sizes)].sort((left, right) => left - right)
+}
+
+function pad(index: number): string {
+  return index.toString().padStart(5, '0')
+}
+
+function renderPlainModule(index: number): string {
+  return `export const value${pad(index)} = ${index + 1}\n`
+}
+
+function renderPlainIndex(count: number): string {
+  if (count === 0) return 'export const plainTotal = 0\n'
+
+  const imports = Array.from(
+    {length: count},
+    (_, index) => `import {value${pad(index)}} from './plain/module-${pad(index)}.ts'`,
+  )
+  const values = Array.from({length: count}, (_, index) => `value${pad(index)}`)
+
+  return `${imports.join('\n')}\n\nexport const plainTotal = [${values.join(', ')}].reduce(\n  (total, value) => total + value,\n  0,\n)\n`
+}
+
+function renderStyleModule(index: number): string {
+  const red = (index * 17 + 20) % 256
+  const green = (index * 29 + 40) % 256
+  const blue = (index * 41 + 60) % 256
+  const backgroundColor = index === 0 ? initialLeafColor : `rgb(${red}, ${green}, ${blue})`
+
+  return [
+    `import {style} from '@vanilla-extract/css'`,
+    `import {accentColor} from '../theme.ts'`,
+    ``,
+    `export const className${pad(index)} = style({`,
+    `  color: accentColor,`,
+    `  backgroundColor: '${backgroundColor}',`,
+    `  border: '1px solid rgb(${blue}, ${red}, ${green})',`,
+    `  padding: '${(index % 8) + 1}px',`,
+    `})`,
+    ``,
+  ].join('\n')
+}
+
+function renderStylesIndex(count: number): string {
+  const imports = Array.from(
+    {length: count},
+    (_, index) => `import {className${pad(index)}} from './styles/style-${pad(index)}.css.ts'`,
+  )
+  const classNames = Array.from({length: count}, (_, index) => `className${pad(index)}`)
+
+  return `${imports.join('\n')}\n\nexport const classNames = [${classNames.join(', ')}]\n`
+}
+
+function renderLibraryEntry(): string {
+  return [
+    `import {plainTotal} from './plain.ts'`,
+    `import {classNames} from './styles.ts'`,
+    ``,
+    `export {plainTotal}`,
+    ``,
+    `export function getBenchmarkClassName() {`,
+    `  return classNames[0] ?? ''`,
+    `}`,
+    ``,
+  ].join('\n')
+}
+
+function renderBrowserEntry(): string {
+  return [
+    `import {plainTotal} from './plain.ts'`,
+    `import {classNames} from './styles.ts'`,
+    ``,
+    `const probe = document.querySelector('#probe')`,
+    `if (!(probe instanceof HTMLElement)) throw new Error('Missing #probe element')`,
+    `probe.className = classNames[0] ?? ''`,
+    `probe.dataset.plainTotal = String(plainTotal)`,
+    ``,
+    `const storageKey = 'vanilla-extract-benchmark-loads'`,
+    `const loads = Number(sessionStorage.getItem(storageKey) ?? '0') + 1`,
+    `sessionStorage.setItem(storageKey, String(loads))`,
+    `const runtime = {loads, ready: true, updates: 0}`,
+    `window['__vanillaExtractBenchmark'] = runtime`,
+    ``,
+    `if (import.meta.hot) {`,
+    `  import.meta.hot.on('vite:afterUpdate', () => {`,
+    `    runtime.updates += 1`,
+    `  })`,
+    `}`,
+    ``,
+  ].join('\n')
+}
+
+async function writeInBatches(files: Array<readonly [string, string]>): Promise<void> {
+  for (let index = 0; index < files.length; index += writeBatchSize) {
+    await Promise.all(
+      files
+        .slice(index, index + writeBatchSize)
+        .map(([filePath, contents]) => writeFile(filePath, contents)),
+    )
+  }
+}
+
+async function generateFixture(definition: FixtureDefinition): Promise<void> {
+  const fixtureRoot = path.join(generatedRoot, definition.directory)
+  const sourceRoot = path.join(fixtureRoot, 'src')
+  const plainRoot = path.join(sourceRoot, 'plain')
+  const stylesRoot = path.join(sourceRoot, 'styles')
+
+  await Promise.all([mkdir(plainRoot, {recursive: true}), mkdir(stylesRoot, {recursive: true})])
+
+  const plainFiles: Array<readonly [string, string]> = Array.from(
+    {length: definition.plainModules},
+    (_, index) => [path.join(plainRoot, `module-${pad(index)}.ts`), renderPlainModule(index)],
+  )
+  const styleFiles: Array<readonly [string, string]> = Array.from(
+    {length: definition.styleModules},
+    (_, index) => [path.join(stylesRoot, `style-${pad(index)}.css.ts`), renderStyleModule(index)],
+  )
+
+  await Promise.all([writeInBatches(plainFiles), writeInBatches(styleFiles)])
+  await Promise.all([
+    writeFile(
+      path.join(fixtureRoot, 'package.json'),
+      `${JSON.stringify(
+        {
+          name: `@vanilla-extract-benchmark/${definition.directory}`,
+          private: true,
+          type: 'module',
+        },
+        null,
+        2,
+      )}\n`,
+    ),
+    writeFile(
+      path.join(fixtureRoot, 'index.html'),
+      '<!doctype html><html><head><meta charset="UTF-8"></head><body><div id="probe">probe</div><script type="module" src="/src/main.ts"></script></body></html>\n',
+    ),
+    writeFile(path.join(sourceRoot, 'library.ts'), renderLibraryEntry()),
+    writeFile(path.join(sourceRoot, 'main.ts'), renderBrowserEntry()),
+    writeFile(path.join(sourceRoot, 'plain.ts'), renderPlainIndex(definition.plainModules)),
+    writeFile(path.join(sourceRoot, 'styles.ts'), renderStylesIndex(definition.styleModules)),
+    writeFile(path.join(sourceRoot, 'theme.ts'), `export const accentColor = '${sharedColor}'\n`),
+  ])
+}
+
+const representativePlainModules = readInteger('VE_BENCH_MODULES', 500, 0)
+const representativeStyleModules = readInteger('VE_BENCH_STYLES', 100, 1)
+const hmrPlainModules = readInteger('VE_BENCH_HMR_MODULES', representativePlainModules, 0)
+const hmrStyleModules = readInteger('VE_BENCH_HMR_STYLES', representativeStyleModules, 1)
+
+const manifest: FixtureManifest = {
+  version: 1,
+  representative: {
+    directory: 'representative',
+    plainModules: representativePlainModules,
+    styleModules: representativeStyleModules,
+  },
+  stress: readStressSizes().map((plainModules) => ({
+    directory: `stress-${plainModules}`,
+    plainModules,
+    styleModules: 1,
+  })),
+  hmr: {
+    official: {
+      directory: 'hmr-official',
+      plainModules: hmrPlainModules,
+      styleModules: hmrStyleModules,
+    },
+    sanity: {
+      directory: 'hmr-sanity',
+      plainModules: hmrPlainModules,
+      styleModules: hmrStyleModules,
+    },
+  },
+}
+
+await rm(generatedRoot, {recursive: true, force: true})
+await mkdir(generatedRoot, {recursive: true})
+
+const definitions = [
+  manifest.representative,
+  ...manifest.stress,
+  manifest.hmr.official,
+  manifest.hmr.sanity,
+]
+await Promise.all(definitions.map((definition) => generateFixture(definition)))
+await writeFile(path.join(generatedRoot, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
+
+console.log(
+  `Generated ${definitions.length} benchmark fixtures in ${path.relative(process.cwd(), generatedRoot)}`,
+)

--- a/benchmarks/vanilla-extract/scripts/generate-fixtures.ts
+++ b/benchmarks/vanilla-extract/scripts/generate-fixtures.ts
@@ -85,6 +85,8 @@ function renderStyleModule(index: number): string {
     `  backgroundColor: '${backgroundColor}',`,
     `  border: '1px solid rgb(${blue}, ${red}, ${green})',`,
     `  padding: '${(index % 8) + 1}px',`,
+    // Lowered to top/right/bottom/left by a chrome61 target, so downleveling is observable
+    `  inset: ${index % 4},`,
     `})`,
     ``,
   ].join('\n')

--- a/benchmarks/vanilla-extract/scripts/generate-fixtures.ts
+++ b/benchmarks/vanilla-extract/scripts/generate-fixtures.ts
@@ -47,7 +47,7 @@ function readStressSizes(): number[] {
     return parsed
   })
 
-  return [...new Set(sizes)].sort((left, right) => left - right)
+  return [...new Set(sizes)].toSorted((left, right) => left - right)
 }
 
 function pad(index: number): string {
@@ -131,6 +131,9 @@ function renderBrowserEntry(): string {
     `window['__vanillaExtractBenchmark'] = runtime`,
     ``,
     `if (import.meta.hot) {`,
+    `  import.meta.hot.accept('./styles.ts', (nextStyles) => {`,
+    `    probe.className = nextStyles?.classNames[0] ?? ''`,
+    `  })`,
     `  import.meta.hot.on('vite:afterUpdate', () => {`,
     `    runtime.updates += 1`,
     `  })`,
@@ -235,6 +238,7 @@ const definitions = [
 await Promise.all(definitions.map((definition) => generateFixture(definition)))
 await writeFile(path.join(generatedRoot, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
 
+// eslint-disable-next-line no-console
 console.log(
   `Generated ${definitions.length} benchmark fixtures in ${path.relative(process.cwd(), generatedRoot)}`,
 )

--- a/benchmarks/vanilla-extract/scripts/print-versions.ts
+++ b/benchmarks/vanilla-extract/scripts/print-versions.ts
@@ -1,0 +1,39 @@
+import {readFile} from 'node:fs/promises'
+import {createRequire} from 'node:module'
+import os from 'node:os'
+
+const require = createRequire(import.meta.url)
+
+const packages = [
+  '@vanilla-extract/rollup-plugin',
+  '@vanilla-extract/vite-plugin',
+  '@sanity/vanilla-extract-rolldown-plugin',
+  '@sanity/vanilla-extract-vite-plugin',
+  'rolldown',
+  'rollup',
+  'vite',
+  'vitest',
+] as const
+
+async function readPackageVersion(packageName: string): Promise<string> {
+  const packageJsonPath = require.resolve(`${packageName}/package.json`)
+  const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {version?: unknown}
+  if (typeof packageJson.version !== 'string') {
+    throw new Error(`Missing version in ${packageJsonPath}`)
+  }
+  return packageJson.version
+}
+
+const versions = await Promise.all(
+  packages.map(async (packageName) => ({
+    component: packageName,
+    version: await readPackageVersion(packageName),
+  })),
+)
+
+console.table([
+  {component: 'node', version: process.version},
+  {component: 'platform', version: `${process.platform}-${process.arch}`},
+  {component: 'cpu', version: os.cpus()[0]?.model ?? 'unknown'},
+  ...versions,
+])

--- a/benchmarks/vanilla-extract/scripts/print-versions.ts
+++ b/benchmarks/vanilla-extract/scripts/print-versions.ts
@@ -15,13 +15,17 @@ const packages = [
   'vitest',
 ] as const
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
 async function readPackageVersion(packageName: string): Promise<string> {
   const packageJsonPath = require.resolve(`${packageName}/package.json`)
-  const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {version?: unknown}
-  if (typeof packageJson.version !== 'string') {
+  const packageJson: unknown = JSON.parse(await readFile(packageJsonPath, 'utf8'))
+  if (!isRecord(packageJson) || typeof packageJson['version'] !== 'string') {
     throw new Error(`Missing version in ${packageJsonPath}`)
   }
-  return packageJson.version
+  return packageJson['version']
 }
 
 const versions = await Promise.all(
@@ -31,6 +35,7 @@ const versions = await Promise.all(
   })),
 )
 
+// eslint-disable-next-line no-console
 console.table([
   {component: 'node', version: process.version},
   {component: 'platform', version: `${process.platform}-${process.arch}`},

--- a/benchmarks/vanilla-extract/scripts/print-versions.ts
+++ b/benchmarks/vanilla-extract/scripts/print-versions.ts
@@ -40,5 +40,8 @@ console.table([
   {component: 'node', version: process.version},
   {component: 'platform', version: `${process.platform}-${process.arch}`},
   {component: 'cpu', version: os.cpus()[0]?.model ?? 'unknown'},
+  // Rolldown parallelizes across cores while Rollup's JS pipeline is largely single-threaded,
+  // so core count meaningfully shifts the relative build results
+  {component: 'cores', version: String(os.availableParallelism())},
   ...versions,
 ])

--- a/benchmarks/vanilla-extract/test/smoke.test.ts
+++ b/benchmarks/vanilla-extract/test/smoke.test.ts
@@ -48,27 +48,17 @@ describe('benchmark configurations', () => {
     )
   })
 
-  describe.each(['official', 'sanity'] as const)('Vite + %s plugin', (plugin) => {
-    test.each(variantCases)(
-      'emits an application and extracted CSS with %s',
-      async (_label, variant) => {
-        const outputDirectory = path.join(
-          generatedRoot,
-          `output/smoke-vite-${plugin}-${variant.slug}`,
-        )
-        await rm(outputDirectory, {recursive: true, force: true})
-        await runViteBuild(fixtureRoot, outputDirectory, plugin, {variant})
-        await assertViteOutput(outputDirectory)
-        // Vite owns minification; downleveling only applies through its CSS minifier, so the
-        // target-only variant is validated as a normal build
-        const css = readCssOutputSync(outputDirectory)
-        if (variant.minify) {
-          expect(css).toContain('#010203')
-        } else {
-          expect(css).toContain('rgb(1, 2, 3)')
-        }
-      },
-      120_000,
-    )
-  })
+  // No variants here: Vite handles minify/target itself, identically for both plugins, so the
+  // benchmark only compares the baseline configuration
+  test.each(['official', 'sanity'] as const)(
+    'Vite + %s plugin emits an application and extracted CSS',
+    async (plugin) => {
+      const outputDirectory = path.join(generatedRoot, `output/smoke-vite-${plugin}`)
+      await rm(outputDirectory, {recursive: true, force: true})
+      await runViteBuild(fixtureRoot, outputDirectory, plugin)
+      await assertViteOutput(outputDirectory)
+      expect(readCssOutputSync(outputDirectory)).toContain('rgb(1, 2, 3)')
+    },
+    120_000,
+  )
 })

--- a/benchmarks/vanilla-extract/test/smoke.test.ts
+++ b/benchmarks/vanilla-extract/test/smoke.test.ts
@@ -1,0 +1,39 @@
+import {rm} from 'node:fs/promises'
+import path from 'node:path'
+import {describe, test} from 'vitest'
+import {runRolldownBuild, runRollupBuild, runViteBuild} from '../bench/helpers/commands.ts'
+import {assertLibraryOutput, assertViteOutput} from '../bench/helpers/output.ts'
+import {fixturePath, generatedRoot, loadFixtureManifest} from '../bench/helpers/paths.ts'
+
+const manifest = await loadFixtureManifest()
+const fixtureRoot = fixturePath(manifest.representative)
+
+describe('benchmark configurations', () => {
+  test.each([
+    ['Rollup + official plugin', runRollupBuild],
+    ['Rolldown + Sanity plugin', runRolldownBuild],
+  ] as const)(
+    '%s emits executable JavaScript and extracted CSS',
+    async (name, runBuild) => {
+      const outputDirectory = path.join(
+        generatedRoot,
+        `output/smoke-${name.toLowerCase().replaceAll(/[^a-z]+/g, '-')}`,
+      )
+      await rm(outputDirectory, {recursive: true, force: true})
+      await runBuild(fixtureRoot, outputDirectory)
+      await assertLibraryOutput(outputDirectory)
+    },
+    120_000,
+  )
+
+  test.each(['official', 'sanity'] as const)(
+    'Vite + %s plugin emits an application and extracted CSS',
+    async (plugin) => {
+      const outputDirectory = path.join(generatedRoot, `output/smoke-vite-${plugin}`)
+      await rm(outputDirectory, {recursive: true, force: true})
+      await runViteBuild(fixtureRoot, outputDirectory, plugin)
+      await assertViteOutput(outputDirectory)
+    },
+    120_000,
+  )
+})

--- a/benchmarks/vanilla-extract/test/smoke.test.ts
+++ b/benchmarks/vanilla-extract/test/smoke.test.ts
@@ -1,39 +1,74 @@
 import {rm} from 'node:fs/promises'
 import path from 'node:path'
-import {describe, test} from 'vitest'
+import {describe, expect, test} from 'vitest'
 import {runRolldownBuild, runRollupBuild, runViteBuild} from '../bench/helpers/commands.ts'
-import {assertLibraryOutput, assertViteOutput} from '../bench/helpers/output.ts'
+import {assertLibraryOutput, assertViteOutput, readCssOutputSync} from '../bench/helpers/output.ts'
 import {fixturePath, generatedRoot, loadFixtureManifest} from '../bench/helpers/paths.ts'
+import {buildVariants, type BuildVariant} from '../bench/helpers/variants.ts'
 
 const manifest = await loadFixtureManifest()
 const fixtureRoot = fixturePath(manifest.representative)
 
-describe('benchmark configurations', () => {
-  test.each([
-    ['Rollup + official plugin', runRollupBuild],
-    ['Rolldown + Sanity plugin', runRolldownBuild],
-  ] as const)(
-    '%s emits executable JavaScript and extracted CSS',
-    async (name, runBuild) => {
-      const outputDirectory = path.join(
-        generatedRoot,
-        `output/smoke-${name.toLowerCase().replaceAll(/[^a-z]+/g, '-')}`,
-      )
-      await rm(outputDirectory, {recursive: true, force: true})
-      await runBuild(fixtureRoot, outputDirectory)
-      await assertLibraryOutput(outputDirectory)
-    },
-    120_000,
-  )
+/** The library-build pipelines own minify/target themselves, so both effects must show. */
+function assertLibraryVariantCss(outputDirectory: string, variant: BuildVariant): void {
+  const css = readCssOutputSync(outputDirectory)
+  if (variant.minify || variant.target) {
+    // lightningcss normalizes the marker to hex whenever it transforms, minified or not
+    expect(css).toContain('#010203')
+    expect(css).not.toContain('rgb(1, 2, 3)')
+  } else {
+    expect(css).toContain('rgb(1, 2, 3)')
+  }
+  if (variant.target) {
+    // chrome61 predates the `inset` shorthand, so it must be lowered to `top`/`right`/…
+    expect(css).not.toMatch(/inset\s*:/)
+    expect(css).toMatch(/top\s*:/)
+  } else {
+    expect(css).toMatch(/inset\s*:/)
+  }
+}
 
-  test.each(['official', 'sanity'] as const)(
-    'Vite + %s plugin emits an application and extracted CSS',
-    async (plugin) => {
-      const outputDirectory = path.join(generatedRoot, `output/smoke-vite-${plugin}`)
-      await rm(outputDirectory, {recursive: true, force: true})
-      await runViteBuild(fixtureRoot, outputDirectory, plugin)
-      await assertViteOutput(outputDirectory)
-    },
-    120_000,
-  )
+const variantCases = buildVariants.map((variant) => [variant.label, variant] as const)
+
+describe('benchmark configurations', () => {
+  describe.each([
+    ['Rollup + official plugin', 'rollup', runRollupBuild],
+    ['Rolldown + Sanity plugin', 'rolldown', runRolldownBuild],
+  ] as const)('%s', (_name, slug, runBuild) => {
+    test.each(variantCases)(
+      'emits executable JavaScript and correct CSS with %s',
+      async (_label, variant) => {
+        const outputDirectory = path.join(generatedRoot, `output/smoke-${slug}-${variant.slug}`)
+        await rm(outputDirectory, {recursive: true, force: true})
+        await runBuild(fixtureRoot, outputDirectory, variant)
+        await assertLibraryOutput(outputDirectory)
+        assertLibraryVariantCss(outputDirectory, variant)
+      },
+      120_000,
+    )
+  })
+
+  describe.each(['official', 'sanity'] as const)('Vite + %s plugin', (plugin) => {
+    test.each(variantCases)(
+      'emits an application and extracted CSS with %s',
+      async (_label, variant) => {
+        const outputDirectory = path.join(
+          generatedRoot,
+          `output/smoke-vite-${plugin}-${variant.slug}`,
+        )
+        await rm(outputDirectory, {recursive: true, force: true})
+        await runViteBuild(fixtureRoot, outputDirectory, plugin, {variant})
+        await assertViteOutput(outputDirectory)
+        // Vite owns minification; downleveling only applies through its CSS minifier, so the
+        // target-only variant is validated as a normal build
+        const css = readCssOutputSync(outputDirectory)
+        if (variant.minify) {
+          expect(css).toContain('#010203')
+        } else {
+          expect(css).toContain('rgb(1, 2, 3)')
+        }
+      },
+      120_000,
+    )
+  })
 })

--- a/benchmarks/vanilla-extract/tsconfig.json
+++ b/benchmarks/vanilla-extract/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@sanity/tsconfig/strictest",
+  "include": ["bench", "scripts", "test", "vitest.config.ts"],
+  "exclude": [".generated", "results"],
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "rootDir": ".",
+    "types": ["node"]
+  }
+}

--- a/benchmarks/vanilla-extract/vitest.config.ts
+++ b/benchmarks/vanilla-extract/vitest.config.ts
@@ -1,0 +1,13 @@
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    benchmark: {
+      include: ['bench/**/*.bench.ts'],
+    },
+    fileParallelism: false,
+    include: ['test/**/*.test.ts'],
+    maxWorkers: 1,
+    testTimeout: 120_000,
+  },
+})

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -2,6 +2,7 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "treatConfigHintsAsErrors": true,
   "ignoreWorkspaces": [
+    "benchmarks/*",
     "playground/*",
     "css-playground/*",
     "packages/@sanity/tsdown-config/test/fixtures/**",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "benchmark:build": "pnpm --filter @benchmarks/vanilla-extract benchmark:build",
+    "benchmark:vanilla-extract": "pnpm --filter @benchmarks/vanilla-extract benchmark",
+    "benchmark:vite-build": "pnpm --filter @benchmarks/vanilla-extract benchmark:vite-build",
+    "benchmark:vite-hmr": "pnpm --filter @benchmarks/vanilla-extract benchmark:vite-hmr",
+    "benchmark:vite-hooks": "pnpm --filter @benchmarks/vanilla-extract benchmark:vite-hooks",
     "build": "pnpm --filter './packages/@sanity/*' build",
     "check:deps": "knip --dependencies",
     "css-playground:build": "pnpm --filter './css-playground/**' build",

--- a/packages/@sanity/vanilla-extract-rolldown-plugin/README.md
+++ b/packages/@sanity/vanilla-extract-rolldown-plugin/README.md
@@ -8,6 +8,8 @@ rolldown projects. It also declares
 [plugin hook filters](https://rolldown.rs/apis/plugin-api#plugin-hook-filters), so rolldown skips
 the Rust ↔ JS roundtrip for modules that aren't vanilla-extract related
 ([vanilla-extract#1641](https://github.com/vanilla-extract-css/vanilla-extract/issues/1641)).
+Head-to-head numbers against the official Rollup pipeline (across minify/target variants) live in
+the [vanilla-extract benchmarks](https://github.com/sanity-io/pkg-utils/tree/main/benchmarks/vanilla-extract#latest-results).
 
 The plugin compiles all `.css.ts` modules and extracts their CSS into a single file (`bundle.css`
 by default), optionally lowered and minified with [lightningcss](https://lightningcss.dev),

--- a/packages/@sanity/vanilla-extract-tsdown-plugin/README.md
+++ b/packages/@sanity/vanilla-extract-tsdown-plugin/README.md
@@ -23,6 +23,8 @@ doesn't pull a second bundler into tsdown projects. It also declares
 [plugin hook filters](https://rolldown.rs/apis/plugin-api#plugin-hook-filters), so rolldown skips
 the Rust ↔ JS roundtrip for modules that aren't vanilla-extract related
 ([vanilla-extract#1641](https://github.com/vanilla-extract-css/vanilla-extract/issues/1641)).
+Head-to-head numbers for the underlying rolldown plugin against the official Rollup pipeline live
+in the [vanilla-extract benchmarks](https://github.com/sanity-io/pkg-utils/tree/main/benchmarks/vanilla-extract#latest-results).
 
 Like `css.inject` in `@tsdown/css`, the `inject` option is disabled by default; `inject: true`
 injects a relative `import "./bundle.css"` into the entry chunks that use vanilla-extract styles —

--- a/packages/@sanity/vanilla-extract-vite-plugin/README.md
+++ b/packages/@sanity/vanilla-extract-vite-plugin/README.md
@@ -19,6 +19,10 @@ alternative to
   [`hotUpdate` hook](https://vite.dev/guide/api-environment-plugins#the-hotupdate-hook)**
   instead of the deprecated `handleHotUpdate`.
 
+Head-to-head numbers against `@vanilla-extract/vite-plugin` — `vite build` across minify/target
+variants, dev HMR, and a hook-filter stress sweep — live in the
+[vanilla-extract benchmarks](https://github.com/sanity-io/pkg-utils/tree/main/benchmarks/vanilla-extract#latest-results).
+
 For _libraries_ that ship a single pre-extracted CSS file, use
 [`@sanity/vanilla-extract-rolldown-plugin`](https://github.com/sanity-io/pkg-utils/tree/main/packages/@sanity/vanilla-extract-rolldown-plugin#readme)
 (raw rolldown) or

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,12 +119,18 @@ importers:
       '@vanilla-extract/css':
         specifier: ^1.21.1
         version: 1.21.1
+      '@vanilla-extract/integration':
+        specifier: ^8.0.10
+        version: 8.0.10
       '@vanilla-extract/rollup-plugin':
         specifier: ^1.5.4
         version: 1.5.4(rollup@4.62.2)
       '@vanilla-extract/vite-plugin':
         specifier: ^5.2.4
         version: 5.2.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
+      lightningcss:
+        specifier: ^1.32.0
+        version: 1.32.0
       playwright:
         specifier: ^1.61.1
         version: 1.61.1
@@ -316,7 +322,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       nuxt:
         specifier: ^4.4.8
-        version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@8.0.1))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -15334,12 +15340,6 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1)':
-    dependencies:
-      '@babel/core': 8.0.1
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -17695,7 +17695,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.8(@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1))(@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2))(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@8.0.1))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.133.0)(rolldown@1.1.5)(typescript@7.0.2)':
+  '@nuxt/nitro-server@4.4.8(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2))(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.133.0)(rolldown@1.1.5)(typescript@7.0.2)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
@@ -17713,7 +17713,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.4(aws4fetch@1.0.20)(oxc-parser@0.133.0)(rolldown@1.1.5)
-      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@8.0.1))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
       nypm: 0.6.7
       ohash: 2.0.11
       pathe: 2.0.3
@@ -17726,8 +17726,8 @@ snapshots:
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
     optionalDependencies:
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@8.0.1)
-      '@rollup/plugin-babel': 7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
+      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -17782,7 +17782,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/vite-builder@4.4.8(425cec01b57479dc7ef3a2fa46539cb8)':
+  '@nuxt/vite-builder@4.4.8(d34e99aa28c9cb482e70f73302f6cb04)':
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.62.2)
@@ -17800,7 +17800,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@8.0.1))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
       nypm: 0.6.7
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -17815,7 +17815,7 @@ snapshots:
       vue: 3.5.39(typescript@7.0.2)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
       rolldown: 1.1.5
       rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.62.2)
     transitivePeerDependencies:
@@ -19859,19 +19859,6 @@ snapshots:
       rollup: 4.62.2
     transitivePeerDependencies:
       - supports-color
-
-  '@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2)':
-    dependencies:
-      '@babel/core': 8.0.1
-      '@babel/helper-module-imports': 7.29.7
-      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
-      workerpool: 9.3.4
-    optionalDependencies:
-      '@types/babel__core': 7.20.5
-      rollup: 4.62.2
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@rollup/plugin-commonjs@29.0.3(rollup@4.62.2)':
     dependencies:
@@ -26304,16 +26291,16 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
-  nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@8.0.1))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0):
+  nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@7.0.2)
       '@nuxt/cli': 3.36.0(@nuxt/schema@4.4.8)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.39(typescript@7.0.2))
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.8(@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1))(@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2))(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@8.0.1))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.133.0)(rolldown@1.1.5)(typescript@7.0.2)
+      '@nuxt/nitro-server': 4.4.8(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2))(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.133.0)(rolldown@1.1.5)(typescript@7.0.2)
       '@nuxt/schema': 4.4.8
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.8(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.8(425cec01b57479dc7ef3a2fa46539cb8)
+      '@nuxt/vite-builder': 4.4.8(d34e99aa28c9cb482e70f73302f6cb04)
       '@unhead/vue': 2.1.15(vue@3.5.39(typescript@7.0.2))
       '@vue/shared': 3.5.38
       chokidar: 5.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,51 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  benchmarks/vanilla-extract:
+    devDependencies:
+      '@sanity/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/@sanity/tsconfig
+      '@sanity/vanilla-extract-rolldown-plugin':
+        specifier: workspace:*
+        version: link:../../packages/@sanity/vanilla-extract-rolldown-plugin
+      '@sanity/vanilla-extract-vite-plugin':
+        specifier: workspace:*
+        version: link:../../packages/@sanity/vanilla-extract-vite-plugin
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
+      '@vanilla-extract/css':
+        specifier: ^1.21.1
+        version: 1.21.1
+      '@vanilla-extract/rollup-plugin':
+        specifier: ^1.5.4
+        version: 1.5.4(rollup@4.62.2)
+      '@vanilla-extract/vite-plugin':
+        specifier: ^5.2.4
+        version: 5.2.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
+      playwright:
+        specifier: ^1.61.1
+        version: 1.61.1
+      rolldown:
+        specifier: ^1.1.5
+        version: 1.1.5
+      rollup:
+        specifier: ^4.62.2
+        version: 4.62.2
+      tsx:
+        specifier: ^4.23.0
+        version: 4.23.0
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite:
+        specifier: ^8.1.4
+        version: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+
   css-playground/astro:
     devDependencies:
       '@astrojs/react':
@@ -154,7 +199,7 @@ importers:
         version: link:../sanity-css-vanilla-extract-test
       ts-jest:
         specifier: ^29.4.11
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@24.13.3))(typescript@6.0.3)
+        version: 29.4.11(@babel/core@8.0.1)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@8.0.1))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@24.13.3))(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -271,7 +316,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       nuxt:
         specifier: ^4.4.8
-        version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@8.0.1))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -14110,49 +14155,6 @@ packages:
       yaml:
         optional: true
 
-  vite@8.1.3:
-    resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.3.0
-      esbuild: ^0.27.0 || ^0.28.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      '@vitejs/devtools':
-        optional: true
-      esbuild:
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@8.1.4:
     resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -14832,12 +14834,12 @@ snapshots:
       '@astrojs/internal-helpers': 0.10.1
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
-      '@vitejs/plugin-react': 5.2.0(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitejs/plugin-react': 5.2.0(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       devalue: 5.8.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       ultrahtml: 1.6.0
-      vite: 8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -15152,20 +15154,44 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
+
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
+
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -15177,15 +15203,33 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
+
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
+
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -15202,45 +15246,99 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
+
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
+
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
+
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
+
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
+
   '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7)':
     dependencies:
@@ -17597,7 +17695,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.8(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2))(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.133.0)(rolldown@1.1.5)(typescript@7.0.2)':
+  '@nuxt/nitro-server@4.4.8(@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1))(@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2))(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@8.0.1))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.133.0)(rolldown@1.1.5)(typescript@7.0.2)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
@@ -17615,7 +17713,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.4(aws4fetch@1.0.20)(oxc-parser@0.133.0)(rolldown@1.1.5)
-      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@8.0.1))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
       nypm: 0.6.7
       ohash: 2.0.11
       pathe: 2.0.3
@@ -17628,8 +17726,8 @@ snapshots:
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
     optionalDependencies:
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
-      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@8.0.1)
+      '@rollup/plugin-babel': 7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -17684,7 +17782,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/vite-builder@4.4.8(d34e99aa28c9cb482e70f73302f6cb04)':
+  '@nuxt/vite-builder@4.4.8(425cec01b57479dc7ef3a2fa46539cb8)':
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.62.2)
@@ -17702,7 +17800,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@8.0.1))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
       nypm: 0.6.7
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -17717,7 +17815,7 @@ snapshots:
       vue: 3.5.39(typescript@7.0.2)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@8.0.1)
       rolldown: 1.1.5
       rollup-plugin-visualizer: 7.0.1(rolldown@1.1.5)(rollup@4.62.2)
     transitivePeerDependencies:
@@ -19761,6 +19859,19 @@ snapshots:
       rollup: 4.62.2
     transitivePeerDependencies:
       - supports-color
+
+  '@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-module-imports': 7.29.7
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
+      workerpool: 9.3.4
+    optionalDependencies:
+      '@types/babel__core': 7.20.5
+      rollup: 4.62.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@rollup/plugin-commonjs@29.0.3(rollup@4.62.2)':
     dependencies:
@@ -21880,7 +21991,7 @@ snapshots:
 
   '@vercel/stega@1.1.0': {}
 
-  '@vitejs/plugin-react@5.2.0(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -21888,7 +21999,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -22491,8 +22602,8 @@ snapshots:
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.11.1)
-      vite: 8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
@@ -22583,6 +22694,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-jest@30.4.1(@babel/core@8.0.1):
+    dependencies:
+      '@babel/core': 8.0.1
+      '@jest/transform': 30.4.1
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 7.0.1
+      babel-preset-jest: 30.4.0(@babel/core@8.0.1)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   babel-plugin-istanbul@7.0.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.29.7
@@ -22664,11 +22789,38 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7)
 
+  babel-preset-current-node-syntax@1.2.0(@babel/core@8.0.1):
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@8.0.1)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@8.0.1)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@8.0.1)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@8.0.1)
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@8.0.1)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@8.0.1)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@8.0.1)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@8.0.1)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@8.0.1)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@8.0.1)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@8.0.1)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@8.0.1)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@8.0.1)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@8.0.1)
+    optional: true
+
   babel-preset-jest@30.4.0(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
       babel-plugin-jest-hoist: 30.4.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
+
+  babel-preset-jest@30.4.0(@babel/core@8.0.1):
+    dependencies:
+      '@babel/core': 8.0.1
+      babel-plugin-jest-hoist: 30.4.0
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@8.0.1)
+    optional: true
 
   babel-preset-solid@1.9.12(@babel/core@7.29.7)(solid-js@1.9.14):
     dependencies:
@@ -26152,16 +26304,16 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
-  nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0):
+  nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@8.0.1))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@7.0.2)
       '@nuxt/cli': 3.36.0(@nuxt/schema@4.4.8)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.39(typescript@7.0.2))
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.8(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2))(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.133.0)(rolldown@1.1.5)(typescript@7.0.2)
+      '@nuxt/nitro-server': 4.4.8(@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1))(@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2))(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@8.0.1))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@7.1.0(@babel/core@8.0.1)(@types/babel__core@7.20.5)(rollup@4.62.2))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.39)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(terser@5.48.0)(tsx@4.23.0)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.133.0)(rolldown@1.1.5)(typescript@7.0.2)
       '@nuxt/schema': 4.4.8
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.8(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.8(d34e99aa28c9cb482e70f73302f6cb04)
+      '@nuxt/vite-builder': 4.4.8(425cec01b57479dc7ef3a2fa46539cb8)
       '@unhead/vue': 2.1.15(vue@3.5.39(typescript@7.0.2))
       '@vue/shared': 3.5.38
       chokidar: 5.0.0
@@ -28716,7 +28868,7 @@ snapshots:
 
   ts-brand@0.2.0: {}
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@24.13.3))(typescript@6.0.3):
+  ts-jest@29.4.11(@babel/core@8.0.1)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@8.0.1))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@24.13.3))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -28730,10 +28882,10 @@ snapshots:
       typescript: 6.0.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 8.0.1
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
-      babel-jest: 30.4.1(@babel/core@7.29.7)
+      babel-jest: 30.4.1(@babel/core@8.0.1)
       esbuild: 0.28.1
       jest-util: 30.4.1
 
@@ -29323,22 +29475,6 @@ snapshots:
       tsx: 4.23.0
       yaml: 2.9.0
 
-  vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.5
-      postcss: 8.5.16
-      rolldown: 1.1.5
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 24.13.3
-      esbuild: 0.28.1
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      terser: 5.48.0
-      tsx: 4.23.0
-      yaml: 2.9.0
-
   vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -29354,10 +29490,6 @@ snapshots:
       terser: 5.48.0
       tsx: 4.23.0
       yaml: 2.9.0
-
-  vitefu@1.1.3(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
-    optionalDependencies:
-      vite: 8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
 
   vitefu@1.1.3(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - benchmarks/*
   - packages/@sanity/*
   - playground/*
   - css-playground/*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add an opt-in Vitest benchmark workspace for Rollup, Rolldown, and Vite 8 Vanilla Extract integrations
- run the library-build comparison across a variant matrix: baseline, CSS minify, `target: 'chrome61'` downleveling, and minify + target combined — each plugin's own `lightningcss` handling is what differs there
- keep the Vite build comparison variant-free: Vite handles minify/target itself, identically for either plugin, so varying them would only add identical work to both sides
- add deterministic representative and hook-filter stress fixtures with JavaScript hook-entry diagnostics
- add browser-observed Vite HMR benchmarks for leaf and shared-dependency updates
- lazy-load only the plugin under test in each benchmark process so implementations cannot cross-contaminate runs, and validate every emitted build artifact (including minified markers and lowered `inset` syntax)
- track CPU core count in the per-run environment table, and document that more cores widen the library-build gap (Rolldown parallelizes in Rust; Rollup's JS pipeline is largely single-threaded) — a 16-core M4 Max measured 2.68x baseline / up to ~4x minify vs 1.63–1.70x on the 4-core runner below
- publish the latest measured results in [`benchmarks/vanilla-extract/README.md`](https://github.com/sanity-io/pkg-utils/blob/cursor/vanilla-extract-benchmarks-89b3/benchmarks/vanilla-extract/README.md#latest-results), link the three plugin READMEs to it, and add a maintenance rule to `AGENTS.md`: whenever `vanilla-extract` dependencies are bumped or the `@sanity/vanilla-extract-*` plugins change, re-run the suite and refresh the README results
- merged `main` (including the `bundle-css.js` shim rename, #3043) and re-measured on top of it

For the official Rollup plugin (which has no minify/target options of its own), the minify/target variants add the `lightningcss` post-pass that real-world official pipelines (like `@sanity/pkg-utils`'s `optimizeCss`) use, so complete pipelines are compared.

## Benchmark results

Full default suite: `pnpm benchmark:vanilla-extract`, run after merging `main` with the `bundle-css.js` shim rename (#3043). These tables are also published in the benchmark README.

Environment: Node.js 24.18.0, Linux x64, Intel Xeon, 4 cores; Rollup 4.62.2, Rolldown 1.1.5, Vite 8.1.4, Vitest 4.1.10. Values are mean wall-clock milliseconds from this runner and are machine-specific — compare ratios, not absolute numbers. More cores widen the library-build gap in Rolldown's favor (a 16-core M4 Max measured 2.68x baseline and up to ~4x with minify, with the Vite build ratio unchanged at ~1.30x).

### Library build, 500 TS + 100 CSS modules (5 samples each)

| Variant | Rollup + `@vanilla-extract/rollup-plugin` | Rolldown + `@sanity/vanilla-extract-rolldown-plugin` | Relative result |
| --- | ---: | ---: | --- |
| No minify, no target | 591.80 ms | 363.19 ms | Sanity 1.63x faster |
| Minify | 622.98 ms | 371.94 ms | Sanity 1.67x faster |
| Target chrome61 | 642.70 ms | 376.96 ms | Sanity 1.70x faster |
| Minify + target chrome61 | 653.61 ms | 385.33 ms | Sanity 1.70x faster |

### Vite build, 500 TS + 100 CSS modules (5 samples each)

| `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result |
| ---: | ---: | --- |
| 792.66 ms | 601.33 ms | Sanity 1.32x faster |

### Vite dev HMR (10 samples each)

| Scenario | Official plugin | Sanity plugin | Relative result |
| --- | ---: | ---: | --- |
| Single `.css.ts` leaf edit | 27.18 ms | 25.73 ms | Sanity 1.06x faster |
| Shared theme edit, 100 style importers | 178.44 ms | 195.64 ms | Official 1.10x faster |

### Hook-filter stress, `vite build` with 1 CSS module (3 samples each)

| Unrelated modules | Official plugin | Sanity plugin | Relative result |
| ---: | ---: | ---: | --- |
| 0 | 463.89 ms | 311.57 ms | Sanity 1.49x faster |
| 1,000 | 508.41 ms | 331.32 ms | Sanity 1.53x faster |
| 5,000 | 761.97 ms | 535.87 ms | Sanity 1.42x faster |

Hook-filter diagnostics make the Rust-to-JavaScript boundary explicit:

| Unrelated modules | Official `load` / `transform` entries | Sanity `load` / `transform` entries |
| ---: | ---: | ---: |
| 0 | 6 / 8 | 1 / 1 |
| 1,000 | 1,006 / 1,008 | 1 / 1 |
| 5,000 | 5,006 / 5,008 | 1 / 1 |

## Testing
- Node.js 24.18.0
- `pnpm lint --deny-warnings --format github`
- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter @benchmarks/vanilla-extract typecheck`
- `pnpm --filter @benchmarks/vanilla-extract smoke` (10 checks: library-build variant matrix with minified-marker and lowered-`inset` assertions, plus Vite baseline), re-run after merging `main`
- full default `pnpm benchmark:vanilla-extract` run after the merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c88dba1-c9dd-407a-9ef3-1830743489b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c88dba1-c9dd-407a-9ef3-1830743489b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

