### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is the `@sanity/pkg-utils` monorepo: a pnpm workspace containing a build/tooling CLI for
+authoring npm packages (`packages/@sanity/pkg-utils`, wraps rolldown/rollup + API Extractor),
+supporting packages (`tsdown-config`, `tsconfig`, `parse-package-json`, the
+`vanilla-extract-*-plugin` packages), a `playground/*` fixture suite (~30 packages exercising
+build/typecheck scenarios), and a `css-playground/*` fixture suite (~20 packages verifying the
+conditional `bundle.css` export pattern across many frameworks/runtimes). There is **no
+long-running application/database** in this repo — it's a CLI/build-tool product; "running the
+product" means running its build/lint/test/typecheck commands (see root `package.json` `scripts`
+and `.github/workflows/main.yml` for the canonical commands, e.g. `pnpm build`, `pnpm lint`,
+`pnpm typecheck`, `pnpm test`, `pnpm knip`, `pnpm playground:build`/`:typecheck`,
+`pnpm css-playground:build`/`:test`; `css-playground/README.md` documents that suite in detail).
+
+### Node version matters (tsdown requires Node ^22.18.0 || >=24.11.0)
+
+`tsdown` (used to build every `@sanity/*` package) needs Node `^22.18.0 || >=24.11.0` for its
+native TypeScript config-loading; on an older Node it fails with `Failed to import module "unrun"`.
+The sandbox's default system Node (`/exec-daemon/node`, v22.14.0) does **not** satisfy this. Fix:
+Node is managed via `nvm`, with the default alias set to `24` (Node v24.18.0 LTS, "Krypton" —
+matching CI's `node-version: lts/*`) and `pnpm@10.34.4` (matching the root `packageManager` field)
+installed globally under that Node version. A normal login shell (`bash -l`, which sources
+`~/.bashrc`) picks this up automatically via nvm's own auto-`use`-default-on-source behavior — no
+manual `nvm use` should be necessary. `deno` (`~/.deno/bin`, pinned to v2.9.2 to match CI) and `bun`
+(`~/.bun/bin`, latest, matching CI) are also installed and on `PATH` via `~/.bashrc`, needed only by
+the two optional `css-playground/deno` and `css-playground/bun` smoke tests.
+
+If a shell ever shows the wrong Node version (e.g. `node -v` reports `v22.14.0`/`/exec-daemon/node`
+or pnpm/deno/bun are "command not found"), run `nvm use 24` (or open a fresh login shell) to fix it
+for that session — `nvm`'s "current" version is sticky per-shell once explicitly set and won't
+retroactively follow later `nvm alias default` changes.
+
+### Testing notes
+
+- `pnpm test` (root) runs a `pretest` hook that cleans+rebuilds `@sanity/pkg-utils` and cleans the
+  `playground/*` fixtures, then runs `vitest run` — pkg-utils' own suite shells out to build/check
+  ~25 `playground/*` fixtures for real, so it's a strong end-to-end signal, not just unit tests.
+- `pnpm knip` produces warnings (currently 3 unused-catalog-entry warnings) but exits 0; that's
+  expected/matches CI (the `knip` CI job doesn't fail the build on warnings).
+- `pnpm playground:build`/`css-playground:*` build steps are memory-hungry; CI sets
+  `NODE_OPTIONS=--max_old_space_size=8192` — do the same locally if you see OOM-style failures.
+- The `pkg-utils init` CLI command (scaffolds a new package) uses the `prompts` package in raw TTY
+  mode and is not suitable for non-interactive/non-PTY shells — it will abort rather than gracefully
+  read piped stdin. It's also not covered by the automated test suite. Prefer exercising
+  `pkg build`/`pkg check` directly (as the existing tests do) rather than `init` when scripting.
+- `css-playground/verify` (`pnpm --filter @css-playground/verify install-browser` once, then
+  `pnpm --filter @css-playground/verify verify-app <consumer> css|no-css`, e.g.
+  `verify-app vite css`) is a great end-to-end smoke check: it starts a consumer's dev server,
+  loads it in headless Chromium, asserts the producer's computed CSS color against the marker
+  `rgb(1, 2, 3)`, and writes a screenshot to `css-playground/verify/screenshots/`. See
+  `css-playground/README.md` for the full manual/automated visual-verification workflow (dev
+  servers for individual consumers, e.g. `pnpm --filter @css-playground/vite dev`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for the `@sanity/pkg-utils` monorepo (no source code changes) and documents non-obvious environment gotchas for future cloud agents in `AGENTS.md`.

- Installed Node v24.18.0 LTS ("Krypton") via `nvm` and set it as the default, since `tsdown` requires Node `^22.18.0 || >=24.11.0` for its native TS config loader (the sandbox's system Node, v22.14.0, does not satisfy this and fails the build with `Failed to import module "unrun"`). This also matches CI's `node-version: lts/*`.
- Installed `pnpm@10.34.4` (matching the root `packageManager` field), `deno@2.9.2` (matching CI's pin), and `bun` (latest) so the full CI matrix — including the two runtime-specific `css-playground/deno` and `css-playground/bun` smoke tests — can run in this environment.
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the Node-version requirement and other non-obvious testing notes (e.g. `pkg-utils init`'s interactive prompts aren't script-friendly, `css-playground/verify`'s automated visual-verification tool).
- Configured the VM update script to `pnpm install`.

**Testing**
- ✅ `pnpm install`
- ✅ `pnpm build` (all `@sanity/*` packages)
- ✅ `pnpm lint` (oxlint, 0 warnings/errors)
- ✅ `pnpm typecheck` (`tsc --build`, 0 errors)
- ✅ `pnpm test` (vitest, 25 test files / 288 tests passed, 15 skipped as expected, 0 type errors)
- ✅ `pnpm knip` (exit 0, matches CI)
- ✅ `pnpm playground:build` / `pnpm playground:typecheck` (all ~39 fixtures)
- ✅ `pnpm --filter sanity-css-vanilla-extract-test build` + `pnpm css-playground:test` (all 19 consumers, including `deno` and `bun`)
- ✅ End-to-end "hello world": `pnpm --filter @css-playground/verify verify-app vite css` — builds the producer package, starts a real Vite dev server, loads it in headless Chromium, and asserts the computed CSS color matches the expected marker (`rgb(1, 2, 3)`); also manually verified live in a browser via computer use (see attached video)

[css_playground_vite_dev_server_working.mp4](https://cursor.com/agents/bc-c0e08ec8-8e0c-4d07-9043-a58581c90f02/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcss_playground_vite_dev_server_working.mp4)
Vite dev server for the css-playground vanilla-extract CSS test harness, showing the conditional `bundle.css` export correctly applying a border/padding/dark text color to the test element (verified visually and via DevTools box model).

[Automated Playwright verification screenshot](https://cursor.com/agents/bc-c0e08ec8-8e0c-4d07-9043-a58581c90f02/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcss_playground_verify_screenshot.png)
Screenshot from the repo's own automated Playwright check (`css-playground/verify`), which passed with `css=applied color=rgb(1, 2, 3)`.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0e08ec8-8e0c-4d07-9043-a58581c90f02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0e08ec8-8e0c-4d07-9043-a58581c90f02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

