### PR TITLE
fix: rename vanilla-extract CSS shim to bundle-css.js

### DIFF
--- a/.changeset/bundle-css-shim-rename.md
+++ b/.changeset/bundle-css-shim-rename.md
@@ -1,0 +1,10 @@
+---
+"@sanity/vanilla-extract-rolldown-plugin": patch
+"@sanity/vanilla-extract-tsdown-plugin": patch
+"@sanity/pkg-utils": patch
+"@sanity/tsdown-config": patch
+---
+
+Rename the vanilla-extract node/SSR CSS shim from `bundle.css.js` to `bundle-css.js`.
+
+`bundle.css.js` matches vanilla-extract's `cssFileFilter` (`/\.css\.(js|…)$/`), so Vite plugins (notably `@sanity/vanilla-extract-vite-plugin` via Vite's `ModuleRunner`) would try to evaluate the empty shim as `.css.ts` output and throw. The public `./bundle.css` export subpath is unchanged; only the on-disk shim (and its `node`/`default` export targets) move to `bundle-css.js`, with matching `bundle-css.d.ts` / `bundle.css.d.ts` companions for both export targets. Rebuilding a package with compat mode on rewrites `package.json` automatically.

--- a/.changeset/bundle-css-shim-rename.md
+++ b/.changeset/bundle-css-shim-rename.md
@@ -5,6 +5,20 @@
 "@sanity/tsdown-config": patch
 ---
 
-Rename the vanilla-extract node/SSR CSS shim from `bundle.css.js` to `bundle-css.js`.
+Rename the vanilla-extract node/SSR CSS shim from `bundle.css.js` to `bundle-css.js`, and add an explicit `types` condition to the conditional `./bundle.css` export.
 
-`bundle.css.js` matches vanilla-extract's `cssFileFilter` (`/\.css\.(js|…)$/`), so Vite plugins (notably `@sanity/vanilla-extract-vite-plugin` via Vite's `ModuleRunner`) would try to evaluate the empty shim as `.css.ts` output and throw. The public `./bundle.css` export subpath is unchanged; only the on-disk shim (and its `node`/`default` export targets) move to `bundle-css.js`, with matching `bundle-css.d.ts` / `bundle.css.d.ts` companions for both export targets. Rebuilding a package with compat mode on rewrites `package.json` automatically.
+`bundle.css.js` matches vanilla-extract's `cssFileFilter` (`/\.css\.(js|…)$/`), so Vite plugins (notably `@sanity/vanilla-extract-vite-plugin` via Vite's `ModuleRunner`) would try to evaluate the empty shim as `.css.ts` output and throw. The public `./bundle.css` export subpath is unchanged; only the on-disk shim (and its `node`/`default` export targets) move to `bundle-css.js`, with matching `bundle-css.d.ts` / `bundle.css.d.ts` companions for both export targets.
+
+Since the shim's basename no longer matches the CSS file's basename, TypeScript's extension-substitution fallback (stripping `.js` to find a sibling `.d.ts`) would now resolve a different file than before - and that fallback is being deprecated in TypeScript itself (microsoft/TypeScript#50762). The conditional export now points a `types` condition directly at the shim's declaration file instead of relying on it:
+
+```json
+"./bundle.css": {
+  "types": "./dist/bundle-css.d.ts",
+  "browser": "./dist/bundle.css",
+  "style": "./dist/bundle.css",
+  "node": "./dist/bundle-css.js",
+  "default": "./dist/bundle-css.js"
+}
+```
+
+Rebuilding a package with compat mode on rewrites `package.json` automatically.

--- a/css-playground/README.md
+++ b/css-playground/README.md
@@ -11,7 +11,7 @@ that cannot import `.css` files (Node SSR, typegen, importing a package in `next
   enables `rollup.vanillaExtract`. With pkg-utils' compat mode (`extract.compatMode`, on by default)
   this is all it takes — pkg-utils automatically injects the self-referential
   `import "sanity-css-vanilla-extract-test/bundle.css"` into the entry chunk, emits the no-op
-  `bundle.css.js` shim, and writes the conditional `./bundle.css` export to `package.json` so that
+  `bundle-css.js` shim, and writes the conditional `./bundle.css` export to `package.json` so that
   the import resolves to:
   - the real CSS file under the `browser`/`style` conditions (bundlers / browsers), and
   - a no-op JS shim (`export default ""`) under the `node`/`default` conditions (Node-like runtimes).

--- a/css-playground/sanity-css-vanilla-extract-test/package.config.ts
+++ b/css-playground/sanity-css-vanilla-extract-test/package.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   rollup: {
     // With `vanillaExtract: true`, pkg-utils' compat mode (on by default) automatically injects the
     // self-referential `import "sanity-css-vanilla-extract-test/bundle.css"`, emits the
-    // `bundle.css.js` shim, and writes the conditional `./bundle.css` export to package.json.
+    // `bundle-css.js` shim, and writes the conditional `./bundle.css` export to package.json.
     vanillaExtract: true,
   },
 })

--- a/css-playground/sanity-css-vanilla-extract-test/package.json
+++ b/css-playground/sanity-css-vanilla-extract-test/package.json
@@ -16,8 +16,8 @@
     "./bundle.css": {
       "browser": "./dist/bundle.css",
       "style": "./dist/bundle.css",
-      "node": "./dist/bundle.css.js",
-      "default": "./dist/bundle.css.js"
+      "node": "./dist/bundle-css.js",
+      "default": "./dist/bundle-css.js"
     },
     "./package.json": "./package.json"
   },
@@ -60,8 +60,8 @@
       "./bundle.css": {
         "browser": "./dist/bundle.css",
         "style": "./dist/bundle.css",
-        "node": "./dist/bundle.css.js",
-        "default": "./dist/bundle.css.js"
+        "node": "./dist/bundle-css.js",
+        "default": "./dist/bundle-css.js"
       },
       "./package.json": "./package.json"
     }

--- a/css-playground/sanity-css-vanilla-extract-test/package.json
+++ b/css-playground/sanity-css-vanilla-extract-test/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/index.js"
     },
     "./bundle.css": {
+      "types": "./dist/bundle-css.d.ts",
       "browser": "./dist/bundle.css",
       "style": "./dist/bundle.css",
       "node": "./dist/bundle-css.js",
@@ -58,6 +59,7 @@
         "default": "./dist/index.js"
       },
       "./bundle.css": {
+        "types": "./dist/bundle-css.d.ts",
         "browser": "./dist/bundle.css",
         "style": "./dist/bundle.css",
         "node": "./dist/bundle-css.js",

--- a/packages/@sanity/parse-package-json/src/parsePackage.ts
+++ b/packages/@sanity/parse-package-json/src/parsePackage.ts
@@ -33,6 +33,7 @@ const exportEntrySchema = z
  * Conditional export for a CSS file, e.g.
  * ```json
  * "./bundle.css": {
+ *   "types": "./dist/bundle-css.d.ts",
  *   "browser": "./dist/bundle.css",
  *   "node": "./dist/bundle-css.js",
  *   "default": "./dist/bundle-css.js"

--- a/packages/@sanity/parse-package-json/src/parsePackage.ts
+++ b/packages/@sanity/parse-package-json/src/parsePackage.ts
@@ -34,8 +34,8 @@ const exportEntrySchema = z
  * ```json
  * "./bundle.css": {
  *   "browser": "./dist/bundle.css",
- *   "node": "./dist/bundle.css.js",
- *   "default": "./dist/bundle.css.js"
+ *   "node": "./dist/bundle-css.js",
+ *   "default": "./dist/bundle-css.js"
  * }
  * ```
  * This lets a package re-add a `import "<pkg>/bundle.css"` statement that resolves to the real CSS

--- a/packages/@sanity/parse-package-json/test/parsePackage.test.ts
+++ b/packages/@sanity/parse-package-json/test/parsePackage.test.ts
@@ -265,8 +265,8 @@ describe('parsePackage', () => {
         './bundle.css': {
           browser: './dist/bundle.css',
           style: './dist/bundle.css',
-          node: './dist/bundle.css.js',
-          default: './dist/bundle.css.js',
+          node: './dist/bundle-css.js',
+          default: './dist/bundle-css.js',
         },
       },
     }
@@ -277,8 +277,8 @@ describe('parsePackage', () => {
     expect(parsed.exports?.['./bundle.css']).toEqual({
       browser: './dist/bundle.css',
       style: './dist/bundle.css',
-      node: './dist/bundle.css.js',
-      default: './dist/bundle.css.js',
+      node: './dist/bundle-css.js',
+      default: './dist/bundle-css.js',
     })
   })
 

--- a/packages/@sanity/parse-package-json/test/parsePackage.test.ts
+++ b/packages/@sanity/parse-package-json/test/parsePackage.test.ts
@@ -263,6 +263,7 @@ describe('parsePackage', () => {
       exports: {
         ...template.exports,
         './bundle.css': {
+          types: './dist/bundle-css.d.ts',
           browser: './dist/bundle.css',
           style: './dist/bundle.css',
           node: './dist/bundle-css.js',
@@ -275,6 +276,7 @@ describe('parsePackage', () => {
 
     // The conditional CSS export must NOT have a `default` computed/added or be otherwise rewritten.
     expect(parsed.exports?.['./bundle.css']).toEqual({
+      types: './dist/bundle-css.d.ts',
       browser: './dist/bundle.css',
       style: './dist/bundle.css',
       node: './dist/bundle-css.js',

--- a/packages/@sanity/pkg-utils/src/node/core/config/types.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/config/types.ts
@@ -55,7 +55,8 @@ export interface PkgVanillaExtractOptions extends Omit<VanillaExtractOptions, 'e
      *   import `.css` files — named with a hyphen rather than a `.css.js` suffix so it does not
      *   match vanilla-extract's `cssFileFilter`, and
      * - writes the conditional `"./<name>"` export to `package.json`
-     *   (`browser`/`style` → the real CSS, `node`/`default` → the shim).
+     *   (`types` → the shim's `.d.ts`, `browser`/`style` → the real CSS, `node`/`default` → the
+     *   shim).
      *
      * The result is that `import "<pkg>/<name>"` resolves to the real CSS in bundlers/browsers and
      * to the no-op shim in Node and similar runtimes. Disable it to wire these up yourself.

--- a/packages/@sanity/pkg-utils/src/node/core/config/types.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/config/types.ts
@@ -51,7 +51,9 @@ export interface PkgVanillaExtractOptions extends Omit<VanillaExtractOptions, 'e
      * not have to. When enabled, pkg-utils:
      *
      * - injects `import "<pkg-name>/<name>"` into each entry chunk (no manual `rollup.output.intro`),
-     * - emits a no-op `<name>.js` shim for runtimes that cannot import `.css` files, and
+     * - emits a no-op shim (e.g. `bundle-css.js` for `name: "bundle.css"`) for runtimes that cannot
+     *   import `.css` files — named with a hyphen rather than a `.css.js` suffix so it does not
+     *   match vanilla-extract's `cssFileFilter`, and
      * - writes the conditional `"./<name>"` export to `package.json`
      *   (`browser`/`style` → the real CSS, `node`/`default` → the shim).
      *
@@ -235,7 +237,7 @@ export interface PkgConfigOptions {
      * minifying the extracted CSS. Pass `true` to use the defaults, or an object to customize.
      *
      * By default (`extract.compatMode: true`) pkg-utils also injects the self-referential
-     * `import "<pkg>/bundle.css"`, emits a `bundle.css.js` shim, and writes the conditional
+     * `import "<pkg>/bundle.css"`, emits a `bundle-css.js` shim, and writes the conditional
      * `"./bundle.css"` export to `package.json` - see {@link PkgVanillaExtractOptions}.
      * @alpha
      */

--- a/packages/@sanity/pkg-utils/src/node/core/pkg/cssShimFileName.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/pkg/cssShimFileName.ts
@@ -1,0 +1,22 @@
+/**
+ * The no-op JS shim file name for a CSS file under vanilla-extract compat mode.
+ *
+ * `bundle.css` → `bundle-css.js` — deliberately not `${cssFileName}.js` (`bundle.css.js`),
+ * which vanilla-extract's `cssFileFilter` (`/\.css\.(js|cjs|mjs|jsx|ts|tsx)$/`) would treat as
+ * a stylesheet module. Kept in sync with `cssShimFileName` in
+ * `@sanity/vanilla-extract-rolldown-plugin`.
+ *
+ * @internal
+ */
+export function cssShimFileName(cssFileName: string): string {
+  return `${cssFileName.replace(/\.css$/, '-css')}.js`
+}
+
+/**
+ * The `.d.ts` companion for {@link cssShimFileName}. `bundle.css` → `bundle-css.d.ts`.
+ *
+ * @internal
+ */
+export function cssShimDtsFileName(cssFileName: string): string {
+  return `${cssFileName.replace(/\.css$/, '-css')}.d.ts`
+}

--- a/packages/@sanity/pkg-utils/src/node/core/pkg/parseAndValidateExports.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/pkg/parseAndValidateExports.ts
@@ -171,7 +171,7 @@ export function parseAndValidateExports(options: {
         }
       } else if (isRecord(exportEntry)) {
         // Conditional CSS export, e.g.
-        // "./bundle.css": { "browser": "./dist/bundle.css", "node": "./dist/bundle-css.js", "default": "./dist/bundle-css.js" }
+        // "./bundle.css": { "types": "./dist/bundle-css.d.ts", "browser": "./dist/bundle.css", "node": "./dist/bundle-css.js", "default": "./dist/bundle-css.js" }
         // This lets a package re-add a `import "<pkg>/bundle.css"` that resolves to the real CSS in
         // bundler/browser environments and to a no-op JS shim in CSS-unaware runtimes (e.g. Node).
         // Only the shape is validated here: the targets usually point at generated `dist` files that

--- a/packages/@sanity/pkg-utils/src/node/core/pkg/parseAndValidateExports.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/pkg/parseAndValidateExports.ts
@@ -171,7 +171,7 @@ export function parseAndValidateExports(options: {
         }
       } else if (isRecord(exportEntry)) {
         // Conditional CSS export, e.g.
-        // "./bundle.css": { "browser": "./dist/bundle.css", "node": "./dist/bundle.css.js", "default": "./dist/bundle.css.js" }
+        // "./bundle.css": { "browser": "./dist/bundle.css", "node": "./dist/bundle-css.js", "default": "./dist/bundle-css.js" }
         // This lets a package re-add a `import "<pkg>/bundle.css"` that resolves to the real CSS in
         // bundler/browser environments and to a no-op JS shim in CSS-unaware runtimes (e.g. Node).
         // Only the shape is validated here: the targets usually point at generated `dist` files that

--- a/packages/@sanity/pkg-utils/src/node/core/pkg/writeBundleCssExports.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/pkg/writeBundleCssExports.ts
@@ -2,6 +2,7 @@ import {readFile, writeFile} from 'node:fs/promises'
 import path from 'node:path'
 import type {Logger} from '../../logger.ts'
 import {isRecord} from '../isRecord.ts'
+import {cssShimFileName} from './cssShimFileName.ts'
 
 /**
  * Build the conditional CSS export object that vanilla-extract compat mode expects, e.g.
@@ -9,10 +10,12 @@ import {isRecord} from '../isRecord.ts'
  * {
  *   "browser": "./dist/bundle.css",
  *   "style": "./dist/bundle.css",
- *   "node": "./dist/bundle.css.js",
- *   "default": "./dist/bundle.css.js"
+ *   "node": "./dist/bundle-css.js",
+ *   "default": "./dist/bundle-css.js"
  * }
  * ```
+ * The shim is named `bundle-css.js` (not `bundle.css.js`) so it does not match
+ * vanilla-extract's `cssFileFilter`.
  */
 function createConditionalCssExport(cssFile: string, shimFile: string) {
   return {browser: cssFile, style: cssFile, node: shimFile, default: shimFile}
@@ -92,7 +95,7 @@ export async function writeBundleCssExports(options: {
   const distRel = (path.relative(cwd, distPath) || 'dist').split(path.sep).join('/')
   const exportKey = `./${cssName}`
   const cssFile = `./${path.posix.join(distRel, cssName)}`
-  const shimFile = `./${path.posix.join(distRel, `${cssName}.js`)}`
+  const shimFile = `./${path.posix.join(distRel, cssShimFileName(cssName))}`
   const conditionalExport = createConditionalCssExport(cssFile, shimFile)
 
   // Only mirror into `publishConfig.exports` when it already exists; never create it here.

--- a/packages/@sanity/pkg-utils/src/node/core/pkg/writeBundleCssExports.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/pkg/writeBundleCssExports.ts
@@ -2,12 +2,13 @@ import {readFile, writeFile} from 'node:fs/promises'
 import path from 'node:path'
 import type {Logger} from '../../logger.ts'
 import {isRecord} from '../isRecord.ts'
-import {cssShimFileName} from './cssShimFileName.ts'
+import {cssShimDtsFileName, cssShimFileName} from './cssShimFileName.ts'
 
 /**
  * Build the conditional CSS export object that vanilla-extract compat mode expects, e.g.
  * ```json
  * {
+ *   "types": "./dist/bundle-css.d.ts",
  *   "browser": "./dist/bundle.css",
  *   "style": "./dist/bundle.css",
  *   "node": "./dist/bundle-css.js",
@@ -15,10 +16,13 @@ import {cssShimFileName} from './cssShimFileName.ts'
  * }
  * ```
  * The shim is named `bundle-css.js` (not `bundle.css.js`) so it does not match
- * vanilla-extract's `cssFileFilter`.
+ * vanilla-extract's `cssFileFilter`. An explicit `types` condition (rather than relying on
+ * TypeScript's extension-substitution fallback, which only works when the shim shares the CSS
+ * file's basename, and which TypeScript is deprecating anyway - microsoft/TypeScript#50762)
+ * points resolvers straight at the shim's declaration file.
  */
-function createConditionalCssExport(cssFile: string, shimFile: string) {
-  return {browser: cssFile, style: cssFile, node: shimFile, default: shimFile}
+function createConditionalCssExport(cssFile: string, shimFile: string, shimDtsFile: string) {
+  return {types: shimDtsFile, browser: cssFile, style: cssFile, node: shimFile, default: shimFile}
 }
 
 function hasMatchingExport(value: unknown, expected: Record<string, string>): boolean {
@@ -96,7 +100,8 @@ export async function writeBundleCssExports(options: {
   const exportKey = `./${cssName}`
   const cssFile = `./${path.posix.join(distRel, cssName)}`
   const shimFile = `./${path.posix.join(distRel, cssShimFileName(cssName))}`
-  const conditionalExport = createConditionalCssExport(cssFile, shimFile)
+  const shimDtsFile = `./${path.posix.join(distRel, cssShimDtsFileName(cssName))}`
+  const conditionalExport = createConditionalCssExport(cssFile, shimFile, shimDtsFile)
 
   // Only mirror into `publishConfig.exports` when it already exists; never create it here.
   const publishConfig = pkg.publishConfig

--- a/packages/@sanity/pkg-utils/src/node/tasks/rollup/bundleCssShim.ts
+++ b/packages/@sanity/pkg-utils/src/node/tasks/rollup/bundleCssShim.ts
@@ -1,33 +1,42 @@
 import type {Plugin} from 'rollup'
+import {cssShimDtsFileName, cssShimFileName} from '../../core/pkg/cssShimFileName.ts'
 
 /**
- * Emits a no-op JavaScript shim (`export default ""`) alongside the extracted CSS. The conditional
- * `./<css>` export points its `node`/`default` conditions at this file so that the self-referential
- * `import "<pkg>/<css>"` resolves to a harmless module in runtimes that cannot import `.css` files,
- * instead of throwing `Error: Unknown file extension ".css"`.
+ * Emits a no-op JavaScript shim alongside the extracted CSS. The conditional `./<css>` export
+ * points its `node`/`default` conditions at this file so that the self-referential
+ * `import "<pkg>/<css>"` resolves to a harmless module in runtimes that cannot import `.css`
+ * files, instead of throwing `Error: Unknown file extension ".css"`.
  *
- * A matching `.d.ts` declaration is emitted next to the shim as well. Both the `browser`/`style`
- * (`<css>`) and the `node`/`default` (`<css>.js`) conditions of the `./<css>` export resolve their
- * types to the same `<css>.d.ts` file, so type-aware tooling (e.g. dts export checkers that load a
- * `.d.ts` for every export target) does not crash on a missing declaration file.
+ * Matching `.d.ts` declarations are emitted for both export targets:
+ * - `<css>.d.ts` for the extracted CSS file (`browser` / `style` conditions)
+ * - `<css-shim>.d.ts` (e.g. `bundle-css.d.ts`) for the JS shim (`node` / `default` conditions)
  *
- * @param options.fileName - The shim file name, e.g. `bundle.css.js`.
+ * The shim is named `bundle-css.js` rather than `bundle.css.js` so it does not match
+ * vanilla-extract's `cssFileFilter` (`/\.css\.(js|…)$/`).
+ *
+ * @param options.cssName - The CSS file name, e.g. `bundle.css`.
  * @internal
  */
-export function bundleCssShim(options: {fileName: string}): Plugin {
-  const cssName = options.fileName.replace(/\.js$/, '')
+export function bundleCssShim(options: {cssName: string}): Plugin {
+  const {cssName} = options
+  const shimFileName = cssShimFileName(cssName)
 
   return {
     name: 'pkg-utils:bundle-css-shim',
     generateBundle() {
       this.emitFile({
         type: 'asset',
-        fileName: options.fileName,
+        fileName: shimFileName,
         source: `// No-op shim for \`${cssName}\` in runtimes that cannot import \`.css\` files directly.\nexport default ""\n`,
       })
       this.emitFile({
         type: 'asset',
         fileName: `${cssName}.d.ts`,
+        source: `// Type declarations for \`${cssName}\` and its no-op JS shim.\ndeclare const _default: string\nexport default _default\n`,
+      })
+      this.emitFile({
+        type: 'asset',
+        fileName: cssShimDtsFileName(cssName),
         source: `// Type declarations for \`${cssName}\` and its no-op JS shim.\ndeclare const _default: string\nexport default _default\n`,
       })
     },

--- a/packages/@sanity/pkg-utils/src/node/tasks/rollup/resolveRollupConfig.ts
+++ b/packages/@sanity/pkg-utils/src/node/tasks/rollup/resolveRollupConfig.ts
@@ -196,8 +196,9 @@ export function resolveRollupConfig(
         minify: vanillaExtract.options.minify ?? true,
       }),
     // In compat mode, emit the no-op JS shim that the `node`/`default` conditions of the
-    // `./<css>` export resolve to.
-    vanillaExtract.compatMode && bundleCssShim({fileName: `${vanillaExtractCssName}.js`}),
+    // `./<css>` export resolve to (named `bundle-css.js`, not `bundle.css.js`, so it does not
+    // match vanilla-extract's `cssFileFilter`).
+    vanillaExtract.compatMode && bundleCssShim({cssName: vanillaExtractCssName}),
     (config?.babel?.reactCompiler || enableStyledComponents) &&
       babel({
         babelrc: false,

--- a/packages/@sanity/pkg-utils/test/bundleCssShim.test.ts
+++ b/packages/@sanity/pkg-utils/test/bundleCssShim.test.ts
@@ -1,8 +1,8 @@
 import {describe, expect, test, vi} from 'vitest'
 import {bundleCssShim} from '../src/node/tasks/rollup/bundleCssShim'
 
-function runGenerateBundle(fileName: string) {
-  const plugin = bundleCssShim({fileName})
+function runGenerateBundle(cssName: string) {
+  const plugin = bundleCssShim({cssName})
   const emitFile = vi.fn()
   const generateBundle = plugin.generateBundle
   if (typeof generateBundle !== 'function') {
@@ -16,28 +16,33 @@ function runGenerateBundle(fileName: string) {
 }
 
 describe('bundleCssShim', () => {
-  test('emits the no-op JS shim', () => {
-    const emitted = runGenerateBundle('bundle.css.js')
-    const shim = emitted.find((file) => file.fileName === 'bundle.css.js')
+  test('emits the no-op JS shim under a non-`.css.js` name', () => {
+    const emitted = runGenerateBundle('bundle.css')
+    const shim = emitted.find((file) => file.fileName === 'bundle-css.js')
     expect(shim).toBeDefined()
     expect(shim?.type).toBe('asset')
     expect(shim?.source).toContain('export default ""')
   })
 
-  test('emits a matching `.d.ts` declaration so dts export checkers do not crash', () => {
-    const emitted = runGenerateBundle('bundle.css.js')
-    const dts = emitted.find((file) => file.fileName === 'bundle.css.d.ts')
-    expect(dts).toBeDefined()
-    expect(dts?.type).toBe('asset')
-    expect(dts?.source).toContain('declare const _default: string')
-    expect(dts?.source).toContain('export default _default')
+  test('emits `.d.ts` companions for both the CSS file and the shim', () => {
+    const emitted = runGenerateBundle('bundle.css')
+    const cssDts = emitted.find((file) => file.fileName === 'bundle.css.d.ts')
+    const shimDts = emitted.find((file) => file.fileName === 'bundle-css.d.ts')
+    expect(cssDts).toBeDefined()
+    expect(shimDts).toBeDefined()
+    for (const dts of [cssDts, shimDts]) {
+      expect(dts?.type).toBe('asset')
+      expect(dts?.source).toContain('declare const _default: string')
+      expect(dts?.source).toContain('export default _default')
+    }
   })
 
   test('respects a custom css name', () => {
-    const emitted = runGenerateBundle('styles.css.js')
+    const emitted = runGenerateBundle('styles.css')
     expect(emitted.map((file) => file.fileName).toSorted()).toEqual([
+      'styles-css.d.ts',
+      'styles-css.js',
       'styles.css.d.ts',
-      'styles.css.js',
     ])
   })
 })

--- a/packages/@sanity/pkg-utils/test/cli.test.ts
+++ b/packages/@sanity/pkg-utils/test/cli.test.ts
@@ -553,14 +553,16 @@ describe.skipIf(process.platform === 'win32')('cli', () => {
       distBundleCss,
       distBundleCssShim,
       distBundleCssDts,
+      distBundleCssShimDts,
       pkg,
     ] = await Promise.all([
       project.readFile('dist/_chunks-es/ColorInput.js'),
       project.readFile('dist/index.js'),
       project.readFile('dist/index.d.ts'),
       project.readFile('dist/bundle.css'),
-      project.readFile('dist/bundle.css.js'),
+      project.readFile('dist/bundle-css.js'),
       project.readFile('dist/bundle.css.d.ts'),
+      project.readFile('dist/bundle-css.d.ts'),
       project.readFile('package.json'),
     ])
 
@@ -571,17 +573,20 @@ describe.skipIf(process.platform === 'win32')('cli', () => {
     expect(distIndexJs).toContain(`import "@sanity/ui/css/index.css"`)
     // `vanillaExtract` compat mode injects the self-referential bundle.css import automatically
     expect(distIndexJs).toContain(`import "sanity-plugin-with-vanilla-extract/bundle.css"`)
-    // …emits a no-op JS shim for CSS-unaware runtimes
+    // …emits a no-op JS shim for CSS-unaware runtimes (named `bundle-css.js`, not
+    // `bundle.css.js`, so vanilla-extract's `cssFileFilter` does not match it)
     expect(distBundleCssShim).toContain('export default ""')
-    // …emits a matching `.d.ts` so dts export checkers don't crash on a missing declaration file
+    // …emits matching `.d.ts` files for both the CSS and shim export targets
     expect(distBundleCssDts).toContain('declare const _default: string')
     expect(distBundleCssDts).toContain('export default _default')
+    expect(distBundleCssShimDts).toContain('declare const _default: string')
+    expect(distBundleCssShimDts).toContain('export default _default')
     // …and declares the conditional `./bundle.css` export in package.json
     expect(JSON.parse(pkg).exports['./bundle.css']).toEqual({
       browser: './dist/bundle.css',
       style: './dist/bundle.css',
-      node: './dist/bundle.css.js',
-      default: './dist/bundle.css.js',
+      node: './dist/bundle-css.js',
+      default: './dist/bundle-css.js',
     })
     // React Compiler adds a `c` function call
     expect(distChunksColorInput).toContain('const $ = c(')

--- a/packages/@sanity/pkg-utils/test/cli.test.ts
+++ b/packages/@sanity/pkg-utils/test/cli.test.ts
@@ -583,6 +583,7 @@ describe.skipIf(process.platform === 'win32')('cli', () => {
     expect(distBundleCssShimDts).toContain('export default _default')
     // …and declares the conditional `./bundle.css` export in package.json
     expect(JSON.parse(pkg).exports['./bundle.css']).toEqual({
+      types: './dist/bundle-css.d.ts',
       browser: './dist/bundle.css',
       style: './dist/bundle.css',
       node: './dist/bundle-css.js',

--- a/packages/@sanity/pkg-utils/test/parseAndValidateExports.test.ts
+++ b/packages/@sanity/pkg-utils/test/parseAndValidateExports.test.ts
@@ -192,6 +192,7 @@ describe.each([{type: 'commonjs' as const}, {type: 'module' as const}, {type: un
           exports: {
             ...reference,
             './bundle.css': {
+              types: './dist/bundle-css.d.ts',
               browser: './dist/bundle.css',
               style: './dist/bundle.css',
               node: './dist/bundle-css.js',

--- a/packages/@sanity/pkg-utils/test/parseAndValidateExports.test.ts
+++ b/packages/@sanity/pkg-utils/test/parseAndValidateExports.test.ts
@@ -194,8 +194,8 @@ describe.each([{type: 'commonjs' as const}, {type: 'module' as const}, {type: un
             './bundle.css': {
               browser: './dist/bundle.css',
               style: './dist/bundle.css',
-              node: './dist/bundle.css.js',
-              default: './dist/bundle.css.js',
+              node: './dist/bundle-css.js',
+              default: './dist/bundle-css.js',
             },
           },
         } as unknown as PackageJSON

--- a/packages/@sanity/pkg-utils/test/publishConfigExports.test.ts
+++ b/packages/@sanity/pkg-utils/test/publishConfigExports.test.ts
@@ -248,6 +248,7 @@ describe('publishConfig.exports validation', () => {
             default: './dist/index.js',
           },
           './bundle.css': {
+            types: './dist/bundle-css.d.ts',
             browser: './dist/bundle.css',
             style: './dist/bundle.css',
             node: './dist/bundle-css.js',
@@ -260,6 +261,7 @@ describe('publishConfig.exports validation', () => {
               default: './dist/index.js',
             },
             './bundle.css': {
+              types: './dist/bundle-css.d.ts',
               browser: './dist/bundle.css',
               style: './dist/bundle.css',
               node: './dist/bundle-css.js',
@@ -286,6 +288,7 @@ describe('publishConfig.exports validation', () => {
             default: './dist/index.js',
           },
           './bundle.css': {
+            types: './dist/bundle-css.d.ts',
             browser: './dist/bundle.css',
             style: './dist/bundle.css',
             node: './dist/bundle-css.js',

--- a/packages/@sanity/pkg-utils/test/publishConfigExports.test.ts
+++ b/packages/@sanity/pkg-utils/test/publishConfigExports.test.ts
@@ -250,8 +250,8 @@ describe('publishConfig.exports validation', () => {
           './bundle.css': {
             browser: './dist/bundle.css',
             style: './dist/bundle.css',
-            node: './dist/bundle.css.js',
-            default: './dist/bundle.css.js',
+            node: './dist/bundle-css.js',
+            default: './dist/bundle-css.js',
           },
         },
         publishConfig: {
@@ -262,8 +262,8 @@ describe('publishConfig.exports validation', () => {
             './bundle.css': {
               browser: './dist/bundle.css',
               style: './dist/bundle.css',
-              node: './dist/bundle.css.js',
-              default: './dist/bundle.css.js',
+              node: './dist/bundle-css.js',
+              default: './dist/bundle-css.js',
             },
           },
         },
@@ -288,8 +288,8 @@ describe('publishConfig.exports validation', () => {
           './bundle.css': {
             browser: './dist/bundle.css',
             style: './dist/bundle.css',
-            node: './dist/bundle.css.js',
-            default: './dist/bundle.css.js',
+            node: './dist/bundle-css.js',
+            default: './dist/bundle-css.js',
           },
         },
         publishConfig: {
@@ -300,7 +300,7 @@ describe('publishConfig.exports validation', () => {
             './bundle.css': {
               browser: './dist/bundle.css',
               style: './dist/bundle.css',
-              node: './dist/bundle.css.js',
+              node: './dist/bundle-css.js',
               // mismatched: points back at the real CSS instead of the shim
               default: './dist/bundle.css',
             },

--- a/packages/@sanity/pkg-utils/test/writeBundleCssExports.test.ts
+++ b/packages/@sanity/pkg-utils/test/writeBundleCssExports.test.ts
@@ -40,6 +40,7 @@ describe('writeBundleCssExports', () => {
 
     const pkg = await readPkg(cwd)
     expect(pkg.exports['./bundle.css']).toEqual({
+      types: './dist/bundle-css.d.ts',
       browser: './dist/bundle.css',
       style: './dist/bundle.css',
       node: './dist/bundle-css.js',
@@ -55,6 +56,7 @@ describe('writeBundleCssExports', () => {
       exports: {
         '.': {source: './src/index.ts', default: './dist/index.js'},
         './bundle.css': {
+          types: './dist/bundle-css.d.ts',
           browser: './dist/bundle.css',
           style: './dist/bundle.css',
           node: './dist/bundle-css.js',
@@ -91,6 +93,7 @@ describe('writeBundleCssExports', () => {
 
     const pkg = await readPkg(cwd)
     expect(pkg.exports['./styles.css']).toEqual({
+      types: './lib/styles-css.d.ts',
       browser: './lib/styles.css',
       style: './lib/styles.css',
       node: './lib/styles-css.js',
@@ -123,6 +126,7 @@ describe('writeBundleCssExports', () => {
 
     const pkg = await readPkg(cwd)
     const expected = {
+      types: './dist/bundle-css.d.ts',
       browser: './dist/bundle.css',
       style: './dist/bundle.css',
       node: './dist/bundle-css.js',
@@ -193,6 +197,7 @@ describe('writeBundleCssExports', () => {
       exports: {
         '.': {source: './src/index.ts', default: './dist/index.js'},
         './bundle.css': {
+          types: './dist/bundle-css.d.ts',
           browser: './dist/bundle.css',
           style: './dist/bundle.css',
           node: './dist/bundle-css.js',
@@ -217,6 +222,7 @@ describe('writeBundleCssExports', () => {
 
     const pkg = await readPkg(cwd)
     expect(pkg.publishConfig?.exports?.['./bundle.css']).toEqual({
+      types: './dist/bundle-css.d.ts',
       browser: './dist/bundle.css',
       style: './dist/bundle.css',
       node: './dist/bundle-css.js',
@@ -226,6 +232,7 @@ describe('writeBundleCssExports', () => {
 
   test('is idempotent when both exports and publishConfig.exports already match', async () => {
     const conditionalExport = {
+      types: './dist/bundle-css.d.ts',
       browser: './dist/bundle.css',
       style: './dist/bundle.css',
       node: './dist/bundle-css.js',

--- a/packages/@sanity/pkg-utils/test/writeBundleCssExports.test.ts
+++ b/packages/@sanity/pkg-utils/test/writeBundleCssExports.test.ts
@@ -42,8 +42,8 @@ describe('writeBundleCssExports', () => {
     expect(pkg.exports['./bundle.css']).toEqual({
       browser: './dist/bundle.css',
       style: './dist/bundle.css',
-      node: './dist/bundle.css.js',
-      default: './dist/bundle.css.js',
+      node: './dist/bundle-css.js',
+      default: './dist/bundle-css.js',
     })
     expect(Object.keys(pkg.exports)).toEqual(['.', './bundle.css', './package.json'])
   })
@@ -57,8 +57,8 @@ describe('writeBundleCssExports', () => {
         './bundle.css': {
           browser: './dist/bundle.css',
           style: './dist/bundle.css',
-          node: './dist/bundle.css.js',
-          default: './dist/bundle.css.js',
+          node: './dist/bundle-css.js',
+          default: './dist/bundle-css.js',
         },
         './package.json': './package.json',
       },
@@ -93,8 +93,8 @@ describe('writeBundleCssExports', () => {
     expect(pkg.exports['./styles.css']).toEqual({
       browser: './lib/styles.css',
       style: './lib/styles.css',
-      node: './lib/styles.css.js',
-      default: './lib/styles.css.js',
+      node: './lib/styles-css.js',
+      default: './lib/styles-css.js',
     })
   })
 
@@ -125,8 +125,8 @@ describe('writeBundleCssExports', () => {
     const expected = {
       browser: './dist/bundle.css',
       style: './dist/bundle.css',
-      node: './dist/bundle.css.js',
-      default: './dist/bundle.css.js',
+      node: './dist/bundle-css.js',
+      default: './dist/bundle-css.js',
     }
     expect(pkg.exports['./bundle.css']).toEqual(expected)
     expect(pkg.publishConfig?.exports?.['./bundle.css']).toEqual(expected)
@@ -195,8 +195,8 @@ describe('writeBundleCssExports', () => {
         './bundle.css': {
           browser: './dist/bundle.css',
           style: './dist/bundle.css',
-          node: './dist/bundle.css.js',
-          default: './dist/bundle.css.js',
+          node: './dist/bundle-css.js',
+          default: './dist/bundle-css.js',
         },
         './package.json': './package.json',
       },
@@ -219,8 +219,8 @@ describe('writeBundleCssExports', () => {
     expect(pkg.publishConfig?.exports?.['./bundle.css']).toEqual({
       browser: './dist/bundle.css',
       style: './dist/bundle.css',
-      node: './dist/bundle.css.js',
-      default: './dist/bundle.css.js',
+      node: './dist/bundle-css.js',
+      default: './dist/bundle-css.js',
     })
   })
 
@@ -228,8 +228,8 @@ describe('writeBundleCssExports', () => {
     const conditionalExport = {
       browser: './dist/bundle.css',
       style: './dist/bundle.css',
-      node: './dist/bundle.css.js',
-      default: './dist/bundle.css.js',
+      node: './dist/bundle-css.js',
+      default: './dist/bundle-css.js',
     }
     const cwd = await setupPackage({
       name: 'example',

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -99,8 +99,8 @@ automatically:
   vanilla-extract styles,
 - emits a no-op `bundle-css.js` shim (plus `bundle.css.d.ts` / `bundle-css.d.ts`) for runtimes
   that cannot import `.css` files, and
-- writes the conditional `"./bundle.css"` export to `package.json` (`browser`/`style` → the real
-  CSS, `node`/`default` → the shim).
+- writes the conditional `"./bundle.css"` export to `package.json` (`types` → the shim's `.d.ts`,
+  `browser`/`style` → the real CSS, `node`/`default` → the shim).
 
 The result is that `import "<pkg>/bundle.css"` resolves to the real CSS in bundlers/browsers and to
 the no-op shim in Node and similar runtimes. Make sure the extracted CSS survives tree-shaking in

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -97,8 +97,8 @@ automatically:
 
 - injects the self-referential `import "<pkg>/bundle.css"` into the entry chunks that use
   vanilla-extract styles,
-- emits a no-op `bundle.css.js` shim (plus `bundle.css.d.ts`) for runtimes that cannot import
-  `.css` files, and
+- emits a no-op `bundle-css.js` shim (plus `bundle.css.d.ts` / `bundle-css.d.ts`) for runtimes
+  that cannot import `.css` files, and
 - writes the conditional `"./bundle.css"` export to `package.json` (`browser`/`style` → the real
   CSS, `node`/`default` → the shim).
 

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -141,7 +141,7 @@ export interface PackageOptions extends Pick<
    * `true` to use the defaults, or an object to customize.
    *
    * By default (`inject: {nodeCompat: true}`) the plugin also injects the self-referential
-   * `import "<pkg>/bundle.css"`, emits a `bundle.css.js` shim, and writes the conditional
+   * `import "<pkg>/bundle.css"`, emits a `bundle-css.js` shim, and writes the conditional
    * `"./bundle.css"` export to `package.json` - see {@link PackageVanillaExtractOptions}.
    * This is the same feature as `rollup.vanillaExtract` in `@sanity/pkg-utils`.
    * @alpha

--- a/packages/@sanity/tsdown-config/test/fixtures/vanilla-extract-cjs-library/package.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/vanilla-extract-cjs-library/package.json
@@ -14,8 +14,8 @@
     "./bundle.css": {
       "browser": "./dist/bundle.css",
       "style": "./dist/bundle.css",
-      "node": "./dist/bundle.css.js",
-      "default": "./dist/bundle.css.js"
+      "node": "./dist/bundle-css.js",
+      "default": "./dist/bundle-css.js"
     },
     "./package.json": "./package.json"
   },
@@ -40,8 +40,8 @@
       "./bundle.css": {
         "browser": "./dist/bundle.css",
         "style": "./dist/bundle.css",
-        "node": "./dist/bundle.css.js",
-        "default": "./dist/bundle.css.js"
+        "node": "./dist/bundle-css.js",
+        "default": "./dist/bundle-css.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/@sanity/tsdown-config/test/fixtures/vanilla-extract-cjs-library/package.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/vanilla-extract-cjs-library/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./bundle.css": {
+      "types": "./dist/bundle-css.d.ts",
       "browser": "./dist/bundle.css",
       "style": "./dist/bundle.css",
       "node": "./dist/bundle-css.js",
@@ -38,6 +39,7 @@
         "require": "./dist/index.js"
       },
       "./bundle.css": {
+        "types": "./dist/bundle-css.d.ts",
         "browser": "./dist/bundle.css",
         "style": "./dist/bundle.css",
         "node": "./dist/bundle-css.js",

--- a/packages/@sanity/tsdown-config/test/fixtures/vanilla-extract-library/package.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/vanilla-extract-library/package.json
@@ -14,8 +14,8 @@
     "./bundle.css": {
       "browser": "./dist/bundle.css",
       "style": "./dist/bundle.css",
-      "node": "./dist/bundle.css.js",
-      "default": "./dist/bundle.css.js"
+      "node": "./dist/bundle-css.js",
+      "default": "./dist/bundle-css.js"
     },
     "./package.json": "./package.json"
   },
@@ -40,8 +40,8 @@
       "./bundle.css": {
         "browser": "./dist/bundle.css",
         "style": "./dist/bundle.css",
-        "node": "./dist/bundle.css.js",
-        "default": "./dist/bundle.css.js"
+        "node": "./dist/bundle-css.js",
+        "default": "./dist/bundle-css.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/@sanity/tsdown-config/test/fixtures/vanilla-extract-library/package.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/vanilla-extract-library/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./bundle.css": {
+      "types": "./dist/bundle-css.d.ts",
       "browser": "./dist/bundle.css",
       "style": "./dist/bundle.css",
       "node": "./dist/bundle-css.js",
@@ -38,6 +39,7 @@
         "require": "./dist/index.cjs"
       },
       "./bundle.css": {
+        "types": "./dist/bundle-css.d.ts",
         "browser": "./dist/bundle.css",
         "style": "./dist/bundle.css",
         "node": "./dist/bundle-css.js",

--- a/packages/@sanity/tsdown-config/test/fixtures/vanilla-extract-node-target-library/package.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/vanilla-extract-node-target-library/package.json
@@ -13,8 +13,8 @@
     "./bundle.css": {
       "browser": "./dist/bundle.css",
       "style": "./dist/bundle.css",
-      "node": "./dist/bundle.css.js",
-      "default": "./dist/bundle.css.js"
+      "node": "./dist/bundle-css.js",
+      "default": "./dist/bundle-css.js"
     },
     "./package.json": "./package.json"
   },
@@ -34,8 +34,8 @@
       "./bundle.css": {
         "browser": "./dist/bundle.css",
         "style": "./dist/bundle.css",
-        "node": "./dist/bundle.css.js",
-        "default": "./dist/bundle.css.js"
+        "node": "./dist/bundle-css.js",
+        "default": "./dist/bundle-css.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/@sanity/tsdown-config/test/fixtures/vanilla-extract-node-target-library/package.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/vanilla-extract-node-target-library/package.json
@@ -11,6 +11,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./bundle.css": {
+      "types": "./dist/bundle-css.d.ts",
       "browser": "./dist/bundle.css",
       "style": "./dist/bundle.css",
       "node": "./dist/bundle-css.js",
@@ -32,6 +33,7 @@
     "exports": {
       ".": "./dist/index.js",
       "./bundle.css": {
+        "types": "./dist/bundle-css.d.ts",
         "browser": "./dist/bundle.css",
         "style": "./dist/bundle.css",
         "node": "./dist/bundle-css.js",

--- a/packages/@sanity/tsdown-config/test/vanilla-extract.test.ts
+++ b/packages/@sanity/tsdown-config/test/vanilla-extract.test.ts
@@ -26,6 +26,7 @@ function fileUrl(...segments: string[]): string {
 }
 
 const conditionalCssExport = {
+  types: './dist/bundle-css.d.ts',
   browser: './dist/bundle.css',
   style: './dist/bundle.css',
   node: './dist/bundle-css.js',
@@ -394,6 +395,7 @@ describe('vanillaExtract option', () => {
     )
 
     expect(result['./styles.css']).toEqual({
+      types: './dist/styles-css.d.ts',
       browser: './dist/styles.css',
       style: './dist/styles.css',
       node: './dist/styles-css.js',

--- a/packages/@sanity/tsdown-config/test/vanilla-extract.test.ts
+++ b/packages/@sanity/tsdown-config/test/vanilla-extract.test.ts
@@ -28,8 +28,8 @@ function fileUrl(...segments: string[]): string {
 const conditionalCssExport = {
   browser: './dist/bundle.css',
   style: './dist/bundle.css',
-  node: './dist/bundle.css.js',
-  default: './dist/bundle.css.js',
+  node: './dist/bundle-css.js',
+  default: './dist/bundle-css.js',
 }
 
 describe('vanilla-extract-library', () => {
@@ -63,15 +63,17 @@ describe('vanilla-extract-library', () => {
   })
 
   test('emits the no-op JS shim and its type declarations', async () => {
-    const [shim, shimDts] = await Promise.all([
-      readFile(path.join(fixtureDir, 'dist/bundle.css.js'), 'utf-8'),
+    const [shim, cssDts, shimDts] = await Promise.all([
+      readFile(path.join(fixtureDir, 'dist/bundle-css.js'), 'utf-8'),
       readFile(path.join(fixtureDir, 'dist/bundle.css.d.ts'), 'utf-8'),
+      readFile(path.join(fixtureDir, 'dist/bundle-css.d.ts'), 'utf-8'),
     ])
 
     // The shim must be free of JS syntax so it parses as both CommonJS and an ES module,
     // regardless of the package `type` (the cjs-library fixture covers this at runtime)
     expect(shim).toContain('No-op shim')
     expect(shim.replaceAll(/^\/\/[^\n]*$/gm, '').trim()).toBe('')
+    expect(cssDts).toContain('export {}')
     expect(shimDts).toContain('export {}')
   })
 
@@ -394,8 +396,8 @@ describe('vanillaExtract option', () => {
     expect(result['./styles.css']).toEqual({
       browser: './dist/styles.css',
       style: './dist/styles.css',
-      node: './dist/styles.css.js',
-      default: './dist/styles.css.js',
+      node: './dist/styles-css.js',
+      default: './dist/styles-css.js',
     })
   })
 

--- a/packages/@sanity/vanilla-extract-rolldown-plugin/README.md
+++ b/packages/@sanity/vanilla-extract-rolldown-plugin/README.md
@@ -18,10 +18,12 @@ Like `css.inject` in `@tsdown/css`, the `inject` option is disabled by default; 
 injects a relative `import "./bundle.css"` into the entry chunks that use vanilla-extract styles —
 through rolldown's native magic-string, so sourcemaps stay intact. `inject: {nodeCompat: true}`
 instead injects the self-referential `import "<pkg>/bundle.css"` of the conditional CSS export
-pattern and emits a no-op `bundle.css.js` shim (plus `bundle.css.d.ts`) for the `node`/`default`
-conditions of that export to point at, so the import is harmless in runtimes that cannot import
-`.css` files. Writing the conditional `"./bundle.css"` export to `package.json` is the host
-tool's job — with tsdown, [`@sanity/vanilla-extract-tsdown-plugin`](https://github.com/sanity-io/pkg-utils/tree/main/packages/@sanity/vanilla-extract-tsdown-plugin#readme)
+pattern and emits a no-op `bundle-css.js` shim (plus `bundle.css.d.ts` / `bundle-css.d.ts`) for
+the `node`/`default` conditions of that export to point at, so the import is harmless in runtimes
+that cannot import `.css` files. The shim is named with a hyphen (`bundle-css.js`) rather than a
+`.css.js` suffix so it does not match vanilla-extract's `cssFileFilter`. Writing the conditional
+`"./bundle.css"` export to `package.json` is the host tool's job — with tsdown,
+[`@sanity/vanilla-extract-tsdown-plugin`](https://github.com/sanity-io/pkg-utils/tree/main/packages/@sanity/vanilla-extract-tsdown-plugin#readme)
 maintains it automatically.
 
 ## Usage

--- a/packages/@sanity/vanilla-extract-rolldown-plugin/src/cssShimFileName.ts
+++ b/packages/@sanity/vanilla-extract-rolldown-plugin/src/cssShimFileName.ts
@@ -1,0 +1,34 @@
+/**
+ * The no-op JS shim file name for a CSS file under `inject.nodeCompat`.
+ *
+ * `bundle.css` → `bundle-css.js` — deliberately not `${cssFileName}.js` (`bundle.css.js`),
+ * which vanilla-extract's `cssFileFilter` (`/\.css\.(js|cjs|mjs|jsx|ts|tsx)$/`) would treat as
+ * a stylesheet module. When a consumer later resolves `./bundle.css` to the shim (e.g. via
+ * Vitest/Vite's `ModuleRunner` under the `node`/`default` export conditions), a `.css.js`
+ * filename would be compiled as if it were `.css.ts` output and throw.
+ *
+ * @public
+ */
+export function cssShimFileName(cssFileName: string): string {
+  return `${cssFileName.replace(/\.css$/, '-css')}.js`
+}
+
+/**
+ * The `.d.ts` companion for {@link cssShimFileName}. `bundle.css` → `bundle-css.d.ts`.
+ * Emitted alongside {@link cssFileDtsFileName} so both the `browser`/`style` (`bundle.css`)
+ * and `node`/`default` (`bundle-css.js`) export targets resolve a declaration file.
+ *
+ * @public
+ */
+export function cssShimDtsFileName(cssFileName: string): string {
+  return `${cssFileName.replace(/\.css$/, '-css')}.d.ts`
+}
+
+/**
+ * The `.d.ts` companion for the extracted CSS file itself. `bundle.css` → `bundle.css.d.ts`.
+ *
+ * @public
+ */
+export function cssFileDtsFileName(cssFileName: string): string {
+  return `${cssFileName}.d.ts`
+}

--- a/packages/@sanity/vanilla-extract-rolldown-plugin/src/index.ts
+++ b/packages/@sanity/vanilla-extract-rolldown-plugin/src/index.ts
@@ -10,18 +10,10 @@ import {
 } from '@vanilla-extract/integration'
 import {transform, type CustomAtRules, type Targets, type TransformOptions} from 'lightningcss'
 import type {OutputChunk, Plugin, RenderedChunk} from 'rolldown'
-import {
-  cssFileDtsFileName,
-  cssShimDtsFileName,
-  cssShimFileName,
-} from './cssShimFileName.ts'
+import {cssFileDtsFileName, cssShimDtsFileName, cssShimFileName} from './cssShimFileName.ts'
 import {esbuildTargetToLightningCSS} from './targets.ts'
 
-export {
-  cssFileDtsFileName,
-  cssShimDtsFileName,
-  cssShimFileName,
-} from './cssShimFileName.ts'
+export {cssFileDtsFileName, cssShimDtsFileName, cssShimFileName} from './cssShimFileName.ts'
 export {esbuildTargetToLightningCSS} from './targets.ts'
 
 /**

--- a/packages/@sanity/vanilla-extract-rolldown-plugin/src/index.ts
+++ b/packages/@sanity/vanilla-extract-rolldown-plugin/src/index.ts
@@ -10,8 +10,18 @@ import {
 } from '@vanilla-extract/integration'
 import {transform, type CustomAtRules, type Targets, type TransformOptions} from 'lightningcss'
 import type {OutputChunk, Plugin, RenderedChunk} from 'rolldown'
+import {
+  cssFileDtsFileName,
+  cssShimDtsFileName,
+  cssShimFileName,
+} from './cssShimFileName.ts'
 import {esbuildTargetToLightningCSS} from './targets.ts'
 
+export {
+  cssFileDtsFileName,
+  cssShimDtsFileName,
+  cssShimFileName,
+} from './cssShimFileName.ts'
 export {esbuildTargetToLightningCSS} from './targets.ts'
 
 /**
@@ -90,11 +100,13 @@ export interface Options {
    *   libraries load their CSS automatically.
    * - `{nodeCompat: true}` additionally makes the import safe for runtimes that cannot import
    *   `.css` files: the injected import becomes the self-referential `"<pkg-name>/<fileName>"`
-   *   bare specifier, and a no-op `<fileName>.js` shim (plus a `<fileName>.d.ts` declaration)
-   *   is emitted for the `node`/`default` conditions of the conditional `"./<fileName>"`
-   *   export to point at. Writing that conditional export to `package.json` is the host's
-   *   job — `@sanity/vanilla-extract-tsdown-plugin` maintains it automatically through
-   *   tsdown's [`exports` feature](https://tsdown.dev/options/package-exports).
+   *   bare specifier, and a no-op shim (e.g. `bundle-css.js`, plus `bundle.css.d.ts` /
+   *   `bundle-css.d.ts` declarations) is emitted for the `node`/`default` conditions of the
+   *   conditional `"./<fileName>"` export to point at. The shim is named with a hyphen
+   *   (`bundle-css.js`) rather than a `.css.js` suffix so it does not match vanilla-extract's
+   *   `cssFileFilter`. Writing that conditional export to `package.json` is the host's job —
+   *   `@sanity/vanilla-extract-tsdown-plugin` maintains it automatically through tsdown's
+   *   [`exports` feature](https://tsdown.dev/options/package-exports).
    *
    * `@sanity/tsdown-config` defaults this to `{nodeCompat: true}`.
    * @defaultValue false
@@ -374,18 +386,30 @@ export function vanillaExtractPlugin(options: Options = {}): VanillaExtractPlugi
       this.emitFile({type: 'asset', fileName, source: css})
 
       if (nodeCompat) {
+        const shimFileName = cssShimFileName(fileName)
         this.emitFile({
           type: 'asset',
-          fileName: `${fileName}.js`,
+          fileName: shimFileName,
           // The shim is intentionally free of syntax so it parses as both CommonJS and an ES
           // module: the package `type` decides how Node interprets a `.js` file, and the same
           // shim backs the `node`/`default` conditions for `require()` and `import` alike.
+          // Named `bundle-css.js` (not `bundle.css.js`) so vanilla-extract's `cssFileFilter`
+          // does not treat it as a stylesheet module when a consumer resolves `./bundle.css`.
           source: `// No-op shim for \`${fileName}\`, resolved by the \`node\`/\`default\` conditions of the\n// conditional CSS export so the self-referential import is harmless in runtimes that cannot\n// load \`.css\` files. Intentionally has no JS syntax: it parses as both CommonJS and an ES\n// module, regardless of the package \`type\`.\n`,
+        })
+        // Emit declaration companions for both export targets: `browser`/`style` resolve the
+        // CSS file (`bundle.css` → `bundle.css.d.ts`), while `node`/`default` resolve the shim
+        // (`bundle-css.js` → `bundle-css.d.ts`).
+        const dtsSource = `// Type declarations for \`${fileName}\` and its no-op JS shim.\nexport {}\n`
+        this.emitFile({
+          type: 'asset',
+          fileName: cssFileDtsFileName(fileName),
+          source: dtsSource,
         })
         this.emitFile({
           type: 'asset',
-          fileName: `${fileName}.d.ts`,
-          source: `// Type declarations for \`${fileName}\` and its no-op JS shim.\nexport {}\n`,
+          fileName: cssShimDtsFileName(fileName),
+          source: dtsSource,
         })
       }
     },

--- a/packages/@sanity/vanilla-extract-rolldown-plugin/test/cssShimFileName.test.ts
+++ b/packages/@sanity/vanilla-extract-rolldown-plugin/test/cssShimFileName.test.ts
@@ -1,9 +1,5 @@
 import {describe, expect, test} from 'vitest'
-import {
-  cssFileDtsFileName,
-  cssShimDtsFileName,
-  cssShimFileName,
-} from '../src/cssShimFileName.ts'
+import {cssFileDtsFileName, cssShimDtsFileName, cssShimFileName} from '../src/cssShimFileName.ts'
 
 describe('cssShimFileName', () => {
   test('turns `bundle.css` into `bundle-css.js` (not `bundle.css.js`)', () => {

--- a/packages/@sanity/vanilla-extract-rolldown-plugin/test/cssShimFileName.test.ts
+++ b/packages/@sanity/vanilla-extract-rolldown-plugin/test/cssShimFileName.test.ts
@@ -1,0 +1,19 @@
+import {describe, expect, test} from 'vitest'
+import {
+  cssFileDtsFileName,
+  cssShimDtsFileName,
+  cssShimFileName,
+} from '../src/cssShimFileName.ts'
+
+describe('cssShimFileName', () => {
+  test('turns `bundle.css` into `bundle-css.js` (not `bundle.css.js`)', () => {
+    // So vanilla-extract's `cssFileFilter` (`/\.css\.(js|…)$/`) does not match the shim.
+    expect(cssShimFileName('bundle.css')).toBe('bundle-css.js')
+    expect(cssShimFileName('styles.css')).toBe('styles-css.js')
+  })
+
+  test('derives matching declaration file names for both export targets', () => {
+    expect(cssFileDtsFileName('bundle.css')).toBe('bundle.css.d.ts')
+    expect(cssShimDtsFileName('bundle.css')).toBe('bundle-css.d.ts')
+  })
+})

--- a/packages/@sanity/vanilla-extract-rolldown-plugin/test/plugin.test.ts
+++ b/packages/@sanity/vanilla-extract-rolldown-plugin/test/plugin.test.ts
@@ -95,7 +95,7 @@ describe('vanillaExtractPlugin', () => {
     // The CSS is extracted, but nothing is injected and no shims are emitted
     expect(findAsset(output, 'bundle.css')).toContain('rgb(1, 2, 3)')
     expect(code).not.toContain('bundle.css')
-    expect(output.some((assetOrChunk) => assetOrChunk.fileName === 'bundle.css.js')).toBe(false)
+    expect(output.some((assetOrChunk) => assetOrChunk.fileName === 'bundle-css.js')).toBe(false)
     expect(output.some((assetOrChunk) => assetOrChunk.fileName === 'bundle.css.d.ts')).toBe(false)
 
     // The styles must not be inlined or imported in the JS output either
@@ -116,7 +116,7 @@ describe('vanillaExtractPlugin', () => {
         format === 'cjs' ? `require("./bundle.css");` : `import "./bundle.css";`,
       )
       expect(code).not.toContain(selfReferentialSpecifier)
-      expect(output.some((assetOrChunk) => assetOrChunk.fileName === 'bundle.css.js')).toBe(false)
+      expect(output.some((assetOrChunk) => assetOrChunk.fileName === 'bundle-css.js')).toBe(false)
     },
   )
 
@@ -156,19 +156,23 @@ describe('vanillaExtractPlugin', () => {
 
     // The shim must be free of JS syntax so it parses as both CommonJS and an ES module: the
     // package `type` decides how Node interprets a `.js` file, and the same shim backs the
-    // `node`/`default` conditions for `require()` and `import` alike
-    const shim = findAsset(output, 'bundle.css.js')
+    // `node`/`default` conditions for `require()` and `import` alike. Named `bundle-css.js`
+    // (not `bundle.css.js`) so vanilla-extract's `cssFileFilter` does not match it.
+    const shim = findAsset(output, 'bundle-css.js')
     expect(shim).toContain('No-op shim')
     expect(shim.replaceAll(/^\/\/[^\n]*$/gm, '').trim()).toBe('')
+    // Declarations for both export targets: CSS file + shim
     expect(findAsset(output, 'bundle.css.d.ts')).toContain('export {}')
+    expect(findAsset(output, 'bundle-css.d.ts')).toContain('export {}')
   })
 
   test('respects a custom `fileName`', async () => {
     const output = await buildFixture({fileName: 'styles.css', inject: {nodeCompat: true}})
 
     expect(findAsset(output, 'styles.css')).toContain('rgb(1, 2, 3)')
-    expect(findAsset(output, 'styles.css.js')).toContain('No-op shim')
+    expect(findAsset(output, 'styles-css.js')).toContain('No-op shim')
     expect(findAsset(output, 'styles.css.d.ts')).toContain('export {}')
+    expect(findAsset(output, 'styles-css.d.ts')).toContain('export {}')
     expect(findEntryChunk(output).code).toContain(
       'import "@sanity/vanilla-extract-rolldown-plugin/styles.css";',
     )
@@ -269,9 +273,10 @@ describe('vanillaExtractPlugin', () => {
     // CSS file and its shims are emitted even when empty to keep it resolving
     const withNodeCompat = await buildFixture({inject: {nodeCompat: true}}, 'esm', false, 'no-css')
     expect(withNodeCompat.map((assetOrChunk) => assetOrChunk.fileName).toSorted()).toEqual([
+      'bundle-css.d.ts',
+      'bundle-css.js',
       'bundle.css',
       'bundle.css.d.ts',
-      'bundle.css.js',
       'index.js',
     ])
     expect(findAsset(withNodeCompat, 'bundle.css')).toBe('')

--- a/packages/@sanity/vanilla-extract-tsdown-plugin/README.md
+++ b/packages/@sanity/vanilla-extract-tsdown-plugin/README.md
@@ -28,9 +28,10 @@ Like `css.inject` in `@tsdown/css`, the `inject` option is disabled by default; 
 injects a relative `import "./bundle.css"` into the entry chunks that use vanilla-extract styles —
 through rolldown's native magic-string, so sourcemaps stay intact. `inject: {nodeCompat: true}`
 additionally wires up the whole conditional CSS export pattern: the injected import becomes the
-self-referential `import "<pkg>/bundle.css"`, a no-op `bundle.css.js` shim (plus
-`bundle.css.d.ts`) is emitted for the `node`/`default` conditions of the export to point at, so
-the import is harmless in runtimes that cannot import `.css` files, and when tsdown's
+self-referential `import "<pkg>/bundle.css"`, a no-op `bundle-css.js` shim (plus
+`bundle.css.d.ts` / `bundle-css.d.ts`) is emitted for the `node`/`default` conditions of the
+export to point at, so the import is harmless in runtimes that cannot import `.css` files, and
+when tsdown's
 [`exports` feature](https://tsdown.dev/options/package-exports) is enabled, the conditional
 `"./bundle.css"` export is written to `package.json` (`browser`/`style` → the real CSS,
 `node`/`default` → the shim) through the plugin's `tsdownConfig` hook.

--- a/packages/@sanity/vanilla-extract-tsdown-plugin/README.md
+++ b/packages/@sanity/vanilla-extract-tsdown-plugin/README.md
@@ -14,9 +14,10 @@ following the same architecture (and option vocabulary and defaults) as
   `engines.node`),
 - the self-referential import injected by `inject: {nodeCompat: true}` uses the package name
   tsdown resolved, and
-- the conditional `"./bundle.css"` export (`browser`/`style` → the real CSS, `node`/`default` →
-  the no-op shim) is written to `package.json` through the plugin's `tsdownConfig` hook when
-  tsdown's [`exports` feature](https://tsdown.dev/options/package-exports) is enabled.
+- the conditional `"./bundle.css"` export (`types` → the shim's `.d.ts`, `browser`/`style` → the
+  real CSS, `node`/`default` → the no-op shim) is written to `package.json` through the plugin's
+  `tsdownConfig` hook when tsdown's [`exports` feature](https://tsdown.dev/options/package-exports)
+  is enabled.
 
 Unlike `@vanilla-extract/rollup-plugin` it doesn't declare `rollup` as a peer dependency, so it
 doesn't pull a second bundler into tsdown projects. It also declares
@@ -33,8 +34,9 @@ self-referential `import "<pkg>/bundle.css"`, a no-op `bundle-css.js` shim (plus
 export to point at, so the import is harmless in runtimes that cannot import `.css` files, and
 when tsdown's
 [`exports` feature](https://tsdown.dev/options/package-exports) is enabled, the conditional
-`"./bundle.css"` export is written to `package.json` (`browser`/`style` → the real CSS,
-`node`/`default` → the shim) through the plugin's `tsdownConfig` hook.
+`"./bundle.css"` export is written to `package.json` (`types` → the shim's `.d.ts`,
+`browser`/`style` → the real CSS, `node`/`default` → the shim) through the plugin's
+`tsdownConfig` hook.
 
 ## Usage
 

--- a/packages/@sanity/vanilla-extract-tsdown-plugin/src/exports.ts
+++ b/packages/@sanity/vanilla-extract-tsdown-plugin/src/exports.ts
@@ -1,13 +1,17 @@
+import {cssShimFileName} from '@sanity/vanilla-extract-rolldown-plugin'
+
 /**
  * Build the conditional CSS export object that the `inject` wiring expects, e.g.
  * ```json
  * {
  *   "browser": "./dist/bundle.css",
  *   "style": "./dist/bundle.css",
- *   "node": "./dist/bundle.css.js",
- *   "default": "./dist/bundle.css.js"
+ *   "node": "./dist/bundle-css.js",
+ *   "default": "./dist/bundle-css.js"
  * }
  * ```
+ * The shim is named `bundle-css.js` (not `bundle.css.js`) so it does not match
+ * vanilla-extract's `cssFileFilter`.
  * @internal
  */
 export function createConditionalCssExport(
@@ -15,7 +19,7 @@ export function createConditionalCssExport(
   outDir: string,
 ): Record<string, string> {
   const cssFile = `./${outDir}/${cssFileName}`
-  const shimFile = `./${outDir}/${cssFileName}.js`
+  const shimFile = `./${outDir}/${cssShimFileName(cssFileName)}`
   return {browser: cssFile, style: cssFile, node: shimFile, default: shimFile}
 }
 

--- a/packages/@sanity/vanilla-extract-tsdown-plugin/src/exports.ts
+++ b/packages/@sanity/vanilla-extract-tsdown-plugin/src/exports.ts
@@ -1,9 +1,10 @@
-import {cssShimFileName} from '@sanity/vanilla-extract-rolldown-plugin'
+import {cssShimDtsFileName, cssShimFileName} from '@sanity/vanilla-extract-rolldown-plugin'
 
 /**
  * Build the conditional CSS export object that the `inject` wiring expects, e.g.
  * ```json
  * {
+ *   "types": "./dist/bundle-css.d.ts",
  *   "browser": "./dist/bundle.css",
  *   "style": "./dist/bundle.css",
  *   "node": "./dist/bundle-css.js",
@@ -11,7 +12,10 @@ import {cssShimFileName} from '@sanity/vanilla-extract-rolldown-plugin'
  * }
  * ```
  * The shim is named `bundle-css.js` (not `bundle.css.js`) so it does not match
- * vanilla-extract's `cssFileFilter`.
+ * vanilla-extract's `cssFileFilter`. An explicit `types` condition (rather than relying on
+ * TypeScript's extension-substitution fallback, which only works when the shim shares the CSS
+ * file's basename, and which TypeScript is deprecating anyway - microsoft/TypeScript#50762)
+ * points resolvers straight at the shim's declaration file.
  * @internal
  */
 export function createConditionalCssExport(
@@ -20,7 +24,8 @@ export function createConditionalCssExport(
 ): Record<string, string> {
   const cssFile = `./${outDir}/${cssFileName}`
   const shimFile = `./${outDir}/${cssShimFileName(cssFileName)}`
-  return {browser: cssFile, style: cssFile, node: shimFile, default: shimFile}
+  const shimDtsFile = `./${outDir}/${cssShimDtsFileName(cssFileName)}`
+  return {types: shimDtsFile, browser: cssFile, style: cssFile, node: shimFile, default: shimFile}
 }
 
 /**

--- a/packages/@sanity/vanilla-extract-tsdown-plugin/test/plugin.test.ts
+++ b/packages/@sanity/vanilla-extract-tsdown-plugin/test/plugin.test.ts
@@ -90,8 +90,8 @@ describe('vanillaExtractPlugin', () => {
 const conditionalCssExport = {
   browser: './dist/bundle.css',
   style: './dist/bundle.css',
-  node: './dist/bundle.css.js',
-  default: './dist/bundle.css.js',
+  node: './dist/bundle-css.js',
+  default: './dist/bundle-css.js',
 }
 
 /** Runs the plugin's `tsdownConfig` hook against a tsdown user config, like tsdown does. */
@@ -189,8 +189,8 @@ describe('tsdownConfig hook', () => {
       './styles.css': {
         browser: './lib/styles.css',
         style: './lib/styles.css',
-        node: './lib/styles.css.js',
-        default: './lib/styles.css.js',
+        node: './lib/styles-css.js',
+        default: './lib/styles-css.js',
       },
     })
   })

--- a/packages/@sanity/vanilla-extract-tsdown-plugin/test/plugin.test.ts
+++ b/packages/@sanity/vanilla-extract-tsdown-plugin/test/plugin.test.ts
@@ -88,6 +88,7 @@ describe('vanillaExtractPlugin', () => {
 })
 
 const conditionalCssExport = {
+  types: './dist/bundle-css.d.ts',
   browser: './dist/bundle.css',
   style: './dist/bundle.css',
   node: './dist/bundle-css.js',
@@ -187,6 +188,7 @@ describe('tsdownConfig hook', () => {
 
     expect(await getCustomExports(config)({}, customExportsContext)).toEqual({
       './styles.css': {
+        types: './lib/styles-css.d.ts',
         browser: './lib/styles.css',
         style: './lib/styles.css',
         node: './lib/styles-css.js',

--- a/playground/sanity-plugin-with-vanilla-extract/package.json
+++ b/playground/sanity-plugin-with-vanilla-extract/package.json
@@ -13,8 +13,8 @@
     "./bundle.css": {
       "browser": "./dist/bundle.css",
       "style": "./dist/bundle.css",
-      "node": "./dist/bundle.css.js",
-      "default": "./dist/bundle.css.js"
+      "node": "./dist/bundle-css.js",
+      "default": "./dist/bundle-css.js"
     },
     "./package.json": "./package.json"
   },

--- a/playground/sanity-plugin-with-vanilla-extract/package.json
+++ b/playground/sanity-plugin-with-vanilla-extract/package.json
@@ -11,6 +11,7 @@
       "default": "./dist/index.js"
     },
     "./bundle.css": {
+      "types": "./dist/bundle-css.d.ts",
       "browser": "./dist/bundle.css",
       "style": "./dist/bundle.css",
       "node": "./dist/bundle-css.js",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`dist/bundle.css.js` (the empty Node/SSR shim for the conditional `./bundle.css` export) matches vanilla-extract's `cssFileFilter` (`/\.css\.(js|cjs|mjs|jsx|ts|tsx)$/`) by filename alone. When a consumer resolves that export under Vite's `ModuleRunner` (e.g. Vitest with `@sanity/vanilla-extract-vite-plugin`), the plugin tries to evaluate the shim as `.css.ts` output and throws — the regression that forced a stub workaround in [sanity-io/plugins#1590](https://github.com/sanity-io/plugins/pull/1590).

Rename the on-disk shim to `bundle-css.js` (and emit matching `bundle-css.d.ts` alongside the existing `bundle.css.d.ts`) so it no longer matches `cssFileFilter`. The public `./bundle.css` export subpath is unchanged; only the `node`/`default` targets move.

Since the shim's basename no longer matches the CSS file's basename, TypeScript's extension-substitution fallback (stripping `.js` to find a sibling `.d.ts`) would now resolve a *different* file than before — and that fallback lookup is being deprecated in TypeScript itself ([microsoft/TypeScript#50762](https://github.com/microsoft/TypeScript/issues/50762)). So the conditional export now also gets an explicit `types` condition pointing straight at the shim's declaration file:

```json
"./bundle.css": {
  "types": "./dist/bundle-css.d.ts",
  "browser": "./dist/bundle.css",
  "style": "./dist/bundle.css",
  "node": "./dist/bundle-css.js",
  "default": "./dist/bundle-css.js"
}
```

- Exported `cssShimFileName` / `cssShimDtsFileName` / `cssFileDtsFileName` helpers from `@sanity/vanilla-extract-rolldown-plugin`
- Updated `@sanity/vanilla-extract-tsdown-plugin`, `@sanity/pkg-utils`, and `@sanity/tsdown-config` (fixtures, docs, package.json exports) accordingly
- Rebuilding a package with compat mode on rewrites `package.json` automatically when the old shim path/shape is still present

## Test plan

- [x] `@sanity/vanilla-extract-rolldown-plugin` tests (23 passed, incl. new `cssShimFileName` unit tests)
- [x] `@sanity/vanilla-extract-tsdown-plugin` tests (7 passed)
- [x] `@sanity/vanilla-extract-vite-plugin` tests (15 passed)
- [x] `@sanity/parse-package-json` tests (28 passed)
- [x] `@sanity/tsdown-config` tests, incl. fixture builds + runtime `require()`/`import()` checks (65 passed)
- [x] `@sanity/pkg-utils` tests, incl. the `sanity-plugin-with-vanilla-extract` playground CLI build (152 passed)
- [x] `pnpm lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5566c419-7ace-419f-8886-a4ab647f0e5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5566c419-7ace-419f-8886-a4ab647f0e5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

