### PR TITLE
feat(tsdown-config): expose `clean` option for pre-build folder cleanup

### DIFF
--- a/.changeset/expose-clean-tsdown-config.md
+++ b/.changeset/expose-clean-tsdown-config.md
@@ -1,0 +1,5 @@
+---
+'@sanity/tsdown-config': minor
+---
+
+Expose tsdown's `clean` option on `PackageOptions` so packages can clean folders before build (prefer `clean: ['dist', …]` over a separate `package.json` `"clean"` script) without `mergeConfig`

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -162,6 +162,29 @@ export default defineConfig({
 })
 ```
 
+## clean
+
+tsdown's [`clean` option](https://tsdown.dev/options/cleaning) is passed through as-is. When left
+undefined, tsdown defaults to `true` and removes `outDir` (`dist` by default) before each build.
+
+Prefer an **array of folders** over a separate `"clean"` script in `package.json`. That way
+`tsdown` / `pnpm build` clears the directories itself — packages don't need `rimraf`, a `clean`
+script, or `prebuild` / `run-s clean build` wiring:
+
+```ts
+import {defineConfig} from '@sanity/tsdown-config'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  // Instead of `"clean": "rimraf dist coverage"` (and running it before build):
+  clean: ['dist', 'coverage'],
+})
+```
+
+A `string[]` replaces tsdown's default (`true` → clean `outDir`), so include `outDir` (usually
+`'dist'`) in the array when you still want it cleaned alongside other folders. Pass `false` to
+skip cleaning entirely.
+
 ## Isolated declarations
 
 If you're using the [`@sanity/tsconfig/isolated-declarations`](https://github.com/sanity-io/pkg-utils/tree/main/packages/@sanity/tsconfig#isolated-declarations-tsconfigjson)

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -87,6 +87,25 @@ export interface PackageOptions extends Pick<
    */
   platform?: UserConfig['platform']
   /**
+   * Clean directories before each build. Prefer an array of folders over a separate `"clean"`
+   * script in `package.json` (e.g. `rimraf dist coverage`) — tsdown removes them as part of
+   * `tsdown` / `pnpm build`, so packages don't need `rimraf`, a `clean` script, or
+   * `prebuild`/`run-s clean build` wiring.
+   *
+   * - `true` (tsdown's default when left undefined) cleans `outDir` (`'dist'` by default)
+   * - `false` skips cleaning
+   * - a `string[]` replaces that default with the listed paths/globs — include `outDir` (e.g.
+   *   `'dist'`) when you still want it cleaned alongside other folders
+   *
+   * @defaultValue true
+   * @example
+   * ```ts
+   * // Instead of `"clean": "rimraf dist coverage"` in package.json:
+   * clean: ['dist', 'coverage']
+   * ```
+   */
+  clean?: UserConfig['clean']
+  /**
    * tsdown's `exports` option, with defaults suited for publishing Sanity libraries:
    * `enabled: 'local-only'` generates the `exports` map during local builds and skips it in CI
    * (where the committed `package.json` is already up to date). When pnpm is detected,
@@ -153,11 +172,12 @@ export interface PackageOptions extends Pick<
  * @public
  */
 export async function defineConfig(options: PackageOptions = {}): Promise<UserConfig> {
-  // `tsconfig`, `entry`, `dts`, `define`, `target` and `outDir` are passed through to tsdown
-  // as-is. When left undefined, tsdown keeps its default behavior (`tsconfig` is auto-detected
-  // from the project, `dts` from `package.json`, `define` replaces nothing, `target` applies no
-  // syntax downleveling, and `outDir` defaults to `'dist'`).
-  const {entry, tsconfig, dts, define, target, outDir} = options
+  // `tsconfig`, `entry`, `dts`, `define`, `target`, `outDir` and `clean` are passed through to
+  // tsdown as-is. When left undefined, tsdown keeps its default behavior (`tsconfig` is
+  // auto-detected from the project, `dts` from `package.json`, `define` replaces nothing,
+  // `target` applies no syntax downleveling, `outDir` defaults to `'dist'`, and `clean`
+  // defaults to `true` — cleaning `outDir` before each build).
+  const {entry, tsconfig, dts, define, target, outDir, clean} = options
   const platform = options.platform ?? 'neutral'
   const sourcemap = options.sourcemap ?? true
   const reactCompiler = options.reactCompiler ?? false
@@ -314,6 +334,7 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
   )
 
   return defineTsdownConfig({
+    clean,
     define,
     deps,
     dts,

--- a/packages/@sanity/tsdown-config/test/options.test.ts
+++ b/packages/@sanity/tsdown-config/test/options.test.ts
@@ -66,6 +66,20 @@ describe('outDir option', () => {
   })
 })
 
+describe('clean option', () => {
+  test('is undefined by default, so tsdown cleans outDir before each build', async () => {
+    expect((await defineConfig()).clean).toBeUndefined()
+  })
+
+  test('is passed through to tsdown as-is', async () => {
+    expect((await defineConfig({clean: false})).clean).toBe(false)
+    expect((await defineConfig({clean: true})).clean).toBe(true)
+    // Prefer an array of folders over a package.json `"clean": "rimraf …"` script — include
+    // outDir (`dist`) when you still want it cleaned alongside other directories
+    expect((await defineConfig({clean: ['dist', 'coverage']})).clean).toEqual(['dist', 'coverage'])
+  })
+})
+
 describe('sourcemap option', () => {
   test('defaults to true, matching @sanity/pkg-utils', async () => {
     // tsdown itself defaults to false and does not read `sourceMap` from the tsconfig


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Exposes tsdown's [`clean`](https://tsdown.dev/reference/api/Interface.InlineConfig#clean) option on `@sanity/tsdown-config`'s `PackageOptions` / `defineConfig`, so packages can clear build output (and related folders) without `mergeConfig`.

### Why

tsdown already cleans `outDir` by default (`clean: true`). Packages that also wipe other folders today often do that with a separate `package.json` script (`"clean": "rimraf dist coverage"` + `prebuild` / `run-s clean build`). Prefer configuring those paths on `clean` instead:

```ts
import {defineConfig} from '@sanity/tsdown-config'

export default defineConfig({
  tsconfig: 'tsconfig.dist.json',
  // Instead of `"clean": "rimraf dist coverage"`:
  clean: ['dist', 'coverage'],
})
```

A `string[]` replaces tsdown's default (`true` → clean `outDir`), so include `outDir` (usually `'dist'`) when you still want it cleaned alongside other folders. Pass `false` to skip cleaning.

### Changes

- Pass `clean` through `PackageOptions` / `defineConfig` (left undefined → tsdown's `true` default)
- Document the option and the array-over-`package.json`-script preference in the README + JSDoc
- Add unit coverage in `options.test.ts`
- Changeset: minor for `@sanity/tsdown-config`

### Verification

- `pnpm --filter @sanity/tsdown-config test` — 67 passed
- `pnpm --filter @sanity/tsdown-config typecheck` — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d35779e-95ac-4312-9eb1-270e39e051bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d35779e-95ac-4312-9eb1-270e39e051bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

