### PR TITLE
feat(tsdown-config): expose clean so packages can drop mergeConfig

### DIFF
--- a/.changeset/expose-clean-tsdown-config.md
+++ b/.changeset/expose-clean-tsdown-config.md
@@ -1,0 +1,5 @@
+---
+"@sanity/tsdown-config": minor
+---
+
+Expose tsdown's `clean` option on `PackageOptions` so packages can disable output cleaning or target specific directories without `mergeConfig`

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -162,6 +162,21 @@ export default defineConfig({
 })
 ```
 
+## clean
+
+tsdown's [`clean` option](https://tsdown.dev/options/cleaning) is passed through as-is.
+When left undefined, tsdown cleans the output directory before each build (`true`). Pass
+`false` to keep existing files, or a string array of directories to clean instead of `outDir`:
+
+```ts
+import {defineConfig} from '@sanity/tsdown-config'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  clean: false,
+})
+```
+
 ## Isolated declarations
 
 If you're using the [`@sanity/tsconfig/isolated-declarations`](https://github.com/sanity-io/pkg-utils/tree/main/packages/@sanity/tsconfig#isolated-declarations-tsconfigjson)

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -71,7 +71,7 @@ export type ReactCompilerOptions = Partial<ReactCompilerPluginOptions>
  */
 export interface PackageOptions extends Pick<
   UserConfig,
-  'tsconfig' | 'entry' | 'format' | 'dts' | 'define' | 'target' | 'outDir'
+  'tsconfig' | 'entry' | 'format' | 'dts' | 'define' | 'target' | 'outDir' | 'clean'
 > {
   /**
    * @defaultValue 'neutral'
@@ -153,11 +153,12 @@ export interface PackageOptions extends Pick<
  * @public
  */
 export async function defineConfig(options: PackageOptions = {}): Promise<UserConfig> {
-  // `tsconfig`, `entry`, `dts`, `define`, `target` and `outDir` are passed through to tsdown
-  // as-is. When left undefined, tsdown keeps its default behavior (`tsconfig` is auto-detected
-  // from the project, `dts` from `package.json`, `define` replaces nothing, `target` applies no
-  // syntax downleveling, and `outDir` defaults to `'dist'`).
-  const {entry, tsconfig, dts, define, target, outDir} = options
+  // `tsconfig`, `entry`, `dts`, `define`, `target`, `outDir` and `clean` are passed through to
+  // tsdown as-is. When left undefined, tsdown keeps its default behavior (`tsconfig` is
+  // auto-detected from the project, `dts` from `package.json`, `define` replaces nothing,
+  // `target` applies no syntax downleveling, `outDir` defaults to `'dist'`, and `clean`
+  // defaults to `true`).
+  const {entry, tsconfig, dts, define, target, outDir, clean} = options
   const platform = options.platform ?? 'neutral'
   const sourcemap = options.sourcemap ?? true
   const reactCompiler = options.reactCompiler ?? false
@@ -314,6 +315,7 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
   )
 
   return defineTsdownConfig({
+    clean,
     define,
     deps,
     dts,

--- a/packages/@sanity/tsdown-config/test/options.test.ts
+++ b/packages/@sanity/tsdown-config/test/options.test.ts
@@ -66,6 +66,18 @@ describe('outDir option', () => {
   })
 })
 
+describe('clean option', () => {
+  test('is undefined by default, so tsdown cleans the output directory', async () => {
+    expect((await defineConfig()).clean).toBeUndefined()
+  })
+
+  test('is passed through to tsdown as-is', async () => {
+    expect((await defineConfig({clean: false})).clean).toBe(false)
+    expect((await defineConfig({clean: true})).clean).toBe(true)
+    expect((await defineConfig({clean: ['dist', 'lib']})).clean).toEqual(['dist', 'lib'])
+  })
+})
+
 describe('sourcemap option', () => {
   test('defaults to true, matching @sanity/pkg-utils', async () => {
     // tsdown itself defaults to false and does not read `sourceMap` from the tsconfig


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Exposes [tsdown's `clean` option](https://tsdown.dev/reference/api/Interface.InlineConfig#clean) on `PackageOptions`, matching the recent `outDir` / `sourcemap` / `deps` pass-throughs.

### Changes
- Forward `clean` (`boolean | string[]`) through `defineConfig` as-is
- When left undefined, tsdown keeps its default (`true` — clean `outDir` before build)
- README docs + options tests + changeset

```ts
import {defineConfig} from '@sanity/tsdown-config'

export default defineConfig({
  clean: false, // or clean: ['dist', 'lib']
})
```

Packages that previously reached for `mergeConfig` just to disable cleaning or clean extra directories can set `clean` directly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86853e24-d8b2-41bf-b848-b143f32e3211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86853e24-d8b2-41bf-b848-b143f32e3211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

