### PR TITLE
fix(deps): update @sanity/icons to v5

### DIFF
--- a/packages/@sanity/pkg-utils/test/__snapshots__/cli.test.ts.snap
+++ b/packages/@sanity/pkg-utils/test/__snapshots__/cli.test.ts.snap
@@ -1126,23 +1126,24 @@ export {
 exports[`cli > should build \`ts-rolldown-bundle-dev-dependency\` package > ./dist/index.cjs 1`] = `
 ""use strict";
 Object.defineProperty(exports, "__esModule", { value: !0 });
-var jsxRuntime = require("react/jsx-runtime"), react = require("react"), logos = require("@sanity/logos");
-const RemoveIcon = /* @__PURE__ */ react.forwardRef(function(props, ref) {
-  return /* @__PURE__ */ jsxRuntime.jsx(
-    "svg",
-    {
-      "data-sanity-icon": "remove",
-      width: "1em",
-      height: "1em",
-      viewBox: "0 0 25 25",
-      fill: "none",
-      xmlns: "http://www.w3.org/2000/svg",
-      ...props,
-      ref,
-      children: /* @__PURE__ */ jsxRuntime.jsx("path", { d: "M5 12.5H20", stroke: "currentColor", strokeWidth: 1.2, strokeLinejoin: "round" })
-    }
-  );
-});
+var jsxRuntime = require("react/jsx-runtime"), logos = require("@sanity/logos");
+function RemoveIcon(props) {
+  return /* @__PURE__ */ jsxRuntime.jsx("svg", {
+    "data-sanity-icon": "remove",
+    width: "1em",
+    height: "1em",
+    viewBox: "0 0 25 25",
+    fill: "none",
+    xmlns: "http://www.w3.org/2000/svg",
+    ...props,
+    children: /* @__PURE__ */ jsxRuntime.jsx("path", {
+      d: "M5 12.5H20",
+      stroke: "currentColor",
+      strokeWidth: 1.2,
+      strokeLinejoin: "round"
+    })
+  });
+}
 function validateApiPerspective(perspective) {
   if (Array.isArray(perspective) && perspective.length > 1 && perspective.includes("raw"))
     throw new TypeError(
@@ -1162,14 +1163,14 @@ exports.validateApiPerspective = validateApiPerspective;
 `;
 
 exports[`cli > should build \`ts-rolldown-bundle-dev-dependency\` package > ./dist/index.d.cts 1`] = `
-"import { ForwardRefExoticComponent, RefAttributes, SVGProps } from "react";
+"import { ComponentPropsWithRef, ReactElement } from "react";
 import { SanityLogo } from "@sanity/logos";
 import "get-it";
 import "rxjs";
 /**
  * @public
  */
-declare const RemoveIcon: ForwardRefExoticComponent<Omit<SVGProps<SVGSVGElement>, "ref"> & RefAttributes<SVGSVGElement>>;
+declare function RemoveIcon(props: ComponentPropsWithRef<"svg">): ReactElement;
 /** @public */
 declare type ClientPerspective = DeprecatedPreviewDrafts | 'published' | 'drafts' | 'raw' | StackablePerspective[];
 /**
@@ -1187,14 +1188,14 @@ export { RemoveIcon, SanityLogo, validateApiPerspective };
 `;
 
 exports[`cli > should build \`ts-rolldown-bundle-dev-dependency\` package > ./dist/index.d.ts 1`] = `
-"import { ForwardRefExoticComponent, RefAttributes, SVGProps } from "react";
+"import { ComponentPropsWithRef, ReactElement } from "react";
 import { SanityLogo } from "@sanity/logos";
 import "get-it";
 import "rxjs";
 /**
  * @public
  */
-declare const RemoveIcon: ForwardRefExoticComponent<Omit<SVGProps<SVGSVGElement>, "ref"> & RefAttributes<SVGSVGElement>>;
+declare function RemoveIcon(props: ComponentPropsWithRef<"svg">): ReactElement;
 /** @public */
 declare type ClientPerspective = DeprecatedPreviewDrafts | 'published' | 'drafts' | 'raw' | StackablePerspective[];
 /**
@@ -1213,24 +1214,24 @@ export { RemoveIcon, SanityLogo, validateApiPerspective };
 
 exports[`cli > should build \`ts-rolldown-bundle-dev-dependency\` package > ./dist/index.js 1`] = `
 "import { jsx } from "react/jsx-runtime";
-import { forwardRef } from "react";
 import { SanityLogo } from "@sanity/logos";
-const RemoveIcon = /* @__PURE__ */ forwardRef(function(props, ref) {
-  return /* @__PURE__ */ jsx(
-    "svg",
-    {
-      "data-sanity-icon": "remove",
-      width: "1em",
-      height: "1em",
-      viewBox: "0 0 25 25",
-      fill: "none",
-      xmlns: "http://www.w3.org/2000/svg",
-      ...props,
-      ref,
-      children: /* @__PURE__ */ jsx("path", { d: "M5 12.5H20", stroke: "currentColor", strokeWidth: 1.2, strokeLinejoin: "round" })
-    }
-  );
-});
+function RemoveIcon(props) {
+  return /* @__PURE__ */ jsx("svg", {
+    "data-sanity-icon": "remove",
+    width: "1em",
+    height: "1em",
+    viewBox: "0 0 25 25",
+    fill: "none",
+    xmlns: "http://www.w3.org/2000/svg",
+    ...props,
+    children: /* @__PURE__ */ jsx("path", {
+      d: "M5 12.5H20",
+      stroke: "currentColor",
+      strokeWidth: 1.2,
+      strokeLinejoin: "round"
+    })
+  });
+}
 function validateApiPerspective(perspective) {
   if (Array.isArray(perspective) && perspective.length > 1 && perspective.includes("raw"))
     throw new TypeError(
@@ -1249,23 +1250,24 @@ export {
 exports[`cli > should build \`ts-rolldown-bundle-peer-dependency\` package > ./dist/index.cjs 1`] = `
 ""use strict";
 Object.defineProperty(exports, "__esModule", { value: !0 });
-var jsxRuntime = require("react/jsx-runtime"), react = require("react"), logos = require("@sanity/logos"), client = require("@sanity/client");
-const RemoveIcon = /* @__PURE__ */ react.forwardRef(function(props, ref) {
-  return /* @__PURE__ */ jsxRuntime.jsx(
-    "svg",
-    {
-      "data-sanity-icon": "remove",
-      width: "1em",
-      height: "1em",
-      viewBox: "0 0 25 25",
-      fill: "none",
-      xmlns: "http://www.w3.org/2000/svg",
-      ...props,
-      ref,
-      children: /* @__PURE__ */ jsxRuntime.jsx("path", { d: "M5 12.5H20", stroke: "currentColor", strokeWidth: 1.2, strokeLinejoin: "round" })
-    }
-  );
-});
+var jsxRuntime = require("react/jsx-runtime"), logos = require("@sanity/logos"), client = require("@sanity/client");
+function RemoveIcon(props) {
+  return /* @__PURE__ */ jsxRuntime.jsx("svg", {
+    "data-sanity-icon": "remove",
+    width: "1em",
+    height: "1em",
+    viewBox: "0 0 25 25",
+    fill: "none",
+    xmlns: "http://www.w3.org/2000/svg",
+    ...props,
+    children: /* @__PURE__ */ jsxRuntime.jsx("path", {
+      d: "M5 12.5H20",
+      stroke: "currentColor",
+      strokeWidth: 1.2,
+      strokeLinejoin: "round"
+    })
+  });
+}
 Object.defineProperty(exports, "SanityLogo", {
   enumerable: !0,
   get: function() {
@@ -1284,50 +1286,50 @@ exports.RemoveIcon = RemoveIcon;
 `;
 
 exports[`cli > should build \`ts-rolldown-bundle-peer-dependency\` package > ./dist/index.d.cts 1`] = `
-"import { ForwardRefExoticComponent, RefAttributes, SVGProps } from "react";
+"import { ComponentPropsWithRef, ReactElement } from "react";
 import { SanityLogo } from "@sanity/logos";
 import { validateApiPerspective } from "@sanity/client";
 /**
  * @public
  */
-declare const RemoveIcon: ForwardRefExoticComponent<Omit<SVGProps<SVGSVGElement>, "ref"> & RefAttributes<SVGSVGElement>>;
+declare function RemoveIcon(props: ComponentPropsWithRef<"svg">): ReactElement;
 export { RemoveIcon, SanityLogo, validateApiPerspective };
 //# sourceMappingURL=index.d.cts.map"
 `;
 
 exports[`cli > should build \`ts-rolldown-bundle-peer-dependency\` package > ./dist/index.d.ts 1`] = `
-"import { ForwardRefExoticComponent, RefAttributes, SVGProps } from "react";
+"import { ComponentPropsWithRef, ReactElement } from "react";
 import { SanityLogo } from "@sanity/logos";
 import { validateApiPerspective } from "@sanity/client";
 /**
  * @public
  */
-declare const RemoveIcon: ForwardRefExoticComponent<Omit<SVGProps<SVGSVGElement>, "ref"> & RefAttributes<SVGSVGElement>>;
+declare function RemoveIcon(props: ComponentPropsWithRef<"svg">): ReactElement;
 export { RemoveIcon, SanityLogo, validateApiPerspective };
 //# sourceMappingURL=index.d.ts.map"
 `;
 
 exports[`cli > should build \`ts-rolldown-bundle-peer-dependency\` package > ./dist/index.js 1`] = `
 "import { jsx } from "react/jsx-runtime";
-import { forwardRef } from "react";
 import { SanityLogo } from "@sanity/logos";
 import { validateApiPerspective } from "@sanity/client";
-const RemoveIcon = /* @__PURE__ */ forwardRef(function(props, ref) {
-  return /* @__PURE__ */ jsx(
-    "svg",
-    {
-      "data-sanity-icon": "remove",
-      width: "1em",
-      height: "1em",
-      viewBox: "0 0 25 25",
-      fill: "none",
-      xmlns: "http://www.w3.org/2000/svg",
-      ...props,
-      ref,
-      children: /* @__PURE__ */ jsx("path", { d: "M5 12.5H20", stroke: "currentColor", strokeWidth: 1.2, strokeLinejoin: "round" })
-    }
-  );
-});
+function RemoveIcon(props) {
+  return /* @__PURE__ */ jsx("svg", {
+    "data-sanity-icon": "remove",
+    width: "1em",
+    height: "1em",
+    viewBox: "0 0 25 25",
+    fill: "none",
+    xmlns: "http://www.w3.org/2000/svg",
+    ...props,
+    children: /* @__PURE__ */ jsx("path", {
+      d: "M5 12.5H20",
+      stroke: "currentColor",
+      strokeWidth: 1.2,
+      strokeLinejoin: "round"
+    })
+  });
+}
 export {
   RemoveIcon,
   SanityLogo,
@@ -1340,23 +1342,24 @@ export {
 exports[`cli > should build \`ts-rolldown-bundle-prod-dependency\` package > ./dist/index.cjs 1`] = `
 ""use strict";
 Object.defineProperty(exports, "__esModule", { value: !0 });
-var jsxRuntime = require("react/jsx-runtime"), react = require("react"), logos = require("@sanity/logos"), client = require("@sanity/client");
-const RemoveIcon = /* @__PURE__ */ react.forwardRef(function(props, ref) {
-  return /* @__PURE__ */ jsxRuntime.jsx(
-    "svg",
-    {
-      "data-sanity-icon": "remove",
-      width: "1em",
-      height: "1em",
-      viewBox: "0 0 25 25",
-      fill: "none",
-      xmlns: "http://www.w3.org/2000/svg",
-      ...props,
-      ref,
-      children: /* @__PURE__ */ jsxRuntime.jsx("path", { d: "M5 12.5H20", stroke: "currentColor", strokeWidth: 1.2, strokeLinejoin: "round" })
-    }
-  );
-});
+var jsxRuntime = require("react/jsx-runtime"), logos = require("@sanity/logos"), client = require("@sanity/client");
+function RemoveIcon(props) {
+  return /* @__PURE__ */ jsxRuntime.jsx("svg", {
+    "data-sanity-icon": "remove",
+    width: "1em",
+    height: "1em",
+    viewBox: "0 0 25 25",
+    fill: "none",
+    xmlns: "http://www.w3.org/2000/svg",
+    ...props,
+    children: /* @__PURE__ */ jsxRuntime.jsx("path", {
+      d: "M5 12.5H20",
+      stroke: "currentColor",
+      strokeWidth: 1.2,
+      strokeLinejoin: "round"
+    })
+  });
+}
 Object.defineProperty(exports, "SanityLogo", {
   enumerable: !0,
   get: function() {
@@ -1375,50 +1378,50 @@ exports.RemoveIcon = RemoveIcon;
 `;
 
 exports[`cli > should build \`ts-rolldown-bundle-prod-dependency\` package > ./dist/index.d.cts 1`] = `
-"import { ForwardRefExoticComponent, RefAttributes, SVGProps } from "react";
+"import { ComponentPropsWithRef, ReactElement } from "react";
 import { SanityLogo } from "@sanity/logos";
 import { validateApiPerspective } from "@sanity/client";
 /**
  * @public
  */
-declare const RemoveIcon: ForwardRefExoticComponent<Omit<SVGProps<SVGSVGElement>, "ref"> & RefAttributes<SVGSVGElement>>;
+declare function RemoveIcon(props: ComponentPropsWithRef<"svg">): ReactElement;
 export { RemoveIcon, SanityLogo, validateApiPerspective };
 //# sourceMappingURL=index.d.cts.map"
 `;
 
 exports[`cli > should build \`ts-rolldown-bundle-prod-dependency\` package > ./dist/index.d.ts 1`] = `
-"import { ForwardRefExoticComponent, RefAttributes, SVGProps } from "react";
+"import { ComponentPropsWithRef, ReactElement } from "react";
 import { SanityLogo } from "@sanity/logos";
 import { validateApiPerspective } from "@sanity/client";
 /**
  * @public
  */
-declare const RemoveIcon: ForwardRefExoticComponent<Omit<SVGProps<SVGSVGElement>, "ref"> & RefAttributes<SVGSVGElement>>;
+declare function RemoveIcon(props: ComponentPropsWithRef<"svg">): ReactElement;
 export { RemoveIcon, SanityLogo, validateApiPerspective };
 //# sourceMappingURL=index.d.ts.map"
 `;
 
 exports[`cli > should build \`ts-rolldown-bundle-prod-dependency\` package > ./dist/index.js 1`] = `
 "import { jsx } from "react/jsx-runtime";
-import { forwardRef } from "react";
 import { SanityLogo } from "@sanity/logos";
 import { validateApiPerspective } from "@sanity/client";
-const RemoveIcon = /* @__PURE__ */ forwardRef(function(props, ref) {
-  return /* @__PURE__ */ jsx(
-    "svg",
-    {
-      "data-sanity-icon": "remove",
-      width: "1em",
-      height: "1em",
-      viewBox: "0 0 25 25",
-      fill: "none",
-      xmlns: "http://www.w3.org/2000/svg",
-      ...props,
-      ref,
-      children: /* @__PURE__ */ jsx("path", { d: "M5 12.5H20", stroke: "currentColor", strokeWidth: 1.2, strokeLinejoin: "round" })
-    }
-  );
-});
+function RemoveIcon(props) {
+  return /* @__PURE__ */ jsx("svg", {
+    "data-sanity-icon": "remove",
+    width: "1em",
+    height: "1em",
+    viewBox: "0 0 25 25",
+    fill: "none",
+    xmlns: "http://www.w3.org/2000/svg",
+    ...props,
+    children: /* @__PURE__ */ jsx("path", {
+      d: "M5 12.5H20",
+      stroke: "currentColor",
+      strokeWidth: 1.2,
+      strokeLinejoin: "round"
+    })
+  });
+}
 export {
   RemoveIcon,
   SanityLogo,
@@ -1463,23 +1466,24 @@ export { ExternalSubpathImport, identity };
 exports[`cli > should build \`ts-rolldown-inline-types-external-js\` package > ./dist/index.cjs 1`] = `
 ""use strict";
 Object.defineProperty(exports, "__esModule", { value: !0 });
-var jsxRuntime = require("react/jsx-runtime"), react = require("react"), logos = require("@sanity/logos"), client = require("@sanity/client");
-const RemoveIcon = /* @__PURE__ */ react.forwardRef(function(props, ref) {
-  return /* @__PURE__ */ jsxRuntime.jsx(
-    "svg",
-    {
-      "data-sanity-icon": "remove",
-      width: "1em",
-      height: "1em",
-      viewBox: "0 0 25 25",
-      fill: "none",
-      xmlns: "http://www.w3.org/2000/svg",
-      ...props,
-      ref,
-      children: /* @__PURE__ */ jsxRuntime.jsx("path", { d: "M5 12.5H20", stroke: "currentColor", strokeWidth: 1.2, strokeLinejoin: "round" })
-    }
-  );
-});
+var jsxRuntime = require("react/jsx-runtime"), logos = require("@sanity/logos"), client = require("@sanity/client");
+function RemoveIcon(props) {
+  return /* @__PURE__ */ jsxRuntime.jsx("svg", {
+    "data-sanity-icon": "remove",
+    width: "1em",
+    height: "1em",
+    viewBox: "0 0 25 25",
+    fill: "none",
+    xmlns: "http://www.w3.org/2000/svg",
+    ...props,
+    children: /* @__PURE__ */ jsxRuntime.jsx("path", {
+      d: "M5 12.5H20",
+      stroke: "currentColor",
+      strokeWidth: 1.2,
+      strokeLinejoin: "round"
+    })
+  });
+}
 Object.defineProperty(exports, "SanityLogo", {
   enumerable: !0,
   get: function() {
@@ -1498,7 +1502,7 @@ exports.RemoveIcon = RemoveIcon;
 `;
 
 exports[`cli > should build \`ts-rolldown-inline-types-external-js\` package > ./dist/index.d.cts 1`] = `
-"import { ForwardRefExoticComponent, RefAttributes, SVGProps } from "react";
+"import { ComponentPropsWithRef, ReactElement } from "react";
 import { SanityLogo } from "@sanity/logos";
 import "@sanity/client/csm";
 import "get-it";
@@ -1506,7 +1510,7 @@ import "rxjs";
 /**
  * @public
  */
-declare const RemoveIcon: ForwardRefExoticComponent<Omit<SVGProps<SVGSVGElement>, "ref"> & RefAttributes<SVGSVGElement>>;
+declare function RemoveIcon(props: ComponentPropsWithRef<"svg">): ReactElement;
 /** @public */
 declare type ClientPerspective = DeprecatedPreviewDrafts | 'published' | 'drafts' | 'raw' | StackablePerspective[];
 /**
@@ -1524,7 +1528,7 @@ export { RemoveIcon, SanityLogo, validateApiPerspective };
 `;
 
 exports[`cli > should build \`ts-rolldown-inline-types-external-js\` package > ./dist/index.d.ts 1`] = `
-"import { ForwardRefExoticComponent, RefAttributes, SVGProps } from "react";
+"import { ComponentPropsWithRef, ReactElement } from "react";
 import { SanityLogo } from "@sanity/logos";
 import "@sanity/client/csm";
 import "get-it";
@@ -1532,7 +1536,7 @@ import "rxjs";
 /**
  * @public
  */
-declare const RemoveIcon: ForwardRefExoticComponent<Omit<SVGProps<SVGSVGElement>, "ref"> & RefAttributes<SVGSVGElement>>;
+declare function RemoveIcon(props: ComponentPropsWithRef<"svg">): ReactElement;
 /** @public */
 declare type ClientPerspective = DeprecatedPreviewDrafts | 'published' | 'drafts' | 'raw' | StackablePerspective[];
 /**
@@ -1551,25 +1555,25 @@ export { RemoveIcon, SanityLogo, validateApiPerspective };
 
 exports[`cli > should build \`ts-rolldown-inline-types-external-js\` package > ./dist/index.js 1`] = `
 "import { jsx } from "react/jsx-runtime";
-import { forwardRef } from "react";
 import { SanityLogo } from "@sanity/logos";
 import { validateApiPerspective } from "@sanity/client";
-const RemoveIcon = /* @__PURE__ */ forwardRef(function(props, ref) {
-  return /* @__PURE__ */ jsx(
-    "svg",
-    {
-      "data-sanity-icon": "remove",
-      width: "1em",
-      height: "1em",
-      viewBox: "0 0 25 25",
-      fill: "none",
-      xmlns: "http://www.w3.org/2000/svg",
-      ...props,
-      ref,
-      children: /* @__PURE__ */ jsx("path", { d: "M5 12.5H20", stroke: "currentColor", strokeWidth: 1.2, strokeLinejoin: "round" })
-    }
-  );
-});
+function RemoveIcon(props) {
+  return /* @__PURE__ */ jsx("svg", {
+    "data-sanity-icon": "remove",
+    width: "1em",
+    height: "1em",
+    viewBox: "0 0 25 25",
+    fill: "none",
+    xmlns: "http://www.w3.org/2000/svg",
+    ...props,
+    children: /* @__PURE__ */ jsx("path", {
+      d: "M5 12.5H20",
+      stroke: "currentColor",
+      strokeWidth: 1.2,
+      strokeLinejoin: "round"
+    })
+  });
+}
 export {
   RemoveIcon,
   SanityLogo,

--- a/packages/@sanity/pkg-utils/test/dependencyPlacement.test.ts
+++ b/packages/@sanity/pkg-utils/test/dependencyPlacement.test.ts
@@ -124,7 +124,7 @@ describe('checkDependencyPlacement', () => {
         dependencies: {
           'react-is': '^18.0.0',
           '@sanity/ui': '^3.0.0',
-          '@sanity/icons': '^3.0.0',
+          '@sanity/icons': '^5.0.0',
           'rxjs': '^7.0.0',
         },
         devDependencies: {'react': '^19.0.0', 'sanity': '^5.0.0', '@types/react': '^19.0.0'},

--- a/playground/ts-rolldown-bundle-dev-dependency/src/index.ts
+++ b/playground/ts-rolldown-bundle-dev-dependency/src/index.ts
@@ -1,3 +1,3 @@
-export {RemoveIcon} from '@sanity/icons'
+export {RemoveIcon} from '@sanity/icons/Remove'
 export {SanityLogo} from '@sanity/logos'
 export {validateApiPerspective} from '@sanity/client'

--- a/playground/ts-rolldown-bundle-peer-dependency/src/index.ts
+++ b/playground/ts-rolldown-bundle-peer-dependency/src/index.ts
@@ -1,3 +1,3 @@
-export {RemoveIcon} from '@sanity/icons'
+export {RemoveIcon} from '@sanity/icons/Remove'
 export {SanityLogo} from '@sanity/logos'
 export {validateApiPerspective} from '@sanity/client'

--- a/playground/ts-rolldown-bundle-prod-dependency/src/index.ts
+++ b/playground/ts-rolldown-bundle-prod-dependency/src/index.ts
@@ -1,3 +1,3 @@
-export {RemoveIcon} from '@sanity/icons'
+export {RemoveIcon} from '@sanity/icons/Remove'
 export {SanityLogo} from '@sanity/logos'
 export {validateApiPerspective} from '@sanity/client'

--- a/playground/ts-rolldown-inline-types-external-js/src/index.ts
+++ b/playground/ts-rolldown-inline-types-external-js/src/index.ts
@@ -1,3 +1,3 @@
-export {RemoveIcon} from '@sanity/icons'
+export {RemoveIcon} from '@sanity/icons/Remove'
 export {SanityLogo} from '@sanity/logos'
 export {validateApiPerspective} from '@sanity/client'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^7.23.0
       version: 7.23.0
     '@sanity/icons':
-      specifier: ^3.8.0
-      version: 3.8.0
+      specifier: ^5.1.0
+      version: 5.1.0
     '@sanity/logos':
       specifier: ^2.2.2
       version: 2.2.2
@@ -1300,7 +1300,7 @@ importers:
         version: 7.23.0
       '@sanity/icons':
         specifier: 'catalog:'
-        version: 3.8.0(react@19.2.7)
+        version: 5.1.0(react@19.2.7)
       '@sanity/logos':
         specifier: 'catalog:'
         version: 2.2.2(react@19.2.7)
@@ -1316,7 +1316,7 @@ importers:
         version: 7.23.0
       '@sanity/icons':
         specifier: 'catalog:'
-        version: 3.8.0(react@19.2.7)
+        version: 5.1.0(react@19.2.7)
       '@sanity/logos':
         specifier: 'catalog:'
         version: 2.2.2(react@19.2.7)
@@ -1328,7 +1328,7 @@ importers:
         version: 7.23.0
       '@sanity/icons':
         specifier: 'catalog:'
-        version: 3.8.0(react@19.2.7)
+        version: 5.1.0(react@19.2.7)
       '@sanity/logos':
         specifier: 'catalog:'
         version: 2.2.2(react@19.2.7)
@@ -1349,7 +1349,7 @@ importers:
         version: 7.23.0
       '@sanity/icons':
         specifier: 'catalog:'
-        version: 3.8.0(react@19.2.7)
+        version: 5.1.0(react@19.2.7)
       '@sanity/logos':
         specifier: 'catalog:'
         version: 2.2.2(react@19.2.7)
@@ -6580,6 +6580,12 @@ packages:
 
   '@sanity/icons@5.0.0':
     resolution: {integrity: sha512-fINQLovVnCANwQbQ63iO2mUVh2ZX3T4h3hiSEaIStvladI5tmrGAuT+XbUuk3jTmBwOHDGD0EL9lpsghGAS+Sg==}
+    engines: {node: '>=22.12'}
+    peerDependencies:
+      react: ^19
+
+  '@sanity/icons@5.1.0':
+    resolution: {integrity: sha512-BPvLFBWnxpXCn9XKb5OgBzNNRZJI29TXRpuSXx1/nKJ8FaYuitFmKSAD0L8jC0kF/BKKUMThaY3TYJ0UuubbTQ==}
     engines: {node: '>=22.12'}
     peerDependencies:
       react: ^19
@@ -20362,6 +20368,10 @@ snapshots:
       react: 19.2.7
 
   '@sanity/icons@5.0.0(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+
+  '@sanity/icons@5.1.0(react@19.2.7)':
     dependencies:
       react: 19.2.7
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ packages:
 
 catalog:
   '@sanity/client': ^7.23.0
-  '@sanity/icons': ^3.8.0
+  '@sanity/icons': ^5.1.0
   '@sanity/logos': ^2.2.2
   '@types/node': ^24.13.3
   lightningcss: ^1.32.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bump the `@sanity/icons` catalog entry from `^3.8.0` to `^5.1.0`.

v5 removes the deprecated root barrel re-exports for individual icons, so playground fixtures that re-export `RemoveIcon` now import from `@sanity/icons/Remove`.

### Changes
- Catalog: `@sanity/icons` → `^5.1.0`
- Playground fixtures updated to subpath imports
- Lockfile refreshed
- CLI snapshots updated for v5 icon output (plain function + `ComponentPropsWithRef` instead of `forwardRef`)
- Test fixture version string aligned in dependency placement test

### Notes
- Transitive copies (e.g. via `@sanity/ui`) may still resolve older majors; only workspace catalog consumers are forced to v5.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e1763e4-08e1-4070-b0b1-1bfc91284d40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e1763e4-08e1-4070-b0b1-1bfc91284d40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

