### PR TITLE
feat(tsdown-config): enable circularDependency check by default

### DIFF
--- a/.changeset/tsdown-config-circular-dependency.md
+++ b/.changeset/tsdown-config-circular-dependency.md
@@ -1,0 +1,5 @@
+---
+"@sanity/tsdown-config": minor
+---
+
+Enable Rolldown's `checks.circularDependency` warning by default (Rolldown itself defaults it to `false`), so import cycles surface during Sanity library builds. Override with `mergeConfig(..., {checks: {circularDependency: false}})` if needed.

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -359,6 +359,23 @@ export default defineConfig({
 })
 ```
 
+## checks
+
+Rolldown's [`checks.circularDependency`](https://rolldown.rs/reference/InputOptions.checks#circulardependency)
+warning is enabled by default (Rolldown itself defaults it to `false`). Circular imports inflate
+bundle size and can cause execution-order issues, so library builds surface them as warnings.
+
+To turn the warning off, merge over the returned config:
+
+```ts
+import {defineConfig} from '@sanity/tsdown-config'
+import {mergeConfig} from 'tsdown'
+
+export default mergeConfig(await defineConfig({tsconfig: 'tsconfig.dist.json'}), {
+  checks: {circularDependency: false},
+})
+```
+
 ## Everything else: `mergeConfig`
 
 `defineConfig` deliberately only exposes options you're likely to change. For anything else, merge

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -353,6 +353,11 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
   )
 
   return defineTsdownConfig({
+    // Rolldown defaults `circularDependency` to `false`; enable it so Sanity library builds
+    // surface import cycles (bigger bundles / execution-order hazards) as warnings.
+    // Override via `mergeConfig(..., {checks: {circularDependency: false}})`.
+    // https://rolldown.rs/reference/InputOptions.checks#circulardependency
+    checks: {circularDependency: true},
     clean,
     css,
     define,

--- a/packages/@sanity/tsdown-config/test/options.test.ts
+++ b/packages/@sanity/tsdown-config/test/options.test.ts
@@ -191,6 +191,15 @@ describe('neutral platform resolution', () => {
   })
 })
 
+describe('checks option', () => {
+  test('enables Rolldown circularDependency warnings by default', async () => {
+    // Rolldown itself defaults `checks.circularDependency` to `false`; this config opts in so
+    // import cycles surface as build warnings. Override with mergeConfig if needed.
+    // https://rolldown.rs/reference/InputOptions.checks#circulardependency
+    expect((await defineConfig()).checks).toEqual({circularDependency: true})
+  })
+})
+
 describe('unexposed options', () => {
   test('lean on tsdown defaults, customizable in userland through `mergeConfig`', async () => {
     // Options not in `PackageOptions` (e.g. `hash`, with its collision-preventing hashed chunk


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Enable Rolldown’s [`checks.circularDependency`](https://rolldown.rs/reference/InputOptions.checks#circulardependency) warning by default in `@sanity/tsdown-config`.

Rolldown itself defaults this to `false`. This change opts in via tsdown’s top-level `checks` option so Sanity library builds surface import cycles as warnings (they inflate bundle size and can cause execution-order issues).

### Override

```ts
import {defineConfig} from '@sanity/tsdown-config'
import {mergeConfig} from 'tsdown'

export default mergeConfig(await defineConfig({tsconfig: 'tsconfig.dist.json'}), {
  checks: {circularDependency: false},
})
```

### Verification

- Unit test asserts `defineConfig().checks === {circularDependency: true}`
- Full `@sanity/tsdown-config` suite: 76/76 passed
- Packages using the config (`parse-package-json`, vanilla-extract plugins, `tsdown-config` itself) rebuild cleanly with no circular-dependency warnings
- Smoke fixture with `a.ts ↔ b.ts` emits `[CIRCULAR_DEPENDENCY] Circular dependency: src/a.ts -> src/b.ts -> src/a.ts.`

### Notes

- Warnings only by default (`failOnWarn` remains off unless consumers enable it)
- Documented in the package README
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6817-e8e9-7f2a-bff7-ec9e86694e22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6817-e8e9-7f2a-bff7-ec9e86694e22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

