### PR TITLE
fix(vite-plugin): externalize runtime during Studio evaluation

### DIFF
--- a/.changeset/fix-vite-browser-resolution.md
+++ b/.changeset/fix-vite-browser-resolution.md
@@ -2,4 +2,4 @@
 "@sanity/vanilla-extract-vite-plugin": patch
 ---
 
-fix: preserve extracted CSS when parent Vite configs enable the `browser` resolve condition
+Fix `.css.ts` evaluation when parent Vite configs force SSR dependencies to be inlined

--- a/.changeset/fix-vite-browser-resolution.md
+++ b/.changeset/fix-vite-browser-resolution.md
@@ -1,0 +1,5 @@
+---
+"@sanity/vanilla-extract-vite-plugin": patch
+---
+
+fix: preserve extracted CSS when parent Vite configs enable the `browser` resolve condition

--- a/benchmarks/vanilla-extract/README.md
+++ b/benchmarks/vanilla-extract/README.md
@@ -79,8 +79,8 @@ Keep this section current: re-run the full suite and update the tables whenever 
 `vanilla-extract` dependencies are bumped or any of the `@sanity/vanilla-extract-*` plugins
 change (see [AGENTS.md](../../AGENTS.md)).
 
-Last run: 2026-07-16 (after filtering parent `browser` resolve entries out of the Vite compiler
-server while preserving custom conditions), full default suite
+Last run: 2026-07-16 (after preserving native Vanilla Extract externals when parent Vite configs
+force SSR dependencies inline), full default suite
 (`pnpm benchmark:vanilla-extract`) on Node.js 24.18.0, Linux x64, Intel Xeon, **4 cores**;
 Rollup 4.62.2, Rolldown 1.2.0, Vite 8.1.5, Vitest 4.1.10, yuku-parser 0.6.4,
 `@vanilla-extract/rollup-plugin` 1.5.4, `@vanilla-extract/vite-plugin` 5.2.5, and both Sanity
@@ -107,14 +107,14 @@ stress 1.37–1.71x.
 
 | Variant                  | Rollup + `@vanilla-extract/rollup-plugin` | Rolldown + `@sanity/vanilla-extract-rolldown-plugin` | Relative result     |
 | ------------------------ | ----------------------------------------: | ---------------------------------------------------: | ------------------- |
-| No minify, no target     |                               1,147.57 ms |                                            386.44 ms | Sanity 2.97x faster |
-| Minify                   |                               1,156.58 ms |                                            397.65 ms | Sanity 2.91x faster |
-| Target chrome61          |                               1,169.77 ms |                                            383.83 ms | Sanity 3.05x faster |
-| Minify + target chrome61 |                               1,126.12 ms |                                            389.13 ms | Sanity 2.89x faster |
-| Debug identifiers        |                               1,388.10 ms |                                            446.28 ms | Sanity 3.11x faster |
+| No minify, no target     |                               1,121.53 ms |                                            375.14 ms | Sanity 2.99x faster |
+| Minify                   |                               1,159.87 ms |                                            417.29 ms | Sanity 2.78x faster |
+| Target chrome61          |                               1,327.03 ms |                                            408.60 ms | Sanity 3.25x faster |
+| Minify + target chrome61 |                               1,240.65 ms |                                            392.45 ms | Sanity 3.16x faster |
+| Debug identifiers        |                               1,432.00 ms |                                            466.70 ms | Sanity 3.07x faster |
 
-Debug identifiers cost each pipeline `debug − baseline`: **+240.5 ms** for the official
-babel-based transform, **+59.8 ms** for the Sanity `yuku-parser` pass — the transform runs
+Debug identifiers cost each pipeline `debug − baseline`: **+310.5 ms** for the official
+babel-based transform, **+91.6 ms** for the Sanity `yuku-parser` pass — the transform runs
 once per `.css.ts` module and scales with file size, so the production-shaped modules widen
 the gap the near-empty fixtures used to understate.
 
@@ -122,29 +122,29 @@ the gap the near-empty fixtures used to understate.
 
 | Identifiers | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result     |
 | ----------- | -----------------------------: | ------------------------------------: | ------------------- |
-| Short       |                      969.81 ms |                             770.49 ms | Sanity 1.26x faster |
-| Debug       |                    1,281.34 ms |                             849.54 ms | Sanity 1.51x faster |
+| Short       |                      976.66 ms |                             804.76 ms | Sanity 1.21x faster |
+| Debug       |                    1,371.17 ms |                             892.61 ms | Sanity 1.54x faster |
 
 ### Vite build kitchen sink, 5,000 TS + 500 CSS modules, debug identifiers, css minify + target chrome61 (5 samples each)
 
 | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result     |
 | -----------------------------: | ------------------------------------: | ------------------- |
-|                    4,575.53 ms |                           3,395.69 ms | Sanity 1.35x faster |
+|                    4,705.24 ms |                           3,334.57 ms | Sanity 1.41x faster |
 
 ### Vite dev HMR (10 samples each)
 
 | Scenario                               | Official plugin | Sanity plugin | Relative result       |
 | -------------------------------------- | --------------: | ------------: | --------------------- |
-| Single `.css.ts` leaf edit             |        25.97 ms |      26.34 ms | Official 1.01x faster |
-| Shared theme edit, 100 style importers |       179.59 ms |     186.79 ms | Official 1.04x faster |
+| Single `.css.ts` leaf edit             |        25.24 ms |      27.61 ms | Official 1.09x faster |
+| Shared theme edit, 100 style importers |       189.41 ms |     196.48 ms | Official 1.04x faster |
 
 ### Hook-filter stress, `vite build` with 1 CSS module (3 samples each)
 
 | Unrelated modules | Official plugin | Sanity plugin | Relative result     |
 | ----------------: | --------------: | ------------: | ------------------- |
-|                 0 |       466.89 ms |     259.40 ms | Sanity 1.80x faster |
-|             1,000 |       500.01 ms |     266.03 ms | Sanity 1.88x faster |
-|             5,000 |       718.49 ms |     446.40 ms | Sanity 1.61x faster |
+|                 0 |       444.39 ms |     249.58 ms | Sanity 1.78x faster |
+|             1,000 |       480.93 ms |     259.24 ms | Sanity 1.86x faster |
+|             5,000 |       690.18 ms |     418.16 ms | Sanity 1.65x faster |
 
 The untimed hook diagnostic shows why: the official plugin's unfiltered hooks enter JavaScript
 once per module, while the Sanity plugin's native hook filters reject unrelated ids before the

--- a/benchmarks/vanilla-extract/README.md
+++ b/benchmarks/vanilla-extract/README.md
@@ -79,12 +79,13 @@ Keep this section current: re-run the full suite and update the tables whenever 
 `vanilla-extract` dependencies are bumped or any of the `@sanity/vanilla-extract-*` plugins
 change (see [AGENTS.md](../../AGENTS.md)).
 
-Last run: 2026-07-16 (after isolating the Vite compiler server from parent `browser` resolve
-conditions), full default suite (`pnpm benchmark:vanilla-extract`) on Node.js 24.18.0, Linux
-x64, Intel Xeon, **4 cores**; Rollup 4.62.2, Rolldown 1.2.0, Vite 8.1.5, Vitest 4.1.10,
-yuku-parser 0.6.4, `@vanilla-extract/rollup-plugin` 1.5.4,
-`@vanilla-extract/vite-plugin` 5.2.5, and both Sanity plugins 0.2.0. Values are mean wall-clock
-milliseconds from that runner and are machine-specific — compare ratios, not absolute numbers.
+Last run: 2026-07-16 (after filtering parent `browser` resolve entries out of the Vite compiler
+server while preserving custom conditions), full default suite
+(`pnpm benchmark:vanilla-extract`) on Node.js 24.18.0, Linux x64, Intel Xeon, **4 cores**;
+Rollup 4.62.2, Rolldown 1.2.0, Vite 8.1.5, Vitest 4.1.10, yuku-parser 0.6.4,
+`@vanilla-extract/rollup-plugin` 1.5.4, `@vanilla-extract/vite-plugin` 5.2.5, and both Sanity
+plugins 0.2.0. Values are mean wall-clock milliseconds from that runner and are
+machine-specific — compare ratios, not absolute numbers.
 
 ### Core count shifts the build ratios
 
@@ -106,14 +107,14 @@ stress 1.37–1.71x.
 
 | Variant                  | Rollup + `@vanilla-extract/rollup-plugin` | Rolldown + `@sanity/vanilla-extract-rolldown-plugin` | Relative result     |
 | ------------------------ | ----------------------------------------: | ---------------------------------------------------: | ------------------- |
-| No minify, no target     |                               1,312.38 ms |                                            424.81 ms | Sanity 3.09x faster |
-| Minify                   |                               1,296.04 ms |                                            398.51 ms | Sanity 3.25x faster |
-| Target chrome61          |                               1,162.90 ms |                                            383.78 ms | Sanity 3.03x faster |
-| Minify + target chrome61 |                               1,121.97 ms |                                            395.41 ms | Sanity 2.84x faster |
-| Debug identifiers        |                               1,477.28 ms |                                            438.14 ms | Sanity 3.37x faster |
+| No minify, no target     |                               1,147.57 ms |                                            386.44 ms | Sanity 2.97x faster |
+| Minify                   |                               1,156.58 ms |                                            397.65 ms | Sanity 2.91x faster |
+| Target chrome61          |                               1,169.77 ms |                                            383.83 ms | Sanity 3.05x faster |
+| Minify + target chrome61 |                               1,126.12 ms |                                            389.13 ms | Sanity 2.89x faster |
+| Debug identifiers        |                               1,388.10 ms |                                            446.28 ms | Sanity 3.11x faster |
 
-Debug identifiers cost each pipeline `debug − baseline`: **+164.9 ms** for the official
-babel-based transform, **+13.3 ms** for the Sanity `yuku-parser` pass — the transform runs
+Debug identifiers cost each pipeline `debug − baseline`: **+240.5 ms** for the official
+babel-based transform, **+59.8 ms** for the Sanity `yuku-parser` pass — the transform runs
 once per `.css.ts` module and scales with file size, so the production-shaped modules widen
 the gap the near-empty fixtures used to understate.
 
@@ -121,29 +122,29 @@ the gap the near-empty fixtures used to understate.
 
 | Identifiers | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result     |
 | ----------- | -----------------------------: | ------------------------------------: | ------------------- |
-| Short       |                    1,123.28 ms |                             810.65 ms | Sanity 1.39x faster |
-| Debug       |                    1,491.96 ms |                             896.08 ms | Sanity 1.66x faster |
+| Short       |                      969.81 ms |                             770.49 ms | Sanity 1.26x faster |
+| Debug       |                    1,281.34 ms |                             849.54 ms | Sanity 1.51x faster |
 
 ### Vite build kitchen sink, 5,000 TS + 500 CSS modules, debug identifiers, css minify + target chrome61 (5 samples each)
 
 | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result     |
 | -----------------------------: | ------------------------------------: | ------------------- |
-|                    5,397.54 ms |                           3,835.65 ms | Sanity 1.41x faster |
+|                    4,575.53 ms |                           3,395.69 ms | Sanity 1.35x faster |
 
 ### Vite dev HMR (10 samples each)
 
 | Scenario                               | Official plugin | Sanity plugin | Relative result       |
 | -------------------------------------- | --------------: | ------------: | --------------------- |
-| Single `.css.ts` leaf edit             |        28.64 ms |      26.82 ms | Sanity 1.07x faster   |
-| Shared theme edit, 100 style importers |       196.79 ms |     217.80 ms | Official 1.11x faster |
+| Single `.css.ts` leaf edit             |        25.97 ms |      26.34 ms | Official 1.01x faster |
+| Shared theme edit, 100 style importers |       179.59 ms |     186.79 ms | Official 1.04x faster |
 
 ### Hook-filter stress, `vite build` with 1 CSS module (3 samples each)
 
 | Unrelated modules | Official plugin | Sanity plugin | Relative result     |
 | ----------------: | --------------: | ------------: | ------------------- |
-|                 0 |       497.67 ms |     273.50 ms | Sanity 1.82x faster |
-|             1,000 |       501.30 ms |     284.08 ms | Sanity 1.76x faster |
-|             5,000 |       776.56 ms |     445.93 ms | Sanity 1.74x faster |
+|                 0 |       466.89 ms |     259.40 ms | Sanity 1.80x faster |
+|             1,000 |       500.01 ms |     266.03 ms | Sanity 1.88x faster |
+|             5,000 |       718.49 ms |     446.40 ms | Sanity 1.61x faster |
 
 The untimed hook diagnostic shows why: the official plugin's unfiltered hooks enter JavaScript
 once per module, while the Sanity plugin's native hook filters reject unrelated ids before the

--- a/benchmarks/vanilla-extract/README.md
+++ b/benchmarks/vanilla-extract/README.md
@@ -79,17 +79,12 @@ Keep this section current: re-run the full suite and update the tables whenever 
 `vanilla-extract` dependencies are bumped or any of the `@sanity/vanilla-extract-*` plugins
 change (see [AGENTS.md](../../AGENTS.md)).
 
-Last run: 2026-07-16 (after vendoring `@vanilla-extract/integration` onto rolldown as
-`@sanity/vanilla-extract-integration` — the library-build compile path swapped its esbuild
-child compilation for rolldown, and debug IDs swapped babel for a `yuku-parser` AST pass —
-adding the `debug identifiers` variant and the kitchen-sink case to this suite, aligning every
-rolldown copy on the 1.1.5 that vite 8 pins, and sizing the build-suite fixtures like
-production source files), full default suite (`pnpm benchmark:vanilla-extract`) on Node.js
-24.18.0, Linux x64, Intel Xeon, **4 cores**; Rollup 4.62.2, Rolldown 1.1.5, Vite 8.1.4,
-Vitest 4.1.10, yuku-parser 0.6.1. Values are mean wall-clock milliseconds from that runner and
-are machine-specific — compare ratios, not absolute numbers. (For the future rolldown bump:
-rolldown 1.2.0 measured the Sanity library build ~15% faster still on the earlier minimal
-fixtures — expect the gap below to widen again when vite updates its pinned rolldown.)
+Last run: 2026-07-16 (after isolating the Vite compiler server from parent `browser` resolve
+conditions), full default suite (`pnpm benchmark:vanilla-extract`) on Node.js 24.18.0, Linux
+x64, Intel Xeon, **4 cores**; Rollup 4.62.2, Rolldown 1.2.0, Vite 8.1.5, Vitest 4.1.10,
+yuku-parser 0.6.4, `@vanilla-extract/rollup-plugin` 1.5.4,
+`@vanilla-extract/vite-plugin` 5.2.5, and both Sanity plugins 0.2.0. Values are mean wall-clock
+milliseconds from that runner and are machine-specific — compare ratios, not absolute numbers.
 
 ### Core count shifts the build ratios
 
@@ -99,25 +94,26 @@ relative to Rollup, and the tables below (from a 4-core runner) understate the g
 developer hardware. The versions table printed with every run includes the core count so results
 stay comparable.
 
-For cross-hardware reference, an Apple M4 Max (16 cores, darwin-arm64, 2026-07-16, same
-versions and the same production-shaped fixtures as the tables below) measured: library build
-2.02–2.18x (short-identifier variants) and 2.47x (debug identifiers, 798ms vs 323ms) in favor
-of Rolldown + the Sanity plugin; Vite build 1.28x/1.58x (short/debug identifiers) and 1.48x on
-the kitchen-sink case (2,757ms vs 1,862ms); dev HMR a wash (1.12x Sanity on leaf edits, 1.05x
-official on theme edits, rme up to ±20%); hook-filter stress 1.37–1.71x.
+For cross-hardware reference, an Apple M4 Max (16 cores, darwin-arm64, 2026-07-16, the prior
+Rolldown 1.1.5 / Vite 8.1.4 / yuku-parser 0.6.1 lockfile and the same production-shaped
+fixtures) measured: library build 2.02–2.18x (short-identifier variants) and 2.47x (debug
+identifiers, 798ms vs 323ms) in favor of Rolldown + the Sanity plugin; Vite build 1.28x/1.58x
+(short/debug identifiers) and 1.48x on the kitchen-sink case (2,757ms vs 1,862ms); dev HMR a
+wash (1.12x Sanity on leaf edits, 1.05x official on theme edits, rme up to ±20%); hook-filter
+stress 1.37–1.71x.
 
 ### Library build, 500 TS + 100 CSS modules (5 samples each)
 
 | Variant                  | Rollup + `@vanilla-extract/rollup-plugin` | Rolldown + `@sanity/vanilla-extract-rolldown-plugin` | Relative result     |
 | ------------------------ | ----------------------------------------: | ---------------------------------------------------: | ------------------- |
-| No minify, no target     |                               1,145.59 ms |                                            415.51 ms | Sanity 2.76x faster |
-| Minify                   |                               1,119.03 ms |                                            415.88 ms | Sanity 2.69x faster |
-| Target chrome61          |                               1,154.48 ms |                                            423.53 ms | Sanity 2.73x faster |
-| Minify + target chrome61 |                               1,118.68 ms |                                            422.78 ms | Sanity 2.65x faster |
-| Debug identifiers        |                               1,407.03 ms |                                            455.64 ms | Sanity 3.09x faster |
+| No minify, no target     |                               1,312.38 ms |                                            424.81 ms | Sanity 3.09x faster |
+| Minify                   |                               1,296.04 ms |                                            398.51 ms | Sanity 3.25x faster |
+| Target chrome61          |                               1,162.90 ms |                                            383.78 ms | Sanity 3.03x faster |
+| Minify + target chrome61 |                               1,121.97 ms |                                            395.41 ms | Sanity 2.84x faster |
+| Debug identifiers        |                               1,477.28 ms |                                            438.14 ms | Sanity 3.37x faster |
 
-Debug identifiers cost each pipeline `debug − baseline`: **+261.4 ms** for the official
-babel-based transform, **+40.1 ms** for the Sanity `yuku-parser` pass — the transform runs
+Debug identifiers cost each pipeline `debug − baseline`: **+164.9 ms** for the official
+babel-based transform, **+13.3 ms** for the Sanity `yuku-parser` pass — the transform runs
 once per `.css.ts` module and scales with file size, so the production-shaped modules widen
 the gap the near-empty fixtures used to understate.
 
@@ -125,29 +121,29 @@ the gap the near-empty fixtures used to understate.
 
 | Identifiers | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result     |
 | ----------- | -----------------------------: | ------------------------------------: | ------------------- |
-| Short       |                      950.45 ms |                             760.99 ms | Sanity 1.25x faster |
-| Debug       |                    1,344.97 ms |                             847.71 ms | Sanity 1.59x faster |
+| Short       |                    1,123.28 ms |                             810.65 ms | Sanity 1.39x faster |
+| Debug       |                    1,491.96 ms |                             896.08 ms | Sanity 1.66x faster |
 
 ### Vite build kitchen sink, 5,000 TS + 500 CSS modules, debug identifiers, css minify + target chrome61 (5 samples each)
 
 | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result     |
 | -----------------------------: | ------------------------------------: | ------------------- |
-|                    4,505.27 ms |                           3,323.23 ms | Sanity 1.36x faster |
+|                    5,397.54 ms |                           3,835.65 ms | Sanity 1.41x faster |
 
 ### Vite dev HMR (10 samples each)
 
 | Scenario                               | Official plugin | Sanity plugin | Relative result       |
 | -------------------------------------- | --------------: | ------------: | --------------------- |
-| Single `.css.ts` leaf edit             |        21.90 ms |      23.46 ms | Official 1.07x faster |
-| Shared theme edit, 100 style importers |       164.47 ms |     176.77 ms | Official 1.07x faster |
+| Single `.css.ts` leaf edit             |        28.64 ms |      26.82 ms | Sanity 1.07x faster   |
+| Shared theme edit, 100 style importers |       196.79 ms |     217.80 ms | Official 1.11x faster |
 
 ### Hook-filter stress, `vite build` with 1 CSS module (3 samples each)
 
 | Unrelated modules | Official plugin | Sanity plugin | Relative result     |
 | ----------------: | --------------: | ------------: | ------------------- |
-|                 0 |       434.26 ms |     243.70 ms | Sanity 1.78x faster |
-|             1,000 |       458.99 ms |     251.05 ms | Sanity 1.83x faster |
-|             5,000 |       671.39 ms |     413.36 ms | Sanity 1.62x faster |
+|                 0 |       497.67 ms |     273.50 ms | Sanity 1.82x faster |
+|             1,000 |       501.30 ms |     284.08 ms | Sanity 1.76x faster |
+|             5,000 |       776.56 ms |     445.93 ms | Sanity 1.74x faster |
 
 The untimed hook diagnostic shows why: the official plugin's unfiltered hooks enter JavaScript
 once per module, while the Sanity plugin's native hook filters reject unrelated ids before the

--- a/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
@@ -48,6 +48,10 @@ const globalAdapterStore = globalThis as typeof globalThis & {
   [GLOBAL_ADAPTER_KEY]?: Adapter
 }
 
+function withoutBrowser(values: string[] | undefined): string[] | undefined {
+  return values?.filter((value) => value !== 'browser')
+}
+
 interface ModuleScanResult {
   cssDeps: string[]
   watchFiles: Set<string>
@@ -191,8 +195,9 @@ export interface CreateCompilerOptions {
    */
   cssImportSpecifier?: (filePath: string) => string
   /**
-   * Vite config forwarded to the internal compiler server (plugins, aliases, etc). The compiler
-   * always uses Node resolve conditions and main fields because it evaluates modules in Node.
+   * Vite config forwarded to the internal compiler server (plugins, aliases, etc). Browser
+   * entries are omitted from resolve conditions and main fields because it evaluates modules
+   * in Node; all other entries are preserved.
    */
   viteConfig?: ViteUserConfig
   /**
@@ -257,20 +262,21 @@ async function createCompilerServer({
     build: {
       assetsInlineLimit: viteConfig.build?.assetsInlineLimit,
     },
-    // Parent app configs (notably `sanity build`) can enable the `browser` condition. This
-    // server evaluates `.css.ts` modules in Node, where resolving vanilla-extract's browser
-    // runtime would export class names without collecting their CSS through our adapter.
+    // Parent app configs (notably `sanity build`) can enable the `browser` condition. Omit it
+    // from every resolver the ModuleRunner can use while preserving custom conditions: this
+    // server evaluates `.css.ts` modules in Node, where vanilla-extract's browser runtime would
+    // export class names without collecting their CSS through our adapter.
     resolve: {
       ...viteConfig.resolve,
-      conditions: ['node', 'import', 'module', 'default'],
-      mainFields: ['module', 'jsnext:main', 'jsnext', 'main'],
+      conditions: withoutBrowser(viteConfig.resolve?.conditions),
+      mainFields: withoutBrowser(viteConfig.resolve?.mainFields),
     },
     ssr: {
       ...viteConfig.ssr,
       resolve: {
         ...viteConfig.ssr?.resolve,
-        conditions: ['node', 'import', 'module', 'default'],
-        externalConditions: ['node', 'import', 'module', 'default'],
+        conditions: withoutBrowser(viteConfig.ssr?.resolve?.conditions),
+        externalConditions: withoutBrowser(viteConfig.ssr?.resolve?.externalConditions),
       },
     },
     // Vite's default SSR externalization applies: project files and linked packages are

--- a/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
@@ -190,7 +190,10 @@ export interface CreateCompilerOptions {
    * Maps a `.css.ts` file path to the virtual CSS module specifier imported by its compiled JS.
    */
   cssImportSpecifier?: (filePath: string) => string
-  /** Vite config forwarded to the internal compiler server (resolve options, plugins, etc). */
+  /**
+   * Vite config forwarded to the internal compiler server (plugins, aliases, etc). The compiler
+   * always uses Node resolve conditions and main fields because it evaluates modules in Node.
+   */
   viteConfig?: ViteUserConfig
   /**
    * The compiler watches the files it evaluates and invalidates its caches on change. Disable
@@ -254,6 +257,22 @@ async function createCompilerServer({
     build: {
       assetsInlineLimit: viteConfig.build?.assetsInlineLimit,
     },
+    // Parent app configs (notably `sanity build`) can enable the `browser` condition. This
+    // server evaluates `.css.ts` modules in Node, where resolving vanilla-extract's browser
+    // runtime would export class names without collecting their CSS through our adapter.
+    resolve: {
+      ...viteConfig.resolve,
+      conditions: ['node', 'import', 'module', 'default'],
+      mainFields: ['module', 'jsnext:main', 'jsnext', 'main'],
+    },
+    ssr: {
+      ...viteConfig.ssr,
+      resolve: {
+        ...viteConfig.ssr?.resolve,
+        conditions: ['node', 'import', 'module', 'default'],
+        externalConditions: ['node', 'import', 'module', 'default'],
+      },
+    },
     // Vite's default SSR externalization applies: project files and linked packages are
     // evaluated through the runner (so they're cached in the module graph), while node_modules
     // dependencies are externalized to real Node imports — required for CJS dependencies,
@@ -280,7 +299,7 @@ async function createCompilerServer({
           // Inject the file scope and the adapter binding: the spliced
           // `setAdapter(globalThis[...])` call binds the project's own copy of
           // `@vanilla-extract/css` to the adapter of the compilation in progress
-          return transform({
+          return await transform({
             source: code,
             rootPath: root,
             filePath: id,

--- a/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
@@ -48,8 +48,15 @@ const globalAdapterStore = globalThis as typeof globalThis & {
   [GLOBAL_ADAPTER_KEY]?: Adapter
 }
 
-function withoutBrowser(values: string[] | undefined): string[] | undefined {
-  return values?.filter((value) => value !== 'browser')
+const VANILLA_EXTRACT_EXTERNALS = [
+  '@vanilla-extract/css',
+  '@vanilla-extract/css/fileScope',
+  '@vanilla-extract/css/adapter',
+]
+
+function mergeExternals(...values: (true | string[] | undefined)[]): true | string[] {
+  if (values.includes(true)) return true
+  return [...new Set(values.flatMap((value) => (Array.isArray(value) ? value : [])))]
 }
 
 interface ModuleScanResult {
@@ -195,9 +202,7 @@ export interface CreateCompilerOptions {
    */
   cssImportSpecifier?: (filePath: string) => string
   /**
-   * Vite config forwarded to the internal compiler server (plugins, aliases, etc). Browser
-   * entries are omitted from resolve conditions and main fields because it evaluates modules
-   * in Node; all other entries are preserved.
+   * Vite config forwarded to the internal compiler server (plugins, aliases, etc).
    */
   viteConfig?: ViteUserConfig
   /**
@@ -236,6 +241,11 @@ async function createCompilerServer({
   onFileRemoved: (filePath: string) => void
 }) {
   const pkg = getPackageInfo(root)
+  const compilerExternals = mergeExternals(
+    viteConfig.ssr?.external,
+    viteConfig.environments?.['ssr']?.resolve?.external,
+    VANILLA_EXTRACT_EXTERNALS,
+  )
 
   const server = await createServer({
     ...viteConfig,
@@ -262,21 +272,18 @@ async function createCompilerServer({
     build: {
       assetsInlineLimit: viteConfig.build?.assetsInlineLimit,
     },
-    // Parent app configs (notably `sanity build`) can enable the `browser` condition. Omit it
-    // from every resolver the ModuleRunner can use while preserving custom conditions: this
-    // server evaluates `.css.ts` modules in Node, where vanilla-extract's browser runtime would
-    // export class names without collecting their CSS through our adapter.
-    resolve: {
-      ...viteConfig.resolve,
-      conditions: withoutBrowser(viteConfig.resolve?.conditions),
-      mainFields: withoutBrowser(viteConfig.resolve?.mainFields),
-    },
-    ssr: {
-      ...viteConfig.ssr,
-      resolve: {
-        ...viteConfig.ssr?.resolve,
-        conditions: withoutBrowser(viteConfig.ssr?.resolve?.conditions),
-        externalConditions: withoutBrowser(viteConfig.ssr?.resolve?.externalConditions),
+    // `ModuleRunner` only native-imports bare dependencies that its SSR environment marks as
+    // external. This must override a parent `noExternal: true`: returning an absolute
+    // `external: true` id from `resolveId` is too late, because Vite rewrites it to `/@fs/…`
+    // and evaluates it inline.
+    environments: {
+      ...viteConfig.environments,
+      ssr: {
+        ...viteConfig.environments?.['ssr'],
+        resolve: {
+          ...viteConfig.environments?.['ssr']?.resolve,
+          external: compilerExternals,
+        },
       },
     },
     // Vite's default SSR externalization applies: project files and linked packages are

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio/.gitignore
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio/.gitignore
@@ -1,0 +1,2 @@
+.sanity
+node_modules

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio/package.json
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@fixtures/vanilla-extract-vite-plugin-sanity-studio",
+  "version": "0.0.0-development",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@sanity/vanilla-extract-vite-plugin": "workspace:*",
+    "@vanilla-extract/css": "^1.21.1",
+    "@vanilla-extract/vite-plugin": "^5.2.5",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "sanity": "^6.4.0",
+    "styled-components": "^6.4.3",
+    "vite": "^8.1.5"
+  }
+}

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio/sanity.cli.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio/sanity.cli.ts
@@ -1,0 +1,39 @@
+import {vanillaExtractPlugin as sanityVanillaExtractPlugin} from '@sanity/vanilla-extract-vite-plugin'
+import {vanillaExtractPlugin as officialVanillaExtractPlugin} from '@vanilla-extract/vite-plugin'
+import {defineCliConfig} from 'sanity/cli'
+
+const pluginKind = process.env['VE_STUDIO_PLUGIN']
+if (pluginKind !== 'official' && pluginKind !== 'sanity') {
+  throw new Error('VE_STUDIO_PLUGIN must be "official" or "sanity"')
+}
+
+const identifierMode = process.env['VE_STUDIO_IDENTIFIERS']
+if (identifierMode !== 'short' && identifierMode !== 'debug' && identifierMode !== 'custom') {
+  throw new Error('VE_STUDIO_IDENTIFIERS must be "short", "debug", or "custom"')
+}
+
+const identifiers =
+  identifierMode === 'custom' ? ({hash}: {hash: string}) => `parity_${hash}` : identifierMode
+const vanillaExtractPlugin =
+  pluginKind === 'official' ? officialVanillaExtractPlugin : sanityVanillaExtractPlugin
+
+export default defineCliConfig({
+  api: {projectId: 'ppsg7ml5', dataset: 'test'},
+  vite: {
+    cacheDir: process.env['VE_STUDIO_CACHE_DIR'],
+    plugins: [vanillaExtractPlugin({identifiers})],
+    // Sanity's schema extraction config forces SSR dependencies inline. Keeping that constraint
+    // explicit here ensures both plugins remain safe when their compiler evaluates CommonJS
+    // transitive dependencies such as picocolors.
+    ssr: {noExternal: true},
+    // Production Studio builds include the browser condition. The compiler still evaluates
+    // styles in Node and must match the official plugin without mutating the parent conditions.
+    resolve: {conditions: ['browser', 'module', 'import', 'default']},
+    build: {
+      cssMinify: process.env['VE_STUDIO_CSS_MINIFY'] === '1',
+      cssTarget: process.env['VE_STUDIO_CSS_TARGET'] || 'esnext',
+      minify: false,
+      sourcemap: false,
+    },
+  },
+})

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio/sanity.config.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio/sanity.config.ts
@@ -1,0 +1,27 @@
+import {defineConfig, defineField, defineType} from 'sanity'
+import {studioMarker} from './src/styles.css'
+
+const parityDocument = defineType({
+  name: 'parityDocument',
+  title: 'Parity document',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      description: `vanilla-extract:${studioMarker}`,
+    }),
+  ],
+})
+
+export default defineConfig({
+  name: 'default',
+  title: 'Vanilla Extract parity',
+  projectId: 'ppsg7ml5',
+  dataset: 'test',
+  schema: {types: [parityDocument]},
+  tasks: {enabled: false},
+  scheduledPublishing: {enabled: false},
+  announcements: {enabled: false},
+})

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio/src/styles.css.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio/src/styles.css.ts
@@ -1,0 +1,8 @@
+import {style} from '@vanilla-extract/css'
+
+export const studioMarker = style({
+  position: 'fixed',
+  inset: 0,
+  borderTop: '3px solid rgb(1, 2, 3)',
+  userSelect: 'none',
+})

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
@@ -61,12 +61,15 @@ function createTestCompiler(root: string, enableFileWatcher = false): Compiler {
 }
 
 describe('vite build', () => {
-  test('feeds the extracted CSS through Vite’s CSS pipeline', async () => {
+  test('extracts CSS when the parent enables the browser resolve condition', async () => {
     const result = await build({
       root: appRoot,
       configFile: false,
       logLevel: 'silent',
       plugins: [vanillaExtractPlugin()],
+      // `sanity build` explicitly enables `browser`; the compiler still evaluates `.css.ts`
+      // modules in Node and must not resolve vanilla-extract's browser runtime.
+      resolve: {conditions: ['browser', 'module', 'import', 'default']},
       build: {write: false},
     })
     const {output} = Array.isArray(result) ? result[0]! : (result as Rollup.RollupOutput)

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
@@ -310,18 +310,18 @@ describe('compiler', () => {
     expect(allCss).toContain('rgb(4, 5, 6)')
   })
 
-  test('forces Node resolution in the compiler server', async () => {
+  test('filters browser resolution from the compiler server', async () => {
     let compilerConfig: ResolvedConfig | undefined
-    const browserConditions = ['browser', 'module', 'import', 'default']
+    const parentConditions = ['browser', 'custom', 'module', 'import', 'default']
     const compiler = createTestCompiler(appRoot, false, {
       resolve: {
-        conditions: browserConditions,
-        mainFields: ['browser', 'module', 'main'],
+        conditions: parentConditions,
+        mainFields: ['browser', 'custom', 'module', 'main'],
       },
       ssr: {
         resolve: {
-          conditions: browserConditions,
-          externalConditions: browserConditions,
+          conditions: parentConditions,
+          externalConditions: parentConditions,
         },
       },
       plugins: [
@@ -339,15 +339,13 @@ describe('compiler', () => {
     expect(compiler.getCssForFile(stylesCssTs)?.css).toContain('rgb(1, 2, 3)')
 
     if (!compilerConfig) expect.unreachable('expected the compiler server config')
-    expect(compilerConfig.resolve.conditions).toEqual(['node', 'import', 'module', 'default'])
-    expect(compilerConfig.resolve.mainFields).toEqual(['module', 'jsnext:main', 'jsnext', 'main'])
-    expect(compilerConfig.ssr.resolve?.conditions).toEqual(['node', 'import', 'module', 'default'])
-    expect(compilerConfig.ssr.resolve?.externalConditions).toEqual([
-      'node',
-      'import',
-      'module',
-      'default',
-    ])
+    const expectedConditions = ['custom', 'module', 'import', 'default']
+    expect(compilerConfig.resolve.conditions).toEqual(expectedConditions)
+    expect(compilerConfig.resolve.mainFields).toEqual(['custom', 'module', 'main'])
+    expect(compilerConfig.ssr.resolve?.conditions).toEqual(expectedConditions)
+    expect(compilerConfig.ssr.resolve?.externalConditions).toEqual(expectedConditions)
+    expect(compilerConfig.environments.ssr.resolve.conditions).toEqual(expectedConditions)
+    expect(compilerConfig.environments.ssr.resolve.externalConditions).toEqual(expectedConditions)
   })
 
   test('collects transitive watch files', async () => {

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
@@ -344,8 +344,10 @@ describe('compiler', () => {
     expect(compilerConfig.resolve.mainFields).toEqual(['custom', 'module', 'main'])
     expect(compilerConfig.ssr.resolve?.conditions).toEqual(expectedConditions)
     expect(compilerConfig.ssr.resolve?.externalConditions).toEqual(expectedConditions)
-    expect(compilerConfig.environments.ssr.resolve.conditions).toEqual(expectedConditions)
-    expect(compilerConfig.environments.ssr.resolve.externalConditions).toEqual(expectedConditions)
+    const ssrEnvironment = compilerConfig.environments['ssr']
+    if (!ssrEnvironment) expect.unreachable('expected the compiler SSR environment')
+    expect(ssrEnvironment.resolve.conditions).toEqual(expectedConditions)
+    expect(ssrEnvironment.resolve.externalConditions).toEqual(expectedConditions)
   })
 
   test('collects transitive watch files', async () => {

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
@@ -340,18 +340,8 @@ describe('compiler', () => {
 
     if (!compilerConfig) expect.unreachable('expected the compiler server config')
     expect(compilerConfig.resolve.conditions).toEqual(['node', 'import', 'module', 'default'])
-    expect(compilerConfig.resolve.mainFields).toEqual([
-      'module',
-      'jsnext:main',
-      'jsnext',
-      'main',
-    ])
-    expect(compilerConfig.ssr.resolve?.conditions).toEqual([
-      'node',
-      'import',
-      'module',
-      'default',
-    ])
+    expect(compilerConfig.resolve.mainFields).toEqual(['module', 'jsnext:main', 'jsnext', 'main'])
+    expect(compilerConfig.ssr.resolve?.conditions).toEqual(['node', 'import', 'module', 'default'])
     expect(compilerConfig.ssr.resolve?.externalConditions).toEqual([
       'node',
       'import',

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
@@ -78,8 +78,8 @@ describe('vite build', () => {
       configFile: false,
       logLevel: 'silent',
       plugins: [vanillaExtractPlugin()],
-      // `sanity build` explicitly enables `browser`; the compiler still evaluates `.css.ts`
-      // modules in Node and must not resolve vanilla-extract's browser runtime.
+      // `sanity build` explicitly enables `browser`; the compiler's SSR environment still
+      // native-externalizes vanilla-extract and collects through the injected adapter.
       resolve: {conditions: ['browser', 'module', 'import', 'default']},
       build: {write: false},
     })
@@ -310,7 +310,7 @@ describe('compiler', () => {
     expect(allCss).toContain('rgb(4, 5, 6)')
   })
 
-  test('filters browser resolution from the compiler server', async () => {
+  test('preserves parent resolution options in the compiler server', async () => {
     let compilerConfig: ResolvedConfig | undefined
     const parentConditions = ['browser', 'custom', 'module', 'import', 'default']
     const compiler = createTestCompiler(appRoot, false, {
@@ -339,15 +339,43 @@ describe('compiler', () => {
     expect(compiler.getCssForFile(stylesCssTs)?.css).toContain('rgb(1, 2, 3)')
 
     if (!compilerConfig) expect.unreachable('expected the compiler server config')
-    const expectedConditions = ['custom', 'module', 'import', 'default']
-    expect(compilerConfig.resolve.conditions).toEqual(expectedConditions)
-    expect(compilerConfig.resolve.mainFields).toEqual(['custom', 'module', 'main'])
-    expect(compilerConfig.ssr.resolve?.conditions).toEqual(expectedConditions)
-    expect(compilerConfig.ssr.resolve?.externalConditions).toEqual(expectedConditions)
+    expect(compilerConfig.resolve.conditions).toEqual(parentConditions)
+    expect(compilerConfig.resolve.mainFields).toEqual(['browser', 'custom', 'module', 'main'])
+    expect(compilerConfig.ssr.resolve?.conditions).toEqual(parentConditions)
+    expect(compilerConfig.ssr.resolve?.externalConditions).toEqual(parentConditions)
     const ssrEnvironment = compilerConfig.environments['ssr']
     if (!ssrEnvironment) expect.unreachable('expected the compiler SSR environment')
-    expect(ssrEnvironment.resolve.conditions).toEqual(expectedConditions)
-    expect(ssrEnvironment.resolve.externalConditions).toEqual(expectedConditions)
+    expect(ssrEnvironment.resolve.conditions).toEqual(parentConditions)
+    expect(ssrEnvironment.resolve.externalConditions).toEqual(parentConditions)
+  })
+
+  test('collects CSS when the parent forces SSR dependencies to be inlined', async () => {
+    let compilerConfig: ResolvedConfig | undefined
+    const compiler = createTestCompiler(appRoot, false, {
+      ssr: {noExternal: true},
+      plugins: [
+        {
+          name: 'capture-compiler-config',
+          configResolved(config) {
+            compilerConfig = config
+          },
+        },
+      ],
+    })
+
+    const result = await compiler.processVanillaFile(stylesCssTs)
+
+    expect(result.source).toContain('.vanilla.css')
+    expect(compiler.getCssForFile(stylesCssTs)?.css).toContain('rgb(1, 2, 3)')
+    if (!compilerConfig) expect.unreachable('expected the compiler server config')
+    expect(compilerConfig.environments['ssr']?.resolve.noExternal).toBe(true)
+    expect(compilerConfig.environments['ssr']?.resolve.external).toEqual(
+      expect.arrayContaining([
+        '@vanilla-extract/css',
+        '@vanilla-extract/css/fileScope',
+        '@vanilla-extract/css/adapter',
+      ]),
+    )
   })
 
   test('collects transitive watch files', async () => {

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
@@ -2,7 +2,14 @@ import {mkdir, rm, writeFile} from 'node:fs/promises'
 import path from 'node:path'
 import {fileURLToPath} from 'node:url'
 import {normalizePath} from '@sanity/vanilla-extract-integration'
-import {build, createServer, type Plugin, type Rollup} from 'vite'
+import {
+  build,
+  createServer,
+  type Plugin,
+  type ResolvedConfig,
+  type Rollup,
+  type UserConfig,
+} from 'vite'
 import {afterEach, describe, expect, test} from 'vitest'
 import {createCompiler, vanillaExtractPlugin, type Compiler} from '../src/index.ts'
 
@@ -54,8 +61,12 @@ afterEach(async () => {
   await Promise.all(compilersToClose.splice(0).map((compiler) => compiler.close()))
 })
 
-function createTestCompiler(root: string, enableFileWatcher = false): Compiler {
-  const compiler = createCompiler({root, identifiers: 'debug', enableFileWatcher})
+function createTestCompiler(
+  root: string,
+  enableFileWatcher = false,
+  viteConfig?: UserConfig,
+): Compiler {
+  const compiler = createCompiler({root, identifiers: 'debug', enableFileWatcher, viteConfig})
   compilersToClose.push(compiler)
   return compiler
 }
@@ -297,6 +308,56 @@ describe('compiler', () => {
     const allCss = compiler.getAllCss()
     expect(allCss).toContain('rgb(1, 2, 3)')
     expect(allCss).toContain('rgb(4, 5, 6)')
+  })
+
+  test('forces Node resolution in the compiler server', async () => {
+    let compilerConfig: ResolvedConfig | undefined
+    const browserConditions = ['browser', 'module', 'import', 'default']
+    const compiler = createTestCompiler(appRoot, false, {
+      resolve: {
+        conditions: browserConditions,
+        mainFields: ['browser', 'module', 'main'],
+      },
+      ssr: {
+        resolve: {
+          conditions: browserConditions,
+          externalConditions: browserConditions,
+        },
+      },
+      plugins: [
+        {
+          name: 'capture-compiler-config',
+          configResolved(config) {
+            compilerConfig = config
+          },
+        },
+      ],
+    })
+
+    const result = await compiler.processVanillaFile(stylesCssTs)
+    expect(result.source).toContain('.vanilla.css')
+    expect(compiler.getCssForFile(stylesCssTs)?.css).toContain('rgb(1, 2, 3)')
+
+    if (!compilerConfig) expect.unreachable('expected the compiler server config')
+    expect(compilerConfig.resolve.conditions).toEqual(['node', 'import', 'module', 'default'])
+    expect(compilerConfig.resolve.mainFields).toEqual([
+      'module',
+      'jsnext:main',
+      'jsnext',
+      'main',
+    ])
+    expect(compilerConfig.ssr.resolve?.conditions).toEqual([
+      'node',
+      'import',
+      'module',
+      'default',
+    ])
+    expect(compilerConfig.ssr.resolve?.externalConditions).toEqual([
+      'node',
+      'import',
+      'module',
+      'default',
+    ])
   })
 
   test('collects transitive watch files', async () => {

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/studio.test.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/studio.test.ts
@@ -243,9 +243,7 @@ function assertIdentifier(className: string, identifiers: IdentifierMode): void 
 function assertBuildVariant(artifact: BuildArtifact, variant: BuildVariant): void {
   assertIdentifier(artifact.className, variant.identifiers)
   expect(artifact.stylesheetLinkCount).toBeGreaterThan(0)
-  expect(artifact.markerColor).toBe(
-    variant.cssMinify || variant.cssTarget === 'chrome61' ? 'hex' : 'rgb',
-  )
+  expect(artifact.markerColor).toBe(variant.cssMinify ? 'hex' : 'rgb')
 
   if (variant.cssTarget === 'chrome61') {
     expect(artifact.declarations).not.toContain('inset:0')
@@ -290,12 +288,14 @@ function findSchemaMarker(value: unknown): string | undefined {
 async function extractSchema(plugin: PluginKind, identifiers: IdentifierMode): Promise<unknown> {
   const outputPath = path.join(temporaryRoot, 'schema', `${identifiers}-${plugin}.json`)
   await mkdir(path.dirname(outputPath), {recursive: true})
+  // The CLI joins `--path` to the Studio root rather than resolving an absolute path.
+  const outputArgument = path.relative(fixtureRoot, outputPath)
   await runSanity(
     [
       'schemas',
       'extract',
       '--path',
-      outputPath,
+      outputArgument,
       '--workspace',
       'default',
       '--enforce-required-fields',

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/studio.test.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/studio.test.ts
@@ -300,7 +300,13 @@ async function getFreePort(): Promise<number> {
     throw new Error('Could not allocate a TCP port')
   }
   await new Promise<void>((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()))
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
   })
   return address.port
 }

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/studio.test.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/studio.test.ts
@@ -245,7 +245,9 @@ function assertBuildVariant(artifact: BuildArtifact, variant: BuildVariant): voi
   expect(artifact.stylesheetLinkCount).toBeGreaterThan(0)
   expect(artifact.markerColor).toBe(variant.cssMinify ? 'hex' : 'rgb')
 
-  if (variant.cssTarget === 'chrome61') {
+  // Vite applies `cssTarget` in its CSS minifier; with minification disabled it deliberately
+  // leaves the authored syntax untouched.
+  if (variant.cssMinify && variant.cssTarget === 'chrome61') {
     expect(artifact.declarations).not.toContain('inset:0')
     expect(artifact.declarations).toEqual(
       expect.arrayContaining(['top:0', 'right:0', 'bottom:0', 'left:0']),
@@ -263,26 +265,6 @@ async function runBuild(plugin: PluginKind, variant: BuildVariant): Promise<Buil
     studioEnvironment(plugin, variant.identifiers, `build-${variant.slug}`, variant),
   )
   return readBuildArtifact(outputDirectory)
-}
-
-function findSchemaMarker(value: unknown): string | undefined {
-  if (typeof value === 'string') {
-    return value.startsWith('vanilla-extract:') ? value.slice('vanilla-extract:'.length) : undefined
-  }
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      const marker = findSchemaMarker(entry)
-      if (marker) return marker
-    }
-    return undefined
-  }
-  if (isRecord(value)) {
-    for (const entry of Object.values(value)) {
-      const marker = findSchemaMarker(entry)
-      if (marker) return marker
-    }
-  }
-  return undefined
 }
 
 async function extractSchema(plugin: PluginKind, identifiers: IdentifierMode): Promise<unknown> {
@@ -411,12 +393,7 @@ describe.sequential('Sanity Studio integration parity', () => {
     'matches the official schema extraction with %s identifiers',
     async (identifiers) => {
       const official = await extractSchema('official', identifiers)
-      const officialMarker = findSchemaMarker(official)
-      expect(officialMarker).toBeTruthy()
-      assertIdentifier(officialMarker!, identifiers)
-
       const sanity = await extractSchema('sanity', identifiers)
-      expect(findSchemaMarker(sanity)).toBe(officialMarker)
       expect(sanity).toEqual(official)
     },
     180_000,

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/studio.test.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/studio.test.ts
@@ -1,0 +1,437 @@
+import {spawn} from 'node:child_process'
+import {readFileSync} from 'node:fs'
+import {mkdir, mkdtemp, readdir, readFile, rm} from 'node:fs/promises'
+import {createRequire} from 'node:module'
+import {createServer} from 'node:net'
+import {tmpdir} from 'node:os'
+import path from 'node:path'
+import {afterAll, beforeAll, describe, expect, test} from 'vitest'
+
+type PluginKind = 'official' | 'sanity'
+type IdentifierMode = 'short' | 'debug' | 'custom'
+
+interface BuildVariant {
+  slug: string
+  identifiers: IdentifierMode
+  cssMinify: boolean
+  cssTarget: 'esnext' | 'chrome61'
+}
+
+interface ProcessExit {
+  code: number | null
+  signal: NodeJS.Signals | null
+}
+
+interface RunningSanity {
+  child: ReturnType<typeof spawn>
+  completed: Promise<ProcessExit>
+  output: () => string
+}
+
+interface StyleArtifact {
+  className: string
+  declarations: string[]
+  markerColor: 'hex' | 'rgb'
+}
+
+interface BuildArtifact extends StyleArtifact {
+  cssFileCount: number
+  stylesheetLinkCount: number
+}
+
+const fixtureRoot = path.join(import.meta.dirname, 'fixtures/studio')
+const requireFromFixture = createRequire(path.join(fixtureRoot, 'package.json'))
+const markerColorPattern = /rgb\(\s*1\s*,\s*2\s*,\s*3\s*\)|#010203/i
+
+const buildVariants = [
+  {slug: 'short-expanded', identifiers: 'short', cssMinify: false, cssTarget: 'esnext'},
+  {slug: 'short-minified-target', identifiers: 'short', cssMinify: true, cssTarget: 'chrome61'},
+  {slug: 'debug-target', identifiers: 'debug', cssMinify: false, cssTarget: 'chrome61'},
+  {slug: 'debug-minified', identifiers: 'debug', cssMinify: true, cssTarget: 'esnext'},
+  {slug: 'custom-expanded', identifiers: 'custom', cssMinify: false, cssTarget: 'esnext'},
+  {
+    slug: 'custom-minified-target',
+    identifiers: 'custom',
+    cssMinify: true,
+    cssTarget: 'chrome61',
+  },
+] as const satisfies readonly BuildVariant[]
+
+let temporaryRoot = ''
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function resolvePackageBin(packageName: string, binName: string): string {
+  const packageJsonPath = requireFromFixture.resolve(`${packageName}/package.json`)
+  const manifest: unknown = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+  if (!isRecord(manifest)) throw new Error(`Invalid package manifest at ${packageJsonPath}`)
+
+  const bin = manifest['bin']
+  const relativeBin =
+    typeof bin === 'string'
+      ? bin
+      : isRecord(bin) && typeof bin[binName] === 'string'
+        ? bin[binName]
+        : undefined
+  if (!relativeBin) throw new Error(`Could not resolve ${binName} from ${packageJsonPath}`)
+  return path.resolve(path.dirname(packageJsonPath), relativeBin)
+}
+
+const sanityBin = resolvePackageBin('sanity', 'sanity')
+
+function startSanity(arguments_: string[], environment: NodeJS.ProcessEnv): RunningSanity {
+  const child = spawn(process.execPath, [sanityBin, ...arguments_], {
+    cwd: fixtureRoot,
+    env: {
+      ...process.env,
+      CI: '1',
+      FORCE_COLOR: '0',
+      NO_COLOR: '1',
+      SANITY_TELEMETRY_DISABLED: '1',
+      ...environment,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  })
+
+  let stderr = ''
+  let stdout = ''
+  child.stderr?.setEncoding('utf8')
+  child.stdout?.setEncoding('utf8')
+  child.stderr?.on('data', (chunk: string) => {
+    stderr += chunk
+  })
+  child.stdout?.on('data', (chunk: string) => {
+    stdout += chunk
+  })
+
+  const completed = new Promise<ProcessExit>((resolve, reject) => {
+    child.on('error', reject)
+    child.on('close', (code, signal) => resolve({code, signal}))
+  })
+
+  return {
+    child,
+    completed,
+    output: () => `${stdout}\n${stderr}`.trim(),
+  }
+}
+
+async function waitForCompletion(running: RunningSanity, timeout: number): Promise<ProcessExit> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const timedOut = new Promise<never>((_resolve, reject) => {
+    timeoutId = setTimeout(() => {
+      running.child.kill('SIGKILL')
+      reject(new Error(`Sanity command timed out after ${timeout}ms\n${running.output()}`))
+    }, timeout)
+  })
+
+  try {
+    return await Promise.race([running.completed, timedOut])
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId)
+  }
+}
+
+async function runSanity(arguments_: string[], environment: NodeJS.ProcessEnv): Promise<string> {
+  const running = startSanity(arguments_, environment)
+  const {code, signal} = await waitForCompletion(running, 120_000)
+  if (code !== 0) {
+    throw new Error(
+      `Sanity exited with ${code === null ? `signal ${signal ?? 'unknown'}` : `code ${code}`}\n${running.output()}`,
+    )
+  }
+  return running.output()
+}
+
+async function stopSanity(running: RunningSanity): Promise<void> {
+  if (running.child.exitCode !== null || running.child.signalCode !== null) return
+  running.child.kill('SIGTERM')
+
+  const stopped = await Promise.race([
+    running.completed.then(() => true),
+    new Promise<false>((resolve) => setTimeout(() => resolve(false), 5_000)),
+  ])
+  if (stopped || running.child.exitCode !== null || running.child.signalCode !== null) return
+
+  running.child.kill('SIGKILL')
+  await running.completed
+}
+
+function studioEnvironment(
+  plugin: PluginKind,
+  identifiers: IdentifierMode,
+  scenario: string,
+  options: {cssMinify?: boolean; cssTarget?: BuildVariant['cssTarget']} = {},
+): NodeJS.ProcessEnv {
+  return {
+    VE_STUDIO_CACHE_DIR: path.join(temporaryRoot, 'vite-cache', `${scenario}-${plugin}`),
+    VE_STUDIO_CSS_MINIFY: options.cssMinify ? '1' : '0',
+    VE_STUDIO_CSS_TARGET: options.cssTarget ?? 'esnext',
+    VE_STUDIO_IDENTIFIERS: identifiers,
+    VE_STUDIO_PLUGIN: plugin,
+  }
+}
+
+async function listFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, {withFileTypes: true})
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(directory, entry.name)
+      return entry.isDirectory() ? listFiles(entryPath) : [entryPath]
+    }),
+  )
+  return files.flat()
+}
+
+function extractStyleArtifact(css: string): StyleArtifact {
+  const withoutComments = css.replaceAll(/\/\*[\s\S]*?\*\//g, '')
+  const rule = [...withoutComments.matchAll(/([^{}]+)\{([^{}]*)\}/g)].find((match) =>
+    markerColorPattern.test(match[2] ?? ''),
+  )
+  if (!rule?.[1] || !rule[2]) throw new Error(`Could not find marker rule in CSS:\n${css}`)
+
+  const className = rule[1].match(/\.([_a-zA-Z][\w-]*)/)?.[1]
+  if (!className) throw new Error(`Could not find marker class in selector: ${rule[1]}`)
+
+  const markerColor = rule[2].match(markerColorPattern)?.[0]
+  if (!markerColor) throw new Error(`Could not find marker color in rule: ${rule[2]}`)
+
+  const declarations = rule[2]
+    .split(';')
+    .map((declaration) =>
+      declaration.trim().replace(markerColorPattern, '#010203').replaceAll(/\s+/g, ''),
+    )
+    .filter(Boolean)
+    .toSorted()
+
+  return {
+    className,
+    declarations,
+    markerColor: markerColor.startsWith('#') ? 'hex' : 'rgb',
+  }
+}
+
+async function readBuildArtifact(outputDirectory: string): Promise<BuildArtifact> {
+  const files = await listFiles(outputDirectory)
+  const cssFiles = files.filter((filePath) => filePath.endsWith('.css')).toSorted()
+  if (cssFiles.length === 0) throw new Error(`No CSS files found in ${outputDirectory}`)
+
+  const css = (await Promise.all(cssFiles.map((filePath) => readFile(filePath, 'utf8')))).join('\n')
+  const html = await readFile(path.join(outputDirectory, 'index.html'), 'utf8')
+  return {
+    ...extractStyleArtifact(css),
+    cssFileCount: cssFiles.length,
+    stylesheetLinkCount: [...html.matchAll(/<link\b(?=[^>]*\brel=["']stylesheet["'])[^>]*>/gi)]
+      .length,
+  }
+}
+
+function assertIdentifier(className: string, identifiers: IdentifierMode): void {
+  if (identifiers === 'debug') {
+    expect(className).toContain('styles_studioMarker__')
+  } else if (identifiers === 'custom') {
+    expect(className).toMatch(/^parity_[\w-]+$/)
+  } else {
+    expect(className).not.toContain('studioMarker')
+    expect(className).not.toMatch(/^parity_/)
+  }
+}
+
+function assertBuildVariant(artifact: BuildArtifact, variant: BuildVariant): void {
+  assertIdentifier(artifact.className, variant.identifiers)
+  expect(artifact.stylesheetLinkCount).toBeGreaterThan(0)
+  expect(artifact.markerColor).toBe(
+    variant.cssMinify || variant.cssTarget === 'chrome61' ? 'hex' : 'rgb',
+  )
+
+  if (variant.cssTarget === 'chrome61') {
+    expect(artifact.declarations).not.toContain('inset:0')
+    expect(artifact.declarations).toEqual(
+      expect.arrayContaining(['top:0', 'right:0', 'bottom:0', 'left:0']),
+    )
+  } else {
+    expect(artifact.declarations).toContain('inset:0')
+  }
+}
+
+async function runBuild(plugin: PluginKind, variant: BuildVariant): Promise<BuildArtifact> {
+  const outputDirectory = path.join(temporaryRoot, 'build', `${variant.slug}-${plugin}`)
+  await rm(outputDirectory, {recursive: true, force: true})
+  await runSanity(
+    ['build', outputDirectory, '--yes', '--no-auto-updates', '--no-minify', '--no-source-maps'],
+    studioEnvironment(plugin, variant.identifiers, `build-${variant.slug}`, variant),
+  )
+  return readBuildArtifact(outputDirectory)
+}
+
+function findSchemaMarker(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value.startsWith('vanilla-extract:') ? value.slice('vanilla-extract:'.length) : undefined
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const marker = findSchemaMarker(entry)
+      if (marker) return marker
+    }
+    return undefined
+  }
+  if (isRecord(value)) {
+    for (const entry of Object.values(value)) {
+      const marker = findSchemaMarker(entry)
+      if (marker) return marker
+    }
+  }
+  return undefined
+}
+
+async function extractSchema(plugin: PluginKind, identifiers: IdentifierMode): Promise<unknown> {
+  const outputPath = path.join(temporaryRoot, 'schema', `${identifiers}-${plugin}.json`)
+  await mkdir(path.dirname(outputPath), {recursive: true})
+  await runSanity(
+    [
+      'schemas',
+      'extract',
+      '--path',
+      outputPath,
+      '--workspace',
+      'default',
+      '--enforce-required-fields',
+    ],
+    studioEnvironment(plugin, identifiers, `schema-${identifiers}`),
+  )
+  return JSON.parse(await readFile(outputPath, 'utf8')) as unknown
+}
+
+async function getFreePort(): Promise<number> {
+  const server = createServer()
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    server.close()
+    throw new Error('Could not allocate a TCP port')
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()))
+  })
+  return address.port
+}
+
+async function waitForServer(url: string, running: RunningSanity): Promise<void> {
+  const deadline = Date.now() + 60_000
+  while (Date.now() < deadline) {
+    if (running.child.exitCode !== null || running.child.signalCode !== null) {
+      const {code, signal} = await running.completed
+      throw new Error(
+        `Sanity dev exited with ${code === null ? `signal ${signal ?? 'unknown'}` : `code ${code}`}\n${running.output()}`,
+      )
+    }
+
+    try {
+      const response = await fetch(url, {signal: AbortSignal.timeout(1_000)})
+      if (response.ok) return
+    } catch {
+      // The dev server is still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  throw new Error(`Sanity dev did not become ready at ${url}\n${running.output()}`)
+}
+
+function extractDevCss(source: string): string {
+  const literal = source.match(/const __vite__css\s*=\s*("(?:\\.|[^"\\])*")/)?.[1]
+  if (!literal) throw new Error(`Could not find Vite's CSS payload:\n${source}`)
+  const css: unknown = JSON.parse(literal)
+  if (typeof css !== 'string') throw new Error('Vite CSS payload was not a string')
+  return css
+}
+
+async function runDev(plugin: PluginKind, identifiers: IdentifierMode): Promise<StyleArtifact> {
+  const port = await getFreePort()
+  const origin = `http://127.0.0.1:${port}`
+  const running = startSanity(
+    ['dev', '--host', '127.0.0.1', '--port', String(port), '--no-auto-updates'],
+    studioEnvironment(plugin, identifiers, `dev-${identifiers}`),
+  )
+
+  try {
+    await waitForServer(origin, running)
+    const moduleResponse = await fetch(`${origin}/src/styles.css.ts`)
+    expect(moduleResponse.ok).toBe(true)
+    const moduleSource = await moduleResponse.text()
+
+    const className = moduleSource.match(
+      /(?:const|let|var)\s+studioMarker\s*=\s*["']([^"']+)["']/,
+    )?.[1]
+    if (!className) throw new Error(`Could not find studioMarker export:\n${moduleSource}`)
+
+    const virtualCssPath = moduleSource.match(/import\s+["']([^"']+\.vanilla\.css[^"']*)["']/)?.[1]
+    if (!virtualCssPath) throw new Error(`Could not find virtual CSS import:\n${moduleSource}`)
+
+    const cssResponse = await fetch(new URL(virtualCssPath, origin))
+    expect(cssResponse.ok).toBe(true)
+    const css = extractDevCss(await cssResponse.text())
+    const artifact = extractStyleArtifact(css)
+    expect(artifact.className).toBe(className)
+    return artifact
+  } finally {
+    await stopSanity(running)
+  }
+}
+
+describe.sequential('Sanity Studio integration parity', () => {
+  beforeAll(async () => {
+    temporaryRoot = await mkdtemp(path.join(tmpdir(), 'vanilla-extract-sanity-studio-'))
+  })
+
+  afterAll(async () => {
+    if (temporaryRoot) await rm(temporaryRoot, {recursive: true, force: true})
+  })
+
+  test.each(buildVariants)(
+    'matches the official build with $slug',
+    async (variant) => {
+      const official = await runBuild('official', variant)
+      assertBuildVariant(official, variant)
+
+      const sanity = await runBuild('sanity', variant)
+      assertBuildVariant(sanity, variant)
+      expect(sanity).toEqual(official)
+    },
+    240_000,
+  )
+
+  test.each(['short', 'debug', 'custom'] as const)(
+    'matches the official schema extraction with %s identifiers',
+    async (identifiers) => {
+      const official = await extractSchema('official', identifiers)
+      const officialMarker = findSchemaMarker(official)
+      expect(officialMarker).toBeTruthy()
+      assertIdentifier(officialMarker!, identifiers)
+
+      const sanity = await extractSchema('sanity', identifiers)
+      expect(findSchemaMarker(sanity)).toBe(officialMarker)
+      expect(sanity).toEqual(official)
+    },
+    180_000,
+  )
+
+  test.each(['short', 'debug', 'custom'] as const)(
+    'matches the official dev output with %s identifiers',
+    async (identifiers) => {
+      const official = await runDev('official', identifiers)
+      assertIdentifier(official.className, identifiers)
+
+      const sanity = await runDev('sanity', identifiers)
+      assertIdentifier(sanity.className, identifiers)
+      expect(sanity).toEqual(official)
+    },
+    180_000,
+  )
+})

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/studio.test.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/studio.test.ts
@@ -3,7 +3,6 @@ import {readFileSync} from 'node:fs'
 import {mkdir, mkdtemp, readdir, readFile, rm} from 'node:fs/promises'
 import {createRequire} from 'node:module'
 import {createServer} from 'node:net'
-import {tmpdir} from 'node:os'
 import path from 'node:path'
 import {afterAll, beforeAll, describe, expect, test} from 'vitest'
 
@@ -375,7 +374,11 @@ async function runDev(plugin: PluginKind, identifiers: IdentifierMode): Promise<
 
 describe.sequential('Sanity Studio integration parity', () => {
   beforeAll(async () => {
-    temporaryRoot = await mkdtemp(path.join(tmpdir(), 'vanilla-extract-sanity-studio-'))
+    // Sanity joins `schemas extract --path` to the Studio root. Keep artifacts on that root's
+    // drive so Windows does not turn `path.relative()` into an absolute cross-drive path.
+    const artifactsRoot = path.join(fixtureRoot, '.sanity')
+    await mkdir(artifactsRoot, {recursive: true})
+    temporaryRoot = await mkdtemp(path.join(artifactsRoot, 'vanilla-extract-studio-'))
   })
 
   afterAll(async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,7 +311,7 @@ importers:
         version: link:../sanity-css-vanilla-extract-test
       tap:
         specifier: ^21.7.4
-        version: 21.7.4(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+        version: 21.7.4(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1092,6 +1092,33 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio:
+    devDependencies:
+      '@sanity/vanilla-extract-vite-plugin':
+        specifier: workspace:*
+        version: link:../../..
+      '@vanilla-extract/css':
+        specifier: ^1.21.1
+        version: 1.21.1
+      '@vanilla-extract/vite-plugin':
+        specifier: ^5.2.5
+        version: 5.2.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      sanity:
+        specifier: ^6.4.0
+        version: 6.5.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.14)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(@sanity/cli-core@2.4.0(@noble/hashes@2.2.0)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.2.0)(styled-components@6.4.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.49.0)(typescript@7.0.2)
+      styled-components:
+        specifier: ^6.4.3
+        version: 6.4.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      vite:
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   playground/babel-plugin:
     devDependencies:
@@ -17006,14 +17033,14 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@5.9.3)':
+  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@5.9.3)':
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node14': 14.1.8
       '@tsconfig/node16': 16.1.8
       '@tsconfig/node18': 18.2.6
       '@tsconfig/node20': 20.1.9
-      '@types/node': 24.13.3
+      '@types/node': 26.1.1
       acorn: 8.17.0
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -17024,14 +17051,14 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.43(@swc/helpers@0.5.23)
 
-  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@6.0.3)':
+  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@6.0.3)':
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node14': 14.1.8
       '@tsconfig/node16': 16.1.8
       '@tsconfig/node18': 18.2.6
       '@tsconfig/node20': 20.1.9
-      '@types/node': 24.13.3
+      '@types/node': 26.1.1
       acorn: 8.17.0
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -21460,19 +21487,19 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.162.0': {}
 
-  '@tapjs/after-each@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/after-each@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       function-loop: 4.0.0
 
-  '@tapjs/after@3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/after@3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       is-actual-promise: 1.0.2
 
-  '@tapjs/asserts@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tapjs/asserts@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/stack': 4.3.3
       is-actual-promise: 1.0.2
       tcompare: 9.3.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -21481,35 +21508,35 @@ snapshots:
       - react
       - react-dom
 
-  '@tapjs/before-each@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/before-each@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       function-loop: 4.0.0
 
-  '@tapjs/before@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/before@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       is-actual-promise: 1.0.2
 
-  '@tapjs/chdir@3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/chdir@3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  '@tapjs/config@5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/config@5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       chalk: 5.6.2
       jackspeak: 4.2.3
       polite-json: 5.0.0
       tap-yaml: 4.4.2
       walk-up-path: 4.0.0
 
-  '@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@tapjs/processinfo': 3.1.12
       '@tapjs/stack': 4.3.3
-      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       async-hook-domain: 4.0.1
       diff: 8.0.4
       is-actual-promise: 1.0.2
@@ -21530,33 +21557,33 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@tapjs/filter@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/filter@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  '@tapjs/fixture@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/fixture@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       mkdirp: 3.0.1
       rimraf: 6.1.3
 
-  '@tapjs/intercept@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/intercept@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/stack': 4.3.3
 
-  '@tapjs/mock@4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/mock@4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/stack': 4.3.3
       resolve-import: 2.4.0
       walk-up-path: 4.0.0
 
-  '@tapjs/node-serialize@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/node-serialize@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/error-serdes': 4.3.2
       '@tapjs/stack': 4.3.3
       tap-parser: 18.3.4
@@ -21569,10 +21596,10 @@ snapshots:
       signal-exit: 4.1.0
       uuid: 14.0.1
 
-  '@tapjs/reporter@4.4.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))':
+  '@tapjs/reporter@4.4.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))':
     dependencies:
-      '@tapjs/config': 5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/config': 5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/stack': 4.3.3
       chalk: 5.6.2
       ink: 5.2.1(@types/react@19.2.17)(react@18.3.1)
@@ -21593,18 +21620,18 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  '@tapjs/run@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tapjs/run@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@isaacs/which': 7.0.4
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/config': 5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/config': 5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/processinfo': 3.1.12
-      '@tapjs/reporter': 4.4.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))
-      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/reporter': 4.4.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))
+      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       c8: 10.1.3
       chalk: 5.6.2
       chokidar: 4.0.3
@@ -21637,9 +21664,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@tapjs/snapshot@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tapjs/snapshot@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       is-actual-promise: 1.0.2
       tcompare: 9.3.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       trivial-deferred: 2.0.0
@@ -21647,36 +21674,36 @@ snapshots:
       - react
       - react-dom
 
-  '@tapjs/spawn@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/spawn@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   '@tapjs/stack@4.3.3': {}
 
-  '@tapjs/stdin@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/stdin@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  '@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@5.9.3)
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/after-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/asserts': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/before-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/chdir': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/filter': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/fixture': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/intercept': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/mock': 4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/node-serialize': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/snapshot': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/typescript': 3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(typescript@5.9.3)
-      '@tapjs/worker': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@5.9.3)
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/after-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/asserts': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/before-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/chdir': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/filter': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/fixture': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/intercept': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/mock': 4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/node-serialize': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/snapshot': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/typescript': 3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(typescript@5.9.3)
+      '@tapjs/worker': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       glob: 13.0.6
       jackspeak: 4.2.3
       mkdirp: 3.0.1
@@ -21695,29 +21722,29 @@ snapshots:
       - react
       - react-dom
 
-  '@tapjs/typescript@3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(typescript@5.9.3)':
+  '@tapjs/typescript@3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(typescript@5.9.3)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@5.9.3)
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@5.9.3)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
       - typescript
 
-  '@tapjs/typescript@3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(typescript@6.0.3)':
+  '@tapjs/typescript@3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(typescript@6.0.3)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@6.0.3)
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@6.0.3)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
       - typescript
 
-  '@tapjs/worker@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/worker@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   '@tsconfig/node14@14.1.8': {}
 
@@ -24114,7 +24141,7 @@ snapshots:
 
   eval@0.1.8:
     dependencies:
-      '@types/node': 24.13.3
+      '@types/node': 26.1.1
       require-like: 0.1.2
 
   event-source-polyfill@1.0.31: {}
@@ -28951,27 +28978,27 @@ snapshots:
       yaml: 2.9.0
       yaml-types: 0.4.0(yaml@2.9.0)
 
-  tap@21.7.4(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
+  tap@21.7.4(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
     dependencies:
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/after-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/asserts': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/before-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/chdir': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/filter': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/fixture': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/intercept': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/mock': 4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/node-serialize': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/run': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/snapshot': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/typescript': 3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(typescript@6.0.3)
-      '@tapjs/worker': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/after-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/asserts': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/before-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/chdir': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/filter': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/fixture': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/intercept': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/mock': 4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/node-serialize': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/run': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/snapshot': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/typescript': 3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(typescript@6.0.3)
+      '@tapjs/worker': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       resolve-import: 2.4.0
     transitivePeerDependencies:
       - '@swc/core'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - playground/*
   - css-playground/*
   - packages/@sanity/tsdown-config/test/fixtures/**
+  - packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio
 
 catalog:
   '@sanity/client': ^7.23.2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- force vanilla-extract runtime modules to remain native Node externals in the internal SSR environment even when a parent Vite config sets `ssr.noExternal: true`
- preserve parent `resolve` conditions and fields; runtime probes found equivalent esbuild/Rolldown selections for `exports`, `main`, `module`, and `browser`
- add a real Sanity Studio parity suite using the official plugin as the reference for `sanity dev`, `sanity build`, and `sanity schemas extract`
- compare observable CSS, class-name, HTML-link, and schema semantics across short, debug, custom-prefix, CSS minify, and CSS target configurations
- keep Studio test artifacts on the fixture drive so schema extraction paths work across Windows drive letters
- include a patch changeset and refreshed vanilla-extract benchmark results

## Testing

- `pnpm --filter @sanity/vanilla-extract-vite-plugin test` (29 passed, including 12 Studio parity cases)
- `pnpm --filter @sanity/vanilla-extract-vite-plugin typecheck`
- `pnpm --filter @sanity/vanilla-extract-vite-plugin build`
- downstream plugins Studio `typegen` / schema extraction and production build reproduction
- `pnpm benchmark:vanilla-extract` (full default suite)
- `pnpm --filter @benchmarks/vanilla-extract smoke` (14 passed)
- `pnpm --filter @benchmarks/vanilla-extract typecheck`
- `pnpm lint --deny-warnings`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test` (34 files, 405 passed, 15 skipped)
- `pnpm knip` (only the 3 expected catalog warnings)
- targeted Prettier check and changeset status
- Windows cross-drive `path.win32.relative` regression simulation
- focused `test/studio.test.ts` rerun after the Windows path fix (12 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1edd379-04e4-4bb5-b8c8-d9339eb24dfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1edd379-04e4-4bb5-b8c8-d9339eb24dfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

