### PR TITLE
fix: keep vanilla-extract CSS when parent Vite uses browser conditions

### DIFF
--- a/.changeset/fix-ve-vite-browser-css.md
+++ b/.changeset/fix-ve-vite-browser-css.md
@@ -1,0 +1,10 @@
+---
+'@sanity/vanilla-extract-vite-plugin': patch
+---
+
+fix: extract CSS when the parent Vite config enables the `browser` resolve condition
+
+The compiler server now forces Node resolve conditions (`resolve`, `ssr.resolve`, and
+`environments.ssr.resolve`) when evaluating `.css.ts` modules. Without this, configs like
+`sanity build` could resolve the browser build of `@vanilla-extract/css`, emit class names
+without rules, and drop virtual `.vanilla.css` imports from production bundles.

--- a/.changeset/fix-ve-vite-browser-css.md
+++ b/.changeset/fix-ve-vite-browser-css.md
@@ -4,7 +4,8 @@
 
 fix: extract CSS when the parent Vite config enables the `browser` resolve condition
 
-The compiler server now forces Node resolve conditions (`resolve`, `ssr.resolve`, and
-`environments.ssr.resolve`) when evaluating `.css.ts` modules. Without this, configs like
-`sanity build` could resolve the browser build of `@vanilla-extract/css`, emit class names
-without rules, and drop virtual `.vanilla.css` imports from production bundles.
+The compiler server now strips `browser` from forwarded resolve conditions and mainFields
+(`resolve`, `ssr.resolve`, and `environments.ssr.resolve`) when evaluating `.css.ts` modules,
+while keeping the parent's other conditions. Without this, configs like `sanity build` could
+resolve the browser build of `@vanilla-extract/css`, emit class names without rules, and drop
+virtual `.vanilla.css` imports from production bundles.

--- a/.changeset/fix-ve-vite-browser-css.md
+++ b/.changeset/fix-ve-vite-browser-css.md
@@ -12,6 +12,6 @@ forwards parent `ssr.noExternal: true`. Vite's `ModuleRunner` cannot evaluate in
 during `sanity schema extract` / TypeGen; inheriting `browser` conditions dropped extracted
 CSS in `sanity build`.
 
-`@sanity/vanilla-extract-integration`: pin rolldown `resolve` to esbuild's `platform: 'node'`
-defaults (`mainFields: ['main', 'module']`, `conditionNames: ['module']`, no `browser` alias
-fields) so dual-shipped packages resolve the same way as before the esbuild → rolldown swap.
+`@sanity/vanilla-extract-integration`: pin rolldown `resolve.mainFields` / `aliasFields` to the
+`platform: 'node'` defaults (no `browser` mainField or package.json `browser` remapping) so
+dual-shipped packages keep resolving the Node build after the esbuild → rolldown swap.

--- a/.changeset/fix-ve-vite-browser-css.md
+++ b/.changeset/fix-ve-vite-browser-css.md
@@ -1,11 +1,17 @@
 ---
 '@sanity/vanilla-extract-vite-plugin': patch
+'@sanity/vanilla-extract-integration': patch
 ---
 
-fix: extract CSS when the parent Vite config enables the `browser` resolve condition
+fix: keep Node resolution when evaluating `.css.ts` (Studio build / schema extract)
 
-The compiler server now strips `browser` from forwarded resolve conditions and mainFields
-(`resolve`, `ssr.resolve`, and `environments.ssr.resolve`) when evaluating `.css.ts` modules,
-while keeping the parent's other conditions. Without this, configs like `sanity build` could
-resolve the browser build of `@vanilla-extract/css`, emit class names without rules, and drop
-virtual `.vanilla.css` imports from production bundles.
+`@sanity/vanilla-extract-vite-plugin`: the compiler server strips `browser` from forwarded
+resolve conditions/mainFields (`resolve`, `ssr.resolve`, `environments.ssr.resolve`) and never
+forwards parent `ssr.noExternal: true`. Vite's `ModuleRunner` cannot evaluate inlined CJS
+(unlike upstream's `vite-node` + `noExternal: true`), which caused `module is not defined`
+during `sanity schema extract` / TypeGen; inheriting `browser` conditions dropped extracted
+CSS in `sanity build`.
+
+`@sanity/vanilla-extract-integration`: pin rolldown `resolve` to esbuild's `platform: 'node'`
+defaults (`mainFields: ['main', 'module']`, `conditionNames: ['module']`, no `browser` alias
+fields) so dual-shipped packages resolve the same way as before the esbuild → rolldown swap.

--- a/benchmarks/vanilla-extract/README.md
+++ b/benchmarks/vanilla-extract/README.md
@@ -79,17 +79,13 @@ Keep this section current: re-run the full suite and update the tables whenever 
 `vanilla-extract` dependencies are bumped or any of the `@sanity/vanilla-extract-*` plugins
 change (see [AGENTS.md](../../AGENTS.md)).
 
-Last run: 2026-07-16 (after vendoring `@vanilla-extract/integration` onto rolldown as
-`@sanity/vanilla-extract-integration` — the library-build compile path swapped its esbuild
-child compilation for rolldown, and debug IDs swapped babel for a `yuku-parser` AST pass —
-adding the `debug identifiers` variant and the kitchen-sink case to this suite, aligning every
-rolldown copy on the 1.1.5 that vite 8 pins, and sizing the build-suite fixtures like
-production source files), full default suite (`pnpm benchmark:vanilla-extract`) on Node.js
-24.18.0, Linux x64, Intel Xeon, **4 cores**; Rollup 4.62.2, Rolldown 1.1.5, Vite 8.1.4,
-Vitest 4.1.10, yuku-parser 0.6.1. Values are mean wall-clock milliseconds from that runner and
-are machine-specific — compare ratios, not absolute numbers. (For the future rolldown bump:
-rolldown 1.2.0 measured the Sanity library build ~15% faster still on the earlier minimal
-fixtures — expect the gap below to widen again when vite updates its pinned rolldown.)
+Last run: 2026-07-16 (after forcing Node resolve conditions on the
+`@sanity/vanilla-extract-vite-plugin` compiler server so parent `browser` conditions cannot
+drop extracted CSS — [#3073](https://github.com/sanity-io/pkg-utils/issues/3073)), full
+default suite (`pnpm benchmark:vanilla-extract`) on Node.js 24.18.0, Linux x64, Intel Xeon,
+**4 cores**; Rollup 4.62.2, Rolldown 1.2.0, Vite 8.1.5, Vitest 4.1.10, yuku-parser 0.6.4.
+Values are mean wall-clock milliseconds from that runner and are machine-specific — compare
+ratios, not absolute numbers.
 
 ### Core count shifts the build ratios
 
@@ -110,14 +106,14 @@ official on theme edits, rme up to ±20%); hook-filter stress 1.37–1.71x.
 
 | Variant                  | Rollup + `@vanilla-extract/rollup-plugin` | Rolldown + `@sanity/vanilla-extract-rolldown-plugin` | Relative result     |
 | ------------------------ | ----------------------------------------: | ---------------------------------------------------: | ------------------- |
-| No minify, no target     |                               1,145.59 ms |                                            415.51 ms | Sanity 2.76x faster |
-| Minify                   |                               1,119.03 ms |                                            415.88 ms | Sanity 2.69x faster |
-| Target chrome61          |                               1,154.48 ms |                                            423.53 ms | Sanity 2.73x faster |
-| Minify + target chrome61 |                               1,118.68 ms |                                            422.78 ms | Sanity 2.65x faster |
-| Debug identifiers        |                               1,407.03 ms |                                            455.64 ms | Sanity 3.09x faster |
+| No minify, no target     |                               1,082.94 ms |                                            363.86 ms | Sanity 2.98x faster |
+| Minify                   |                               1,088.76 ms |                                            377.57 ms | Sanity 2.88x faster |
+| Target chrome61          |                               1,121.16 ms |                                            391.81 ms | Sanity 2.86x faster |
+| Minify + target chrome61 |                               1,130.36 ms |                                            386.80 ms | Sanity 2.92x faster |
+| Debug identifiers        |                               1,369.25 ms |                                            436.33 ms | Sanity 3.14x faster |
 
-Debug identifiers cost each pipeline `debug − baseline`: **+261.4 ms** for the official
-babel-based transform, **+40.1 ms** for the Sanity `yuku-parser` pass — the transform runs
+Debug identifiers cost each pipeline `debug − baseline`: **+286.3 ms** for the official
+babel-based transform, **+72.5 ms** for the Sanity `yuku-parser` pass — the transform runs
 once per `.css.ts` module and scales with file size, so the production-shaped modules widen
 the gap the near-empty fixtures used to understate.
 
@@ -125,29 +121,29 @@ the gap the near-empty fixtures used to understate.
 
 | Identifiers | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result     |
 | ----------- | -----------------------------: | ------------------------------------: | ------------------- |
-| Short       |                      950.45 ms |                             760.99 ms | Sanity 1.25x faster |
-| Debug       |                    1,344.97 ms |                             847.71 ms | Sanity 1.59x faster |
+| Short       |                    1,002.33 ms |                             814.57 ms | Sanity 1.23x faster |
+| Debug       |                    1,300.80 ms |                             835.83 ms | Sanity 1.56x faster |
 
 ### Vite build kitchen sink, 5,000 TS + 500 CSS modules, debug identifiers, css minify + target chrome61 (5 samples each)
 
 | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result     |
 | -----------------------------: | ------------------------------------: | ------------------- |
-|                    4,505.27 ms |                           3,323.23 ms | Sanity 1.36x faster |
+|                    4,409.26 ms |                           3,263.23 ms | Sanity 1.35x faster |
 
 ### Vite dev HMR (10 samples each)
 
 | Scenario                               | Official plugin | Sanity plugin | Relative result       |
 | -------------------------------------- | --------------: | ------------: | --------------------- |
-| Single `.css.ts` leaf edit             |        21.90 ms |      23.46 ms | Official 1.07x faster |
-| Shared theme edit, 100 style importers |       164.47 ms |     176.77 ms | Official 1.07x faster |
+| Single `.css.ts` leaf edit             |        21.51 ms |      18.48 ms | Sanity 1.16x faster   |
+| Shared theme edit, 100 style importers |       161.06 ms |     166.31 ms | Official 1.03x faster |
 
 ### Hook-filter stress, `vite build` with 1 CSS module (3 samples each)
 
 | Unrelated modules | Official plugin | Sanity plugin | Relative result     |
 | ----------------: | --------------: | ------------: | ------------------- |
-|                 0 |       434.26 ms |     243.70 ms | Sanity 1.78x faster |
-|             1,000 |       458.99 ms |     251.05 ms | Sanity 1.83x faster |
-|             5,000 |       671.39 ms |     413.36 ms | Sanity 1.62x faster |
+|                 0 |       427.91 ms |     245.78 ms | Sanity 1.74x faster |
+|             1,000 |       439.37 ms |     254.24 ms | Sanity 1.73x faster |
+|             5,000 |       654.24 ms |     392.29 ms | Sanity 1.67x faster |
 
 The untimed hook diagnostic shows why: the official plugin's unfiltered hooks enter JavaScript
 once per module, while the Sanity plugin's native hook filters reject unrelated ids before the

--- a/packages/@sanity/vanilla-extract-integration/src/compile.ts
+++ b/packages/@sanity/vanilla-extract-integration/src/compile.ts
@@ -44,6 +44,16 @@ export async function compile({
     input: [filePath],
     cwd,
     platform: 'node',
+    // Pin esbuild `platform: 'node'` resolve defaults explicitly so a future rolldown change
+    // (or accidental `browser` condition) cannot pull browser builds of dual-shipped packages
+    // into the `.css.ts` evaluation graph. Matches `@vanilla-extract/integration`'s esbuild
+    // path: mainFields `main`/`module` (no `browser`), bundler `module` condition, no
+    // package.json `browser` field remapping.
+    resolve: {
+      mainFields: ['main', 'module'],
+      conditionNames: ['module'],
+      aliasFields: [],
+    },
     external: [/^@vanilla-extract($|\/)/],
     logLevel: 'silent',
     plugins: [

--- a/packages/@sanity/vanilla-extract-integration/src/compile.ts
+++ b/packages/@sanity/vanilla-extract-integration/src/compile.ts
@@ -44,14 +44,14 @@ export async function compile({
     input: [filePath],
     cwd,
     platform: 'node',
-    // Pin esbuild `platform: 'node'` resolve defaults explicitly so a future rolldown change
-    // (or accidental `browser` condition) cannot pull browser builds of dual-shipped packages
-    // into the `.css.ts` evaluation graph. Matches `@vanilla-extract/integration`'s esbuild
-    // path: mainFields `main`/`module` (no `browser`), bundler `module` condition, no
-    // package.json `browser` field remapping.
+    // Pin the resolve fields that would otherwise admit browser builds of dual-shipped
+    // packages into the `.css.ts` evaluation graph. `platform: 'node'` already supplies
+    // import/require + `node` + `default` conditions (rolldown merges any custom
+    // `conditionNames` with those — we deliberately do not override them). Explicitly set
+    // mainFields / aliasFields to the node defaults so a future rolldown change cannot
+    // reintroduce `browser` mainField or package.json `browser` remapping.
     resolve: {
       mainFields: ['main', 'module'],
-      conditionNames: ['module'],
       aliasFields: [],
     },
     external: [/^@vanilla-extract($|\/)/],

--- a/packages/@sanity/vanilla-extract-vite-plugin/package.json
+++ b/packages/@sanity/vanilla-extract-vite-plugin/package.json
@@ -47,6 +47,8 @@
     "@sanity/tsconfig": "workspace:^",
     "@sanity/tsdown-config": "workspace:^",
     "@types/node": "catalog:",
+    "@vanilla-extract/vite-plugin": "^5.2.5",
+    "picocolors": "^1.1.1",
     "publint": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
@@ -214,7 +214,11 @@ type ResolveConditionFields = {
   conditions?: string[]
   externalConditions?: string[]
   mainFields?: string[]
-  noExternal?: unknown
+  noExternal?: string | true | RegExp | (string | RegExp)[]
+}
+
+type SanitizedCompilerResolve = Omit<ResolveConditionFields, 'noExternal'> & {
+  noExternal: []
 }
 
 /**
@@ -225,18 +229,13 @@ type ResolveConditionFields = {
  * packages like `picocolors`). Parent `noExternal` must never reach the compiler — including
  * when Vite 8 has folded it into `environments.ssr.resolve.noExternal`.
  */
-function sanitizeCompilerResolve<T extends ResolveConditionFields>(resolve: T): T {
-  const {noExternal: _noExternal, ...rest} = resolve
-  return {
-    ...rest,
-    ...(rest.conditions ? {conditions: withoutBrowser(rest.conditions)} : undefined),
-    ...(rest.externalConditions
-      ? {externalConditions: withoutBrowser(rest.externalConditions)}
-      : undefined),
-    ...(rest.mainFields ? {mainFields: withoutBrowser(rest.mainFields)} : undefined),
-    // Force default node_modules externalization for ModuleRunner
-    noExternal: [],
-  } as T
+function sanitizeCompilerResolve(resolve: ResolveConditionFields): SanitizedCompilerResolve {
+  const {noExternal: _noExternal, conditions, externalConditions, mainFields, ...rest} = resolve
+  const sanitized: SanitizedCompilerResolve = {...rest, noExternal: []}
+  if (conditions) sanitized.conditions = withoutBrowser(conditions)
+  if (externalConditions) sanitized.externalConditions = withoutBrowser(externalConditions)
+  if (mainFields) sanitized.mainFields = withoutBrowser(mainFields)
+  return sanitized
 }
 
 /** Invalidates the runner's evaluated modules for a changed file, and their importers. */

--- a/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
@@ -214,18 +214,29 @@ type ResolveConditionFields = {
   conditions?: string[]
   externalConditions?: string[]
   mainFields?: string[]
+  noExternal?: unknown
 }
 
-/** Forwards resolve fields with `browser` stripped from any list the parent set. */
-function withoutBrowserResolveFields<T extends ResolveConditionFields>(resolve: T): T {
+/**
+ * Forwards resolve fields with `browser` stripped and `noExternal` cleared.
+ *
+ * Upstream `@vanilla-extract/compiler` sets `ssr.noExternal: true` because `vite-node` can
+ * evaluate inlined CJS. Vite's native `ModuleRunner` cannot (`module is not defined` on
+ * packages like `picocolors`). Parent `noExternal` must never reach the compiler — including
+ * when Vite 8 has folded it into `environments.ssr.resolve.noExternal`.
+ */
+function sanitizeCompilerResolve<T extends ResolveConditionFields>(resolve: T): T {
+  const {noExternal: _noExternal, ...rest} = resolve
   return {
-    ...resolve,
-    ...(resolve.conditions ? {conditions: withoutBrowser(resolve.conditions)} : undefined),
-    ...(resolve.externalConditions
-      ? {externalConditions: withoutBrowser(resolve.externalConditions)}
+    ...rest,
+    ...(rest.conditions ? {conditions: withoutBrowser(rest.conditions)} : undefined),
+    ...(rest.externalConditions
+      ? {externalConditions: withoutBrowser(rest.externalConditions)}
       : undefined),
-    ...(resolve.mainFields ? {mainFields: withoutBrowser(resolve.mainFields)} : undefined),
-  }
+    ...(rest.mainFields ? {mainFields: withoutBrowser(rest.mainFields)} : undefined),
+    // Force default node_modules externalization for ModuleRunner
+    noExternal: [],
+  } as T
 }
 
 /** Invalidates the runner's evaluated modules for a changed file, and their importers. */
@@ -282,39 +293,24 @@ async function createCompilerServer({
     build: {
       assetsInlineLimit: viteConfig.build?.assetsInlineLimit,
     },
-    // Strip `browser` from every resolve-condition surface the parent may have set. Vite 8
-    // merges `resolve` / `ssr.resolve` / `environments.ssr.resolve`, so filtering only the
-    // top-level list still leaves `browser` in the SSR environment's merged conditions.
-    ...(viteConfig.resolve
-      ? {resolve: withoutBrowserResolveFields(viteConfig.resolve)}
-      : undefined),
-    ...(viteConfig.ssr
-      ? {
-          ssr: {
-            ...viteConfig.ssr,
-            ...(viteConfig.ssr.resolve
-              ? {resolve: withoutBrowserResolveFields(viteConfig.ssr.resolve)}
-              : undefined),
-          },
-        }
-      : undefined),
-    ...(viteConfig.environments?.['ssr']
-      ? {
-          environments: {
-            ...viteConfig.environments,
-            ssr: {
-              ...viteConfig.environments['ssr'],
-              ...(viteConfig.environments['ssr'].resolve
-                ? {
-                    resolve: withoutBrowserResolveFields(
-                      viteConfig.environments['ssr'].resolve,
-                    ),
-                  }
-                : undefined),
-            },
-          },
-        }
-      : undefined),
+    // Sanitize every resolve-condition surface the parent may have set:
+    // - strip `browser` (Vite 8 merges resolve / ssr.resolve / environments.ssr.resolve)
+    // - force `noExternal: []` so ModuleRunner never inlines CJS (unlike upstream's
+    //   vite-node + `ssr.noExternal: true`)
+    resolve: sanitizeCompilerResolve(viteConfig.resolve ?? {}),
+    ssr: {
+      ...viteConfig.ssr,
+      // Top-level `ssr.noExternal` must not reach the compiler server
+      noExternal: [],
+      resolve: sanitizeCompilerResolve(viteConfig.ssr?.resolve ?? {}),
+    },
+    environments: {
+      ...viteConfig.environments,
+      ssr: {
+        ...viteConfig.environments?.['ssr'],
+        resolve: sanitizeCompilerResolve(viteConfig.environments?.['ssr']?.resolve ?? {}),
+      },
+    },
     // Vite's default SSR externalization applies: project files and linked packages are
     // evaluated through the runner (so they're cached in the module graph), while node_modules
     // dependencies are externalized to real Node imports — required for CJS dependencies,

--- a/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
@@ -200,6 +200,11 @@ export interface CreateCompilerOptions {
   enableFileWatcher?: boolean
 }
 
+/** Resolve conditions the compiler server must use when evaluating `.css.ts` in Node. */
+const compilerResolveConditions = ['node', 'import', 'module', 'default'] as const
+/** `mainFields` without `browser`, matching Node resolution for the compiler server. */
+const compilerMainFields = ['module', 'jsnext:main', 'jsnext', 'main'] as const
+
 /** Invalidates the runner's evaluated modules for a changed file, and their importers. */
 function invalidateRunnerFile(runner: ModuleRunner, filePath: string): void {
   const seen = new Set<EvaluatedModuleNode>()
@@ -253,6 +258,39 @@ async function createCompilerServer({
     },
     build: {
       assetsInlineLimit: viteConfig.build?.assetsInlineLimit,
+    },
+    // Parent app configs (notably `sanity build`) often enable the `browser` resolve
+    // condition. The compiler evaluates `.css.ts` in Node via `ModuleRunner`; resolving the
+    // browser build of `@vanilla-extract/css` makes `style()` use the runtime/inject adapter
+    // path, so `appendCss` never reaches our cssCache and virtual `.vanilla.css` imports are
+    // omitted (class names still export, CSS rules do not).
+    //
+    // Vite 8 merges `resolve` / `ssr.resolve` / `environments.ssr.resolve` conditions, so a
+    // top-level override alone is not enough when the parent sets environment-specific
+    // `browser` conditions — override all three.
+    resolve: {
+      ...viteConfig.resolve,
+      conditions: [...compilerResolveConditions],
+      mainFields: [...compilerMainFields],
+    },
+    ssr: {
+      ...viteConfig.ssr,
+      resolve: {
+        ...viteConfig.ssr?.resolve,
+        conditions: [...compilerResolveConditions],
+        externalConditions: [...compilerResolveConditions],
+      },
+    },
+    environments: {
+      ...viteConfig.environments,
+      ssr: {
+        ...viteConfig.environments?.['ssr'],
+        resolve: {
+          ...viteConfig.environments?.['ssr']?.resolve,
+          conditions: [...compilerResolveConditions],
+          externalConditions: [...compilerResolveConditions],
+        },
+      },
     },
     // Vite's default SSR externalization applies: project files and linked packages are
     // evaluated through the runner (so they're cached in the module graph), while node_modules

--- a/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
@@ -200,10 +200,33 @@ export interface CreateCompilerOptions {
   enableFileWatcher?: boolean
 }
 
-/** Resolve conditions the compiler server must use when evaluating `.css.ts` in Node. */
-const compilerResolveConditions = ['node', 'import', 'module', 'default'] as const
-/** `mainFields` without `browser`, matching Node resolution for the compiler server. */
-const compilerMainFields = ['module', 'jsnext:main', 'jsnext', 'main'] as const
+/**
+ * Drops the `browser` export condition / mainField. The compiler evaluates `.css.ts` in Node
+ * via `ModuleRunner`; packages like `@vanilla-extract/css` ship a browser build that takes the
+ * runtime/inject adapter path, so forwarding `browser` makes `appendCss` miss our cssCache
+ * (class names still export, CSS rules do not). Other parent conditions are kept as-is.
+ */
+function withoutBrowser(values: readonly string[]): string[] {
+  return values.filter((value) => value !== 'browser')
+}
+
+type ResolveConditionFields = {
+  conditions?: string[]
+  externalConditions?: string[]
+  mainFields?: string[]
+}
+
+/** Forwards resolve fields with `browser` stripped from any list the parent set. */
+function withoutBrowserResolveFields<T extends ResolveConditionFields>(resolve: T): T {
+  return {
+    ...resolve,
+    ...(resolve.conditions ? {conditions: withoutBrowser(resolve.conditions)} : undefined),
+    ...(resolve.externalConditions
+      ? {externalConditions: withoutBrowser(resolve.externalConditions)}
+      : undefined),
+    ...(resolve.mainFields ? {mainFields: withoutBrowser(resolve.mainFields)} : undefined),
+  }
+}
 
 /** Invalidates the runner's evaluated modules for a changed file, and their importers. */
 function invalidateRunnerFile(runner: ModuleRunner, filePath: string): void {
@@ -259,39 +282,39 @@ async function createCompilerServer({
     build: {
       assetsInlineLimit: viteConfig.build?.assetsInlineLimit,
     },
-    // Parent app configs (notably `sanity build`) often enable the `browser` resolve
-    // condition. The compiler evaluates `.css.ts` in Node via `ModuleRunner`; resolving the
-    // browser build of `@vanilla-extract/css` makes `style()` use the runtime/inject adapter
-    // path, so `appendCss` never reaches our cssCache and virtual `.vanilla.css` imports are
-    // omitted (class names still export, CSS rules do not).
-    //
-    // Vite 8 merges `resolve` / `ssr.resolve` / `environments.ssr.resolve` conditions, so a
-    // top-level override alone is not enough when the parent sets environment-specific
-    // `browser` conditions — override all three.
-    resolve: {
-      ...viteConfig.resolve,
-      conditions: [...compilerResolveConditions],
-      mainFields: [...compilerMainFields],
-    },
-    ssr: {
-      ...viteConfig.ssr,
-      resolve: {
-        ...viteConfig.ssr?.resolve,
-        conditions: [...compilerResolveConditions],
-        externalConditions: [...compilerResolveConditions],
-      },
-    },
-    environments: {
-      ...viteConfig.environments,
-      ssr: {
-        ...viteConfig.environments?.['ssr'],
-        resolve: {
-          ...viteConfig.environments?.['ssr']?.resolve,
-          conditions: [...compilerResolveConditions],
-          externalConditions: [...compilerResolveConditions],
-        },
-      },
-    },
+    // Strip `browser` from every resolve-condition surface the parent may have set. Vite 8
+    // merges `resolve` / `ssr.resolve` / `environments.ssr.resolve`, so filtering only the
+    // top-level list still leaves `browser` in the SSR environment's merged conditions.
+    ...(viteConfig.resolve
+      ? {resolve: withoutBrowserResolveFields(viteConfig.resolve)}
+      : undefined),
+    ...(viteConfig.ssr
+      ? {
+          ssr: {
+            ...viteConfig.ssr,
+            ...(viteConfig.ssr.resolve
+              ? {resolve: withoutBrowserResolveFields(viteConfig.ssr.resolve)}
+              : undefined),
+          },
+        }
+      : undefined),
+    ...(viteConfig.environments?.['ssr']
+      ? {
+          environments: {
+            ...viteConfig.environments,
+            ssr: {
+              ...viteConfig.environments['ssr'],
+              ...(viteConfig.environments['ssr'].resolve
+                ? {
+                    resolve: withoutBrowserResolveFields(
+                      viteConfig.environments['ssr'].resolve,
+                    ),
+                  }
+                : undefined),
+            },
+          },
+        }
+      : undefined),
     // Vite's default SSR externalization applies: project files and linked packages are
     // evaluated through the runner (so they're cached in the module graph), while node_modules
     // dependencies are externalized to real Node imports — required for CJS dependencies,

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio-ssr/package.json
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio-ssr/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@test/studio-ssr",
+  "private": true,
+  "type": "module"
+}

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio-ssr/src/main.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio-ssr/src/main.ts
@@ -1,0 +1,3 @@
+import {box} from './styles.css.ts'
+
+export default box

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio-ssr/src/styles.css.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio-ssr/src/styles.css.ts
@@ -1,0 +1,7 @@
+import {style} from '@vanilla-extract/css'
+import {accentColor} from './theme.ts'
+
+export const box: string = style({
+  color: accentColor,
+  height: '40rem',
+})

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio-ssr/src/theme.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/studio-ssr/src/theme.ts
@@ -1,0 +1,11 @@
+import pc from 'picocolors'
+
+/**
+ * Greppable colour marker. Importing `picocolors` (CJS) into the `.css.ts` graph reproduces
+ * the TypeGen/`sanity schema extract` failure mode when the compiler inherits
+ * `ssr.noExternal: true` — ModuleRunner then inlines CJS and throws `module is not defined`.
+ */
+export const accentColor: string = 'rgb(1, 2, 3)'
+
+// Keep the CJS import live so the compiler must resolve/evaluate it
+void pc.green

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/parity.test.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/parity.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Studio-shaped parity: compare `@vanilla-extract/vite-plugin` (reference) with
+ * `@sanity/vanilla-extract-vite-plugin` under the resolve/SSR conditions Sanity uses for
+ * `sanity build` / `sanity schema extract`, plus identifier and CSS pipeline options.
+ *
+ * Soft parity only — class hashes may differ between `@vanilla-extract/integration` and
+ * `@sanity/vanilla-extract-integration`. Absolute regressions (empty CSS, `module is not
+ * defined`) always fail the Sanity side.
+ */
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {build, createServer, type PluginOption, type Rollup} from 'vite'
+import {describe, expect, test} from 'vitest'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const appRoot = path.resolve(__dirname, 'fixtures/app')
+const studioSsrRoot = path.resolve(__dirname, 'fixtures/studio-ssr')
+
+/** Parent resolve shape used by `sanity build` (browser-oriented application conditions). */
+const studioBrowserResolve = {
+  resolve: {
+    conditions: ['browser', 'module', 'import', 'default'],
+    mainFields: ['browser', 'module', 'jsnext:main', 'jsnext', 'main'],
+  },
+  ssr: {
+    resolve: {
+      conditions: ['browser', 'module', 'import', 'default'],
+      externalConditions: ['browser', 'module', 'import', 'default'],
+    },
+  },
+  environments: {
+    client: {
+      resolve: {
+        conditions: ['browser', 'module', 'import', 'default'],
+      },
+    },
+    ssr: {
+      resolve: {
+        conditions: ['browser', 'module', 'import', 'default'],
+        externalConditions: ['browser', 'module', 'import', 'default'],
+      },
+    },
+  },
+}
+
+function containsBoxMarker(css: string): boolean {
+  return css.includes('rgb(1, 2, 3)') || css.includes('#010203')
+}
+
+function findCssAsset(output: readonly (Rollup.OutputAsset | Rollup.OutputChunk)[]): string {
+  const asset = output.find(
+    (assetOrChunk) => assetOrChunk.type === 'asset' && assetOrChunk.fileName.endsWith('.css'),
+  )
+  if (!asset || asset.type !== 'asset') {
+    expect.unreachable('expected an emitted `.css` asset')
+  }
+  const {source} = asset
+  return typeof source === 'string' ? source : new TextDecoder().decode(source)
+}
+
+async function loadOfficialPlugin(): Promise<() => PluginOption[]> {
+  const mod = await import('@vanilla-extract/vite-plugin')
+  return () => mod.vanillaExtractPlugin()
+}
+
+async function loadSanityPlugin(): Promise<
+  (options?: {identifiers?: 'short' | 'debug'}) => PluginOption[]
+> {
+  const mod = await import('../src/index.ts')
+  return (options) => mod.vanillaExtractPlugin(options)
+}
+
+describe('studio-shaped parity (official reference)', () => {
+  test.each([
+    {identifiers: 'debug' as const, cssMinify: false, cssTarget: undefined},
+    {identifiers: 'short' as const, cssMinify: false, cssTarget: undefined},
+    {identifiers: 'debug' as const, cssMinify: true, cssTarget: 'chrome61' as const},
+    {identifiers: 'short' as const, cssMinify: true, cssTarget: 'chrome61' as const},
+  ])(
+    'vite build with browser conditions: identifiers=$identifiers minify=$cssMinify target=$cssTarget',
+    async ({identifiers, cssMinify, cssTarget}) => {
+      const officialPlugin = await loadOfficialPlugin()
+      const sanityPlugin = await loadSanityPlugin()
+
+      const run = async (plugins: PluginOption[]) => {
+        const result = await build({
+          root: appRoot,
+          configFile: false,
+          logLevel: 'silent',
+          plugins,
+          ...studioBrowserResolve,
+          build: {
+            write: false,
+            cssMinify,
+            ...(cssTarget ? {cssTarget} : undefined),
+          },
+        })
+        const {output} = Array.isArray(result) ? result[0]! : (result as Rollup.RollupOutput)
+        return findCssAsset(output)
+      }
+
+      // Sanity must always extract CSS under studio resolve conditions (#3073)
+      const sanityCss = await run(sanityPlugin({identifiers}))
+      expect(containsBoxMarker(sanityCss)).toBe(true)
+      expect(sanityCss.includes('rgb(4, 5, 6)') || sanityCss.includes('#040506')).toBe(true)
+
+      // Official is the reference when it also succeeds; it may still drop CSS under browser
+      // conditions (same root cause) — soft-compare only when its bundle is non-empty.
+      let officialCss: string | undefined
+      try {
+        officialCss = await run(officialPlugin())
+      } catch {
+        officialCss = undefined
+      }
+      if (officialCss && containsBoxMarker(officialCss)) {
+        expect(containsBoxMarker(sanityCss)).toBe(containsBoxMarker(officialCss))
+      }
+
+      if (cssTarget === 'chrome61') {
+        expect(sanityCss).not.toMatch(/\binset\s*:/)
+      }
+    },
+  )
+
+  test('ssrLoadModule with browser conditions + parent noExternal + CJS in the .css.ts graph', async () => {
+    const sanityPlugin = await loadSanityPlugin()
+
+    // Parent apps (and some Sanity SSR paths) set `ssr.noExternal: true`. Upstream's
+    // vite-node compiler wants that; our ModuleRunner must not inherit it or CJS deps like
+    // `picocolors` in the `.css.ts` graph throw `module is not defined` (TypeGen failure mode).
+    const server = await createServer({
+      root: studioSsrRoot,
+      configFile: false,
+      logLevel: 'silent',
+      server: {middlewareMode: true},
+      appType: 'custom',
+      plugins: [sanityPlugin({identifiers: 'debug'})],
+      ...studioBrowserResolve,
+      ssr: {
+        ...studioBrowserResolve.ssr,
+        noExternal: true,
+      },
+    })
+    try {
+      const mod = (await server.ssrLoadModule('/src/main.ts')) as {default: string}
+      expect(mod.default).toMatch(/box/)
+
+      const transformed = await server.transformRequest('/src/styles.css.ts')
+      expect(transformed?.code).toContain('.vanilla.css')
+      const virtualImport = transformed?.code.match(/import\s+["']([^"']+\.vanilla\.css[^"']*)["']/)
+      expect(virtualImport).toBeTruthy()
+      const css = await server.transformRequest(virtualImport![1]!)
+      expect(css?.code).toContain('rgb(1, 2, 3)')
+      expect(css?.code).toContain('40rem')
+    } finally {
+      await server.close()
+    }
+  })
+
+  test('official ssrLoadModule baseline (no browser conditions) still extracts CSS', async () => {
+    const officialPlugin = await loadOfficialPlugin()
+    const server = await createServer({
+      root: appRoot,
+      configFile: false,
+      logLevel: 'silent',
+      server: {middlewareMode: true},
+      appType: 'custom',
+      plugins: [officialPlugin()],
+    })
+    try {
+      const mod = (await server.ssrLoadModule('/src/styles.css.ts')) as {box: string}
+      expect(mod.box).toMatch(/box/)
+    } finally {
+      await server.close()
+    }
+  })
+})

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
@@ -97,8 +97,8 @@ describe('vite build', () => {
   })
 
   // Regression for https://github.com/sanity-io/pkg-utils/issues/3073: `sanity build` enables
-  // the `browser` resolve condition on the parent Vite config. The compiler must not inherit
-  // that when evaluating `.css.ts` — otherwise `@vanilla-extract/css` resolves to its browser
+  // the `browser` resolve condition on the parent Vite config. The compiler must strip that
+  // when evaluating `.css.ts` — otherwise `@vanilla-extract/css` resolves to its browser
   // build, class names still export, and the CSS bundle stays empty.
   test('still extracts CSS when the parent config enables the browser resolve condition', async () => {
     const result = await build({
@@ -334,30 +334,31 @@ describe('compiler', () => {
     expect(second).toBe(first)
   })
 
-  test('forces Node resolve conditions on the compiler server when the parent enables browser', async () => {
-    // Vite 8 merges `resolve` / `ssr.resolve` / `environments.ssr.resolve` conditions, so the
-    // compiler must override all three (a top-level-only override still leaves `browser` in the
-    // SSR environment's merged list).
+  test('strips browser from compiler resolve conditions but forwards other parent conditions', async () => {
+    // Vite 8 merges `resolve` / `ssr.resolve` / `environments.ssr.resolve` conditions, so
+    // `browser` must be filtered from all three (a top-level-only filter still leaves it in the
+    // SSR environment's merged list). Custom conditions like `development` stay forwarded.
     let compilerResolveConditions: readonly string[] | undefined
     let compilerSsrConditions: readonly string[] | undefined
     let compilerEnvSsrConditions: readonly string[] | undefined
+    let compilerMainFields: readonly string[] | undefined
 
     const compiler = createTestCompiler(appRoot, false, {
       resolve: {
-        conditions: ['browser', 'module', 'import', 'default'],
+        conditions: ['browser', 'development', 'module', 'import', 'default'],
         mainFields: ['browser', 'module', 'jsnext:main', 'jsnext', 'main'],
       },
       ssr: {
         resolve: {
-          conditions: ['browser', 'module', 'import', 'default'],
-          externalConditions: ['browser', 'module', 'import', 'default'],
+          conditions: ['browser', 'development', 'module', 'import', 'default'],
+          externalConditions: ['browser', 'development', 'module', 'import', 'default'],
         },
       },
       environments: {
         ssr: {
           resolve: {
-            conditions: ['browser', 'module', 'import', 'default'],
-            externalConditions: ['browser', 'module', 'import', 'default'],
+            conditions: ['browser', 'development', 'module', 'import', 'default'],
+            externalConditions: ['browser', 'development', 'module', 'import', 'default'],
           },
         },
       },
@@ -368,6 +369,7 @@ describe('compiler', () => {
             compilerResolveConditions = config.resolve.conditions
             compilerSsrConditions = config.ssr.resolve?.conditions
             compilerEnvSsrConditions = config.environments['ssr']?.resolve.conditions
+            compilerMainFields = config.resolve.mainFields
           },
         },
       ],
@@ -384,9 +386,12 @@ describe('compiler', () => {
       compilerEnvSsrConditions,
     ]) {
       expect(conditions).toBeTruthy()
-      expect(conditions).toContain('node')
+      expect(conditions).toContain('development')
+      expect(conditions).toContain('module')
       expect(conditions).not.toContain('browser')
     }
+    expect(compilerMainFields).toContain('module')
+    expect(compilerMainFields).not.toContain('browser')
   })
 
   test('exposes the extracted CSS per file and in aggregate', async () => {

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
@@ -368,7 +368,7 @@ describe('compiler', () => {
           configResolved(config) {
             compilerResolveConditions = config.resolve.conditions
             compilerSsrConditions = config.ssr.resolve?.conditions
-            compilerEnvSsrConditions = config.environments['ssr']?.resolve.conditions
+            compilerEnvSsrConditions = config.environments['ssr']?.resolve?.conditions
             compilerMainFields = config.resolve.mainFields
           },
         },

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
@@ -54,8 +54,12 @@ afterEach(async () => {
   await Promise.all(compilersToClose.splice(0).map((compiler) => compiler.close()))
 })
 
-function createTestCompiler(root: string, enableFileWatcher = false): Compiler {
-  const compiler = createCompiler({root, identifiers: 'debug', enableFileWatcher})
+function createTestCompiler(
+  root: string,
+  enableFileWatcher = false,
+  viteConfig?: Parameters<typeof createCompiler>[0]['viteConfig'],
+): Compiler {
+  const compiler = createCompiler({root, identifiers: 'debug', enableFileWatcher, viteConfig})
   compilersToClose.push(compiler)
   return compiler
 }
@@ -90,6 +94,54 @@ describe('vite build', () => {
     )
     if (!html || html.type !== 'asset') expect.unreachable('expected the index.html asset')
     expect(String(html.source)).toMatch(/<link rel="stylesheet"[^>]+\.css/)
+  })
+
+  // Regression for https://github.com/sanity-io/pkg-utils/issues/3073: `sanity build` enables
+  // the `browser` resolve condition on the parent Vite config. The compiler must not inherit
+  // that when evaluating `.css.ts` — otherwise `@vanilla-extract/css` resolves to its browser
+  // build, class names still export, and the CSS bundle stays empty.
+  test('still extracts CSS when the parent config enables the browser resolve condition', async () => {
+    const result = await build({
+      root: appRoot,
+      configFile: false,
+      logLevel: 'silent',
+      plugins: [vanillaExtractPlugin()],
+      resolve: {
+        conditions: ['browser', 'module', 'import', 'default'],
+        mainFields: ['browser', 'module', 'jsnext:main', 'jsnext', 'main'],
+      },
+      ssr: {
+        resolve: {
+          conditions: ['browser', 'module', 'import', 'default'],
+          externalConditions: ['browser', 'module', 'import', 'default'],
+        },
+      },
+      environments: {
+        client: {
+          resolve: {
+            conditions: ['browser', 'module', 'import', 'default'],
+          },
+        },
+        ssr: {
+          resolve: {
+            conditions: ['browser', 'module', 'import', 'default'],
+            externalConditions: ['browser', 'module', 'import', 'default'],
+          },
+        },
+      },
+      build: {write: false},
+    })
+    const {output} = Array.isArray(result) ? result[0]! : (result as Rollup.RollupOutput)
+
+    const css = findCssAsset(output)
+    expect(containsBoxMarker(css)).toBe(true)
+    expect(css.includes('rgb(4, 5, 6)') || css.includes('#040506')).toBe(true)
+
+    const entry = output.find(
+      (assetOrChunk) => assetOrChunk.type === 'chunk' && assetOrChunk.isEntry,
+    )
+    if (!entry || entry.type !== 'chunk') expect.unreachable('expected an entry chunk')
+    expect(entry.code).toContain('className')
   })
 })
 
@@ -280,6 +332,61 @@ describe('compiler', () => {
     // Unchanged module: the memoized result object itself is returned
     const second = await compiler.processVanillaFile(stylesCssTs)
     expect(second).toBe(first)
+  })
+
+  test('forces Node resolve conditions on the compiler server when the parent enables browser', async () => {
+    // Vite 8 merges `resolve` / `ssr.resolve` / `environments.ssr.resolve` conditions, so the
+    // compiler must override all three (a top-level-only override still leaves `browser` in the
+    // SSR environment's merged list).
+    let compilerResolveConditions: readonly string[] | undefined
+    let compilerSsrConditions: readonly string[] | undefined
+    let compilerEnvSsrConditions: readonly string[] | undefined
+
+    const compiler = createTestCompiler(appRoot, false, {
+      resolve: {
+        conditions: ['browser', 'module', 'import', 'default'],
+        mainFields: ['browser', 'module', 'jsnext:main', 'jsnext', 'main'],
+      },
+      ssr: {
+        resolve: {
+          conditions: ['browser', 'module', 'import', 'default'],
+          externalConditions: ['browser', 'module', 'import', 'default'],
+        },
+      },
+      environments: {
+        ssr: {
+          resolve: {
+            conditions: ['browser', 'module', 'import', 'default'],
+            externalConditions: ['browser', 'module', 'import', 'default'],
+          },
+        },
+      },
+      plugins: [
+        {
+          name: 'capture-compiler-resolve-conditions',
+          configResolved(config) {
+            compilerResolveConditions = config.resolve.conditions
+            compilerSsrConditions = config.ssr.resolve?.conditions
+            compilerEnvSsrConditions = config.environments['ssr']?.resolve.conditions
+          },
+        },
+      ],
+    })
+
+    const {source} = await compiler.processVanillaFile(stylesCssTs)
+    expect(source).toContain('export var box')
+    expect(source).toContain('.vanilla.css')
+    expect(compiler.getCssForFile(stylesCssTs)?.css).toContain('rgb(1, 2, 3)')
+
+    for (const conditions of [
+      compilerResolveConditions,
+      compilerSsrConditions,
+      compilerEnvSsrConditions,
+    ]) {
+      expect(conditions).toBeTruthy()
+      expect(conditions).toContain('node')
+      expect(conditions).not.toContain('browser')
+    }
   })
 
   test('exposes the extracted CSS per file and in aggregate', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,7 +311,7 @@ importers:
         version: link:../sanity-css-vanilla-extract-test
       tap:
         specifier: ^21.7.4
-        version: 21.7.4(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+        version: 21.7.4(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1077,6 +1077,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
+      '@vanilla-extract/vite-plugin':
+        specifier: ^5.2.5
+        version: 5.2.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
       publint:
         specifier: 'catalog:'
         version: 0.3.21
@@ -17006,14 +17012,14 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@5.9.3)':
+  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@5.9.3)':
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node14': 14.1.8
       '@tsconfig/node16': 16.1.8
       '@tsconfig/node18': 18.2.6
       '@tsconfig/node20': 20.1.9
-      '@types/node': 24.13.3
+      '@types/node': 26.1.1
       acorn: 8.17.0
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -17024,14 +17030,14 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.43(@swc/helpers@0.5.23)
 
-  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@6.0.3)':
+  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@6.0.3)':
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node14': 14.1.8
       '@tsconfig/node16': 16.1.8
       '@tsconfig/node18': 18.2.6
       '@tsconfig/node20': 20.1.9
-      '@types/node': 24.13.3
+      '@types/node': 26.1.1
       acorn: 8.17.0
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -21460,19 +21466,19 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.162.0': {}
 
-  '@tapjs/after-each@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/after-each@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       function-loop: 4.0.0
 
-  '@tapjs/after@3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/after@3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       is-actual-promise: 1.0.2
 
-  '@tapjs/asserts@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tapjs/asserts@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/stack': 4.3.3
       is-actual-promise: 1.0.2
       tcompare: 9.3.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -21481,35 +21487,35 @@ snapshots:
       - react
       - react-dom
 
-  '@tapjs/before-each@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/before-each@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       function-loop: 4.0.0
 
-  '@tapjs/before@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/before@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       is-actual-promise: 1.0.2
 
-  '@tapjs/chdir@3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/chdir@3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  '@tapjs/config@5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/config@5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       chalk: 5.6.2
       jackspeak: 4.2.3
       polite-json: 5.0.0
       tap-yaml: 4.4.2
       walk-up-path: 4.0.0
 
-  '@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@tapjs/processinfo': 3.1.12
       '@tapjs/stack': 4.3.3
-      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       async-hook-domain: 4.0.1
       diff: 8.0.4
       is-actual-promise: 1.0.2
@@ -21530,33 +21536,33 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@tapjs/filter@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/filter@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  '@tapjs/fixture@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/fixture@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       mkdirp: 3.0.1
       rimraf: 6.1.3
 
-  '@tapjs/intercept@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/intercept@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/stack': 4.3.3
 
-  '@tapjs/mock@4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/mock@4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/stack': 4.3.3
       resolve-import: 2.4.0
       walk-up-path: 4.0.0
 
-  '@tapjs/node-serialize@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/node-serialize@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/error-serdes': 4.3.2
       '@tapjs/stack': 4.3.3
       tap-parser: 18.3.4
@@ -21569,10 +21575,10 @@ snapshots:
       signal-exit: 4.1.0
       uuid: 14.0.1
 
-  '@tapjs/reporter@4.4.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))':
+  '@tapjs/reporter@4.4.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))':
     dependencies:
-      '@tapjs/config': 5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/config': 5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/stack': 4.3.3
       chalk: 5.6.2
       ink: 5.2.1(@types/react@19.2.17)(react@18.3.1)
@@ -21593,18 +21599,18 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  '@tapjs/run@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tapjs/run@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@isaacs/which': 7.0.4
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/config': 5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/config': 5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/processinfo': 3.1.12
-      '@tapjs/reporter': 4.4.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))
-      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/reporter': 4.4.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))
+      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       c8: 10.1.3
       chalk: 5.6.2
       chokidar: 4.0.3
@@ -21637,9 +21643,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@tapjs/snapshot@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tapjs/snapshot@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       is-actual-promise: 1.0.2
       tcompare: 9.3.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       trivial-deferred: 2.0.0
@@ -21647,36 +21653,36 @@ snapshots:
       - react
       - react-dom
 
-  '@tapjs/spawn@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/spawn@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   '@tapjs/stack@4.3.3': {}
 
-  '@tapjs/stdin@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/stdin@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  '@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@5.9.3)
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/after-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/asserts': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/before-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/chdir': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/filter': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/fixture': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/intercept': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/mock': 4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/node-serialize': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/snapshot': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/typescript': 3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(typescript@5.9.3)
-      '@tapjs/worker': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@5.9.3)
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/after-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/asserts': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/before-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/chdir': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/filter': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/fixture': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/intercept': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/mock': 4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/node-serialize': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/snapshot': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/typescript': 3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(typescript@5.9.3)
+      '@tapjs/worker': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       glob: 13.0.6
       jackspeak: 4.2.3
       mkdirp: 3.0.1
@@ -21695,29 +21701,29 @@ snapshots:
       - react
       - react-dom
 
-  '@tapjs/typescript@3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(typescript@5.9.3)':
+  '@tapjs/typescript@3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(typescript@5.9.3)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@5.9.3)
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@5.9.3)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
       - typescript
 
-  '@tapjs/typescript@3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(typescript@6.0.3)':
+  '@tapjs/typescript@3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(typescript@6.0.3)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@6.0.3)
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@6.0.3)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
       - typescript
 
-  '@tapjs/worker@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/worker@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   '@tsconfig/node14@14.1.8': {}
 
@@ -28951,27 +28957,27 @@ snapshots:
       yaml: 2.9.0
       yaml-types: 0.4.0(yaml@2.9.0)
 
-  tap@21.7.4(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
+  tap@21.7.4(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
     dependencies:
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/after-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/asserts': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/before-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/chdir': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/filter': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/fixture': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/intercept': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/mock': 4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/node-serialize': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/run': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/snapshot': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/typescript': 3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(typescript@6.0.3)
-      '@tapjs/worker': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/after-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/asserts': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/before-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/chdir': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/filter': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/fixture': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/intercept': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/mock': 4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/node-serialize': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/run': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/snapshot': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/typescript': 3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(typescript@6.0.3)
+      '@tapjs/worker': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       resolve-import: 2.4.0
     transitivePeerDependencies:
       - '@swc/core'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#3073](https://github.com/sanity-io/pkg-utils/issues/3073) and the Studio regressions seen in [plugins#1615](https://github.com/sanity-io/plugins/pull/1615) / [plugins#1616](https://github.com/sanity-io/plugins/pull/1616) (`sanity build` empty CSS, `sanity schema extract` / TypeGen `module is not defined`).

The break lines up with adopting `@sanity/vanilla-extract-vite-plugin` (and the `@vanilla-extract/integration` → `@sanity/vanilla-extract-integration` swap in 0.2.0). Root cause is the compiler server forwarding parent Vite resolve/SSR settings that are safe for upstream’s `vite-node` + `ssr.noExternal: true`, but not for our `ModuleRunner`.

## Cause

1. **`browser` resolve conditions** (`sanity build`): parent config is forwarded into the compiler; `@vanilla-extract/css` resolves to its browser build; class names export without CSS rules.
2. **`ssr.noExternal: true`** (schema extract / TypeGen): upstream wants this for `vite-node`. ModuleRunner inlines CJS (e.g. `picocolors`) and throws `module is not defined`.
3. Vite 8 merges `resolve` / `ssr.resolve` / `environments.ssr.resolve`, so sanitizing only the top-level list is not enough.

## Fix

**`@sanity/vanilla-extract-vite-plugin`**
- Strip `browser` from forwarded conditions / `externalConditions` / `mainFields`
- Force `noExternal: []` on `resolve`, `ssr`, and `environments.ssr.resolve`
- Preserve other parent conditions (e.g. `development`)

**`@sanity/vanilla-extract-integration`**
- Pin rolldown `resolve.mainFields` / `aliasFields` to the `platform: 'node'` defaults (no `browser` mainField or package.json `browser` remapping). Leave `conditionNames` unset so rolldown keeps its node import/require + `node` + `default` set.

## Tests

Studio-shaped parity suite (`test/parity.test.ts`) comparing against `@vanilla-extract/vite-plugin`:
- `vite build` under browser conditions × identifiers short/debug × css minify/target
- `ssrLoadModule` with browser conditions + parent `noExternal: true` + CJS in the `.css.ts` graph (TypeGen failure mode)

## Test plan

- [x] `pnpm --filter @sanity/vanilla-extract-vite-plugin test` (23)
- [x] `pnpm --filter @sanity/vanilla-extract-integration test` (90)
- [x] Typecheck both packages
- [x] Vanilla-extract benchmarks refreshed earlier in this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b78dae4-3ebb-496e-8102-5489979b678a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b78dae4-3ebb-496e-8102-5489979b678a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

