### PR TITLE
test: sanity CLI integration suite for the vanilla-extract vite plugin, fix CSS loss & schema-extract crash it caught

### DIFF
--- a/.changeset/vanilla-extract-vite-plugin-node-resolution.md
+++ b/.changeset/vanilla-extract-vite-plugin-node-resolution.md
@@ -1,0 +1,32 @@
+---
+'@sanity/vanilla-extract-vite-plugin': patch
+---
+
+fix: pin Node resolve conditions in the compiler server, so CLI hosts like Sanity Studio keep their vanilla-extract CSS
+
+The internal compiler server that evaluates `.css.ts` modules now pins Node-shaped module
+resolution instead of inheriting whatever the consuming app's Vite config (and Vite's own
+defaults) imply, fixing two regressions against `@vanilla-extract/vite-plugin` when the plugin
+runs inside the Sanity CLI ([#3073](https://github.com/sanity-io/pkg-utils/issues/3073)):
+
+- **`sanity build` silently dropped all vanilla-extract CSS** (class names kept working, rules
+  vanished — e.g. `@sanity/google-maps-input`'s dialog losing its `height: 40rem`). Vite's
+  default `ssr.resolve.externalConditions` (`['node', 'module-sync']`) resolved the
+  externalized `@vanilla-extract/*` packages to their CJS `default` exports, whose wrappers
+  pick a dev or prod build off `NODE_ENV` at first load. A CLI host imports this plugin (and
+  through it `@vanilla-extract/css`) before `vite build` flips `NODE_ENV` to `production`, so
+  the evaluated `.css.ts` modules bound the compilation adapter to the dev copy while
+  `style()` appended CSS through the prod copy's mock adapter. The compiler now resolves with
+  `['node', 'import', 'module', 'default']`, preferring the single-file ESM builds — one
+  adapter instance, CSS intact.
+- **`sanity schema extract` crashed** (`Error: module is not defined`) because the CLI's
+  schema-extraction worker sets `ssr.noExternal: true`, which the compiler inherited — inlining
+  CJS dependencies that Vite's native `ModuleRunner` (unlike the legacy `vite-node`) cannot
+  evaluate. The parent `ssr` and `environments` options are no longer forwarded to the
+  compiler server.
+
+Both are covered by the new `@integration/vanilla-extract-studio` suite, which runs a real
+studio fixture through `sanity dev`, `sanity build`, and `sanity schema extract` with this
+plugin and with `@vanilla-extract/vite-plugin` as the reference, comparing emitted CSS, class
+names, and extracted schemas across identifier (`short`/`debug`/custom prefix function),
+`build.cssMinify`, and `build.cssTarget` variants.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,24 @@ jobs:
         env:
           NODE_OPTIONS: --max_old_space_size=8192
 
+  integration:
+    runs-on: ubuntu-latest
+    name: Sanity Studio integration tests
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+      - run: pnpm install
+      - run: pnpm integration:typecheck
+      # Runs the studio fixture through `sanity dev` / `sanity build` / `sanity schema extract`
+      # with @sanity/vanilla-extract-vite-plugin and with @vanilla-extract/vite-plugin as the
+      # reference, comparing output across the identifier/cssMinify/cssTarget matrix.
+      - run: pnpm integration:test
+        env:
+          NODE_OPTIONS: --max_old_space_size=8192
+
   test:
     runs-on: ${{ matrix.platform }}
     name: Node.js ${{ matrix.node-version }} / ${{ matrix.platform }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,13 +6,17 @@ This is the `@sanity/pkg-utils` monorepo: a pnpm workspace containing a build/to
 authoring npm packages (`packages/@sanity/pkg-utils`, wraps rolldown/rollup + API Extractor),
 supporting packages (`tsdown-config`, `tsconfig`, `parse-package-json`, the
 `vanilla-extract-*-plugin` packages), a `playground/*` fixture suite (~30 packages exercising
-build/typecheck scenarios), and a `css-playground/*` fixture suite (~20 packages verifying the
-conditional `bundle.css` export pattern across many frameworks/runtimes). There is **no
-long-running application/database** in this repo — it's a CLI/build-tool product; "running the
-product" means running its build/lint/test/typecheck commands (see root `package.json` `scripts`
-and `.github/workflows/main.yml` for the canonical commands, e.g. `pnpm build`, `pnpm lint`,
-`pnpm typecheck`, `pnpm test`, `pnpm knip`, `pnpm playground:build`/`:typecheck`,
-`pnpm css-playground:build`/`:test`; `css-playground/README.md` documents that suite in detail).
+build/typecheck scenarios), a `css-playground/*` fixture suite (~20 packages verifying the
+conditional `bundle.css` export pattern across many frameworks/runtimes), and an
+`integration/*` suite (a real Sanity Studio fixture comparing
+`@sanity/vanilla-extract-vite-plugin` against upstream `@vanilla-extract/vite-plugin` through
+the `sanity` CLI). There is **no long-running application/database** in this repo — it's a
+CLI/build-tool product; "running the product" means running its build/lint/test/typecheck
+commands (see root `package.json` `scripts` and `.github/workflows/main.yml` for the canonical
+commands, e.g. `pnpm build`, `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm knip`,
+`pnpm playground:build`/`:typecheck`, `pnpm css-playground:build`/`:test`,
+`pnpm integration:test`; `css-playground/README.md` and
+`integration/vanilla-extract-studio/README.md` document those suites in detail).
 
 ### Node version matters (tsdown requires Node ^22.18.0 || >=24.11.0)
 
@@ -77,3 +81,12 @@ sample-count overrides.
   `rgb(1, 2, 3)`, and writes a screenshot to `css-playground/verify/screenshots/`. See
   `css-playground/README.md` for the full manual/automated visual-verification workflow (dev
   servers for individual consumers, e.g. `pnpm --filter @css-playground/vite dev`).
+- `pnpm integration:test` runs `integration/vanilla-extract-studio`: a real Sanity Studio
+  fixture driven through `sanity dev`, `sanity build`, and `sanity schema extract` with
+  `@sanity/vanilla-extract-vite-plugin` and with upstream `@vanilla-extract/vite-plugin` as the
+  reference — the fork's CSS/class-name/schema output must match upstream exactly across
+  identifier (`short`/`debug`/custom prefix), `build.cssMinify`, and `build.cssTarget`
+  variants. **Run it whenever `@sanity/vanilla-extract-vite-plugin` or
+  `@sanity/vanilla-extract-integration` changes.** The suite spawns the CLI without `NODE_ENV`
+  on purpose (that's what reproduces GH-3073); it needs no Sanity auth/network. Takes ~2 min
+  (sequential CLI runs).

--- a/benchmarks/vanilla-extract/README.md
+++ b/benchmarks/vanilla-extract/README.md
@@ -79,17 +79,15 @@ Keep this section current: re-run the full suite and update the tables whenever 
 `vanilla-extract` dependencies are bumped or any of the `@sanity/vanilla-extract-*` plugins
 change (see [AGENTS.md](../../AGENTS.md)).
 
-Last run: 2026-07-16 (after vendoring `@vanilla-extract/integration` onto rolldown as
-`@sanity/vanilla-extract-integration` — the library-build compile path swapped its esbuild
-child compilation for rolldown, and debug IDs swapped babel for a `yuku-parser` AST pass —
-adding the `debug identifiers` variant and the kitchen-sink case to this suite, aligning every
-rolldown copy on the 1.1.5 that vite 8 pins, and sizing the build-suite fixtures like
-production source files), full default suite (`pnpm benchmark:vanilla-extract`) on Node.js
-24.18.0, Linux x64, Intel Xeon, **4 cores**; Rollup 4.62.2, Rolldown 1.1.5, Vite 8.1.4,
-Vitest 4.1.10, yuku-parser 0.6.1. Values are mean wall-clock milliseconds from that runner and
-are machine-specific — compare ratios, not absolute numbers. (For the future rolldown bump:
-rolldown 1.2.0 measured the Sanity library build ~15% faster still on the earlier minimal
-fixtures — expect the gap below to widen again when vite updates its pinned rolldown.)
+Last run: 2026-07-16 (after pinning Node resolve conditions in
+`@sanity/vanilla-extract-vite-plugin`'s compiler server — the GH-3073 fix, no measurable
+build-time shift expected or observed — with every rolldown copy now on the 1.2.0 that vite
+8.1.5 pins), full default suite (`pnpm benchmark:vanilla-extract`) on Node.js 24.18.0, Linux
+x64, Intel Xeon, **4 cores**; Rollup 4.62.2, Rolldown 1.2.0, Vite 8.1.5, Vitest 4.1.10,
+yuku-parser 0.6.4. Values are mean wall-clock milliseconds from that runner and are
+machine-specific — compare ratios, not absolute numbers. (The previous run's prediction for
+the rolldown 1.2.0 bump held: the library-build gap widened from 2.65–2.76x to 2.87–2.99x on
+the short-identifier variants.)
 
 ### Core count shifts the build ratios
 
@@ -99,25 +97,26 @@ relative to Rollup, and the tables below (from a 4-core runner) understate the g
 developer hardware. The versions table printed with every run includes the core count so results
 stay comparable.
 
-For cross-hardware reference, an Apple M4 Max (16 cores, darwin-arm64, 2026-07-16, same
-versions and the same production-shaped fixtures as the tables below) measured: library build
-2.02–2.18x (short-identifier variants) and 2.47x (debug identifiers, 798ms vs 323ms) in favor
-of Rolldown + the Sanity plugin; Vite build 1.28x/1.58x (short/debug identifiers) and 1.48x on
-the kitchen-sink case (2,757ms vs 1,862ms); dev HMR a wash (1.12x Sanity on leaf edits, 1.05x
-official on theme edits, rme up to ±20%); hook-filter stress 1.37–1.71x.
+For cross-hardware reference, an Apple M4 Max (16 cores, darwin-arm64, 2026-07-16, the same
+production-shaped fixtures but the previous run's Rolldown 1.1.5 / Vite 8.1.4) measured:
+library build 2.02–2.18x (short-identifier variants) and 2.47x (debug identifiers, 798ms vs
+323ms) in favor of Rolldown + the Sanity plugin; Vite build 1.28x/1.58x (short/debug
+identifiers) and 1.48x on the kitchen-sink case (2,757ms vs 1,862ms); dev HMR a wash (1.12x
+Sanity on leaf edits, 1.05x official on theme edits, rme up to ±20%); hook-filter stress
+1.37–1.71x.
 
 ### Library build, 500 TS + 100 CSS modules (5 samples each)
 
 | Variant                  | Rollup + `@vanilla-extract/rollup-plugin` | Rolldown + `@sanity/vanilla-extract-rolldown-plugin` | Relative result     |
 | ------------------------ | ----------------------------------------: | ---------------------------------------------------: | ------------------- |
-| No minify, no target     |                               1,145.59 ms |                                            415.51 ms | Sanity 2.76x faster |
-| Minify                   |                               1,119.03 ms |                                            415.88 ms | Sanity 2.69x faster |
-| Target chrome61          |                               1,154.48 ms |                                            423.53 ms | Sanity 2.73x faster |
-| Minify + target chrome61 |                               1,118.68 ms |                                            422.78 ms | Sanity 2.65x faster |
-| Debug identifiers        |                               1,407.03 ms |                                            455.64 ms | Sanity 3.09x faster |
+| No minify, no target     |                               1,060.27 ms |                                            354.90 ms | Sanity 2.99x faster |
+| Minify                   |                               1,057.25 ms |                                            368.74 ms | Sanity 2.87x faster |
+| Target chrome61          |                               1,067.24 ms |                                            371.69 ms | Sanity 2.87x faster |
+| Minify + target chrome61 |                               1,068.42 ms |                                            370.25 ms | Sanity 2.89x faster |
+| Debug identifiers        |                               1,339.04 ms |                                            419.54 ms | Sanity 3.19x faster |
 
-Debug identifiers cost each pipeline `debug − baseline`: **+261.4 ms** for the official
-babel-based transform, **+40.1 ms** for the Sanity `yuku-parser` pass — the transform runs
+Debug identifiers cost each pipeline `debug − baseline`: **+278.8 ms** for the official
+babel-based transform, **+64.6 ms** for the Sanity `yuku-parser` pass — the transform runs
 once per `.css.ts` module and scales with file size, so the production-shaped modules widen
 the gap the near-empty fixtures used to understate.
 
@@ -125,29 +124,29 @@ the gap the near-empty fixtures used to understate.
 
 | Identifiers | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result     |
 | ----------- | -----------------------------: | ------------------------------------: | ------------------- |
-| Short       |                      950.45 ms |                             760.99 ms | Sanity 1.25x faster |
-| Debug       |                    1,344.97 ms |                             847.71 ms | Sanity 1.59x faster |
+| Short       |                      940.70 ms |                             740.58 ms | Sanity 1.27x faster |
+| Debug       |                    1,237.05 ms |                             813.99 ms | Sanity 1.52x faster |
 
 ### Vite build kitchen sink, 5,000 TS + 500 CSS modules, debug identifiers, css minify + target chrome61 (5 samples each)
 
 | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result     |
 | -----------------------------: | ------------------------------------: | ------------------- |
-|                    4,505.27 ms |                           3,323.23 ms | Sanity 1.36x faster |
+|                    4,263.46 ms |                           3,203.07 ms | Sanity 1.33x faster |
 
 ### Vite dev HMR (10 samples each)
 
 | Scenario                               | Official plugin | Sanity plugin | Relative result       |
 | -------------------------------------- | --------------: | ------------: | --------------------- |
-| Single `.css.ts` leaf edit             |        21.90 ms |      23.46 ms | Official 1.07x faster |
-| Shared theme edit, 100 style importers |       164.47 ms |     176.77 ms | Official 1.07x faster |
+| Single `.css.ts` leaf edit             |        19.39 ms |      22.11 ms | Official 1.14x faster |
+| Shared theme edit, 100 style importers |       156.25 ms |     165.64 ms | Official 1.06x faster |
 
 ### Hook-filter stress, `vite build` with 1 CSS module (3 samples each)
 
 | Unrelated modules | Official plugin | Sanity plugin | Relative result     |
 | ----------------: | --------------: | ------------: | ------------------- |
-|                 0 |       434.26 ms |     243.70 ms | Sanity 1.78x faster |
-|             1,000 |       458.99 ms |     251.05 ms | Sanity 1.83x faster |
-|             5,000 |       671.39 ms |     413.36 ms | Sanity 1.62x faster |
+|                 0 |       417.27 ms |     240.41 ms | Sanity 1.74x faster |
+|             1,000 |       426.57 ms |     253.74 ms | Sanity 1.68x faster |
+|             5,000 |       605.06 ms |     386.79 ms | Sanity 1.56x faster |
 
 The untimed hook diagnostic shows why: the official plugin's unfiltered hooks enter JavaScript
 once per module, while the Sanity plugin's native hook filters reject unrelated ids before the

--- a/integration/vanilla-extract-studio/.gitignore
+++ b/integration/vanilla-extract-studio/.gitignore
@@ -1,0 +1,3 @@
+.sanity/
+dist/
+output/

--- a/integration/vanilla-extract-studio/README.md
+++ b/integration/vanilla-extract-studio/README.md
@@ -1,0 +1,55 @@
+# @integration/vanilla-extract-studio
+
+Integration suite that runs a real Sanity Studio fixture through the `sanity` CLI with
+`@sanity/vanilla-extract-vite-plugin` (the fork) and with `@vanilla-extract/vite-plugin` (the
+upstream original), and compares their output. **The upstream plugin is the reference**: for
+every command and option variant, the fork's output must match it exactly.
+
+The suite exists because the fork initially shipped without CLI-level coverage and regressed in
+ways its unit tests couldn't see (missing CSS in `sanity build` output, a crash in
+`sanity schema extract`) while `sanity dev` kept working — see
+[sanity-io/pkg-utils#3073](https://github.com/sanity-io/pkg-utils/issues/3073).
+
+## What's covered
+
+Commands, each across the shared option matrix in `test/variants.ts`:
+
+- **`sanity build`** (`test/build.test.ts`) — plugin-default / `short` / `debug` /
+  custom-function (`prefix`) identifiers, `build.cssMinify` (`default` / `true` /
+  `'lightningcss'`), and `build.cssTarget` (`chrome61`) variants. Asserts the emitted CSS
+  assets and the class names in the built JS: identifier formatting, per-class CSS rules
+  (class names in JS without matching CSS was the production regression), minify/target
+  effects, and fork ≡ upstream equality of both.
+- **`sanity dev`** (`test/dev.test.ts`) — identifier variants. Requests the transformed
+  `.css.ts` modules over HTTP like the browser would, follows their virtual `.vanilla.css`
+  imports, and compares served CSS and exported class names.
+- **`sanity schema extract`** (`test/schema-extract.test.ts`) — identifier variants. The
+  fixture schema embeds the generated class names in a field description, so the extracted
+  schema doubles as identifier output; the command also exercises `.css.ts` evaluation inside
+  the CLI's `ssr.noExternal: true` worker environment.
+
+The studio fixture is this package itself: `sanity.cli.ts` selects the plugin implementation
+and options through `VE_PLUGIN` / `VE_IDENTIFIERS` / `VE_CSS_MINIFY` / `VE_CSS_TARGET`
+environment variables set by the tests.
+
+## Running
+
+```sh
+pnpm --filter @integration/vanilla-extract-studio test
+```
+
+No Sanity authentication or network project access is needed; `build`, `dev` (module serving),
+and `schema extract` all run locally.
+
+Note: the tests spawn the `sanity` CLI **without `NODE_ENV`** (like a real terminal). This is
+load-bearing — `@vanilla-extract/css` ships `NODE_ENV`-switching CJS wrappers and `vite build`
+flips `NODE_ENV` to `production` mid-process, which is exactly the divergence behind the
+`sanity build` regression; a test-runner-provided `NODE_ENV=test` would mask it.
+
+To poke at the fixture manually:
+
+```sh
+cd integration/vanilla-extract-studio
+VE_PLUGIN=fork pnpm exec sanity dev
+VE_PLUGIN=upstream pnpm exec sanity build output/manual --no-minify
+```

--- a/integration/vanilla-extract-studio/package.json
+++ b/integration/vanilla-extract-studio/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@integration/vanilla-extract-studio",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "clean": "rimraf dist .sanity node_modules/.sanity output",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@sanity/tsconfig": "workspace:*",
+    "@sanity/vanilla-extract-vite-plugin": "workspace:*",
+    "@types/node": "catalog:",
+    "@types/react": "^19.2.17",
+    "@vanilla-extract/css": "^1.21.1",
+    "@vanilla-extract/vite-plugin": "^5.2.5",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "rimraf": "^6.1.3",
+    "sanity": "^6.5.0",
+    "styled-components": "^6.1.19",
+    "typescript": "catalog:",
+    "vite": "^8.1.5",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.12"
+  }
+}

--- a/integration/vanilla-extract-studio/sanity.cli.ts
+++ b/integration/vanilla-extract-studio/sanity.cli.ts
@@ -1,0 +1,63 @@
+/**
+ * The CLI config of the fixture studio. The vanilla-extract plugin implementation and its
+ * options are selected through `VE_*` environment variables so the integration tests can run
+ * the same studio through `sanity dev` / `sanity build` / `sanity schema extract` with the
+ * fork (`@sanity/vanilla-extract-vite-plugin`) and with the upstream reference
+ * (`@vanilla-extract/vite-plugin`) across the option matrix. See `test/variants.ts`.
+ */
+import {vanillaExtractPlugin as forkVanillaExtractPlugin} from '@sanity/vanilla-extract-vite-plugin'
+import {vanillaExtractPlugin as upstreamVanillaExtractPlugin} from '@vanilla-extract/vite-plugin'
+import {defineCliConfig} from 'sanity/cli'
+import type {BuildOptions, PluginOption} from 'vite'
+
+type IdentifierOption = Parameters<typeof forkVanillaExtractPlugin>[0] extends
+  {identifiers?: infer T} | undefined
+  ? T
+  : never
+
+/**
+ * The custom identifier function of the `prefix` variant, shared verbatim between both
+ * implementations: derived class names must come out identical.
+ */
+const prefixIdentifiers: IdentifierOption = ({hash, debugId}) =>
+  debugId ? `ve_${debugId}_${hash}` : `ve_${hash}`
+
+function resolveIdentifiers(): IdentifierOption | undefined {
+  const identifiers = process.env['VE_IDENTIFIERS']
+  if (!identifiers) return undefined
+  if (identifiers === 'prefix') return prefixIdentifiers
+  if (identifiers === 'short' || identifiers === 'debug') return identifiers
+  throw new Error(`Unsupported VE_IDENTIFIERS value: ${identifiers}`)
+}
+
+function resolvePlugin(): PluginOption {
+  const implementation = process.env['VE_PLUGIN'] ?? 'fork'
+  const identifiers = resolveIdentifiers()
+  const options = identifiers === undefined ? {} : {identifiers}
+  if (implementation === 'fork') return forkVanillaExtractPlugin(options)
+  if (implementation === 'upstream') return upstreamVanillaExtractPlugin(options)
+  throw new Error(`Unsupported VE_PLUGIN value: ${implementation}`)
+}
+
+function resolveCssBuildOptions(): Pick<BuildOptions, 'cssMinify' | 'cssTarget'> {
+  const build: Pick<BuildOptions, 'cssMinify' | 'cssTarget'> = {}
+  const cssMinify = process.env['VE_CSS_MINIFY']
+  if (cssMinify === 'true') build.cssMinify = true
+  else if (cssMinify === 'false') build.cssMinify = false
+  else if (cssMinify === 'lightningcss') build.cssMinify = 'lightningcss'
+  else if (cssMinify) throw new Error(`Unsupported VE_CSS_MINIFY value: ${cssMinify}`)
+  const cssTarget = process.env['VE_CSS_TARGET']
+  if (cssTarget) build.cssTarget = cssTarget
+  return build
+}
+
+export default defineCliConfig({
+  api: {
+    projectId: process.env['SANITY_STUDIO_PROJECT_ID'] || 'ppsg7ml5',
+    dataset: process.env['SANITY_STUDIO_DATASET'] || 'test',
+  },
+  vite: {
+    plugins: [resolvePlugin()],
+    build: resolveCssBuildOptions(),
+  },
+})

--- a/integration/vanilla-extract-studio/sanity.config.ts
+++ b/integration/vanilla-extract-studio/sanity.config.ts
@@ -1,0 +1,35 @@
+import {defineConfig, defineField, defineType} from 'sanity'
+import {veStudioButton} from './src/button.css'
+import {veStudioDialog, veStudioOverlay} from './src/styles.css'
+
+/**
+ * The schema embeds the generated class names as a string-literal list option (which
+ * `sanity schema extract` preserves as a literal value type), so the extracted schema carries
+ * them: the integration tests compare the extracted schema of the fork against the upstream
+ * reference, which asserts both that `.css.ts` evaluation works inside the schema-extraction
+ * worker and that both implementations generate identical identifiers.
+ */
+const veStyledDocument = defineType({
+  name: 'veStyledDocument',
+  title: 'VE styled document',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      type: 'string',
+      title: 'Name',
+      description: `dialog:${veStudioDialog} overlay:${veStudioOverlay} button:${veStudioButton}`,
+      options: {
+        list: [`dialog:${veStudioDialog} overlay:${veStudioOverlay} button:${veStudioButton}`],
+      },
+    }),
+  ],
+})
+
+export default defineConfig({
+  projectId: process.env['SANITY_STUDIO_PROJECT_ID'] || 'ppsg7ml5',
+  dataset: process.env['SANITY_STUDIO_DATASET'] || 'test',
+  schema: {
+    types: [veStyledDocument],
+  },
+})

--- a/integration/vanilla-extract-studio/src/button.css.ts
+++ b/integration/vanilla-extract-studio/src/button.css.ts
@@ -1,0 +1,15 @@
+import {style} from '@vanilla-extract/css'
+
+/** A second vanilla-extract module; `rgb(4, 5, 6)` (or minified `#040506`) is its marker. */
+const base = style({
+  color: 'rgb(4, 5, 6)',
+  margin: '10px',
+})
+
+/** A composed style, so class-list composition is part of the compared output. */
+export const veStudioButton: string = style([
+  base,
+  {
+    fontWeight: 600,
+  },
+])

--- a/integration/vanilla-extract-studio/src/styles.css.ts
+++ b/integration/vanilla-extract-studio/src/styles.css.ts
@@ -1,0 +1,19 @@
+import {style} from '@vanilla-extract/css'
+import {accentColor} from './theme'
+
+/**
+ * Mirrors the real-world regression fixed by the integration suite: the Google Maps input
+ * dialog styles of `@sanity/google-maps-input` lost their `height: 40rem` rule in `sanity
+ * build` output while the class name stayed on the element
+ * ({@link https://github.com/sanity-io/pkg-utils/issues/3073}).
+ */
+export const veStudioDialog: string = style({
+  color: accentColor,
+  height: '40rem',
+})
+
+/** `inset` is lowered to `top`/`right`/`bottom`/`left` by old `cssTarget`s like `chrome61`. */
+export const veStudioOverlay: string = style({
+  position: 'absolute',
+  inset: 0,
+})

--- a/integration/vanilla-extract-studio/src/theme.ts
+++ b/integration/vanilla-extract-studio/src/theme.ts
@@ -1,0 +1,6 @@
+/**
+ * A plain (non-vanilla-extract) module imported by `styles.css.ts`, so the studio commands
+ * exercise transitive `.css.ts` dependencies. `rgb(1, 2, 3)` is the greppable marker for the
+ * extracted CSS (minifiers may normalize it to `#010203`).
+ */
+export const accentColor: string = 'rgb(1, 2, 3)'

--- a/integration/vanilla-extract-studio/test/build.test.ts
+++ b/integration/vanilla-extract-studio/test/build.test.ts
@@ -1,0 +1,99 @@
+import {rm} from 'node:fs/promises'
+import path from 'node:path'
+import {describe, expect, test} from 'vitest'
+import {
+  describeResult,
+  outputRoot,
+  readBuildClassNames,
+  readBuildCss,
+  runSanityCommand,
+  type FixtureClassNames,
+  type PluginImplementation,
+} from './helpers.ts'
+import {buildVariants, classNameExpectation, type BuildVariant} from './variants.ts'
+
+interface BuildOutput {
+  css: string
+  classNames: FixtureClassNames
+}
+
+/**
+ * Builds run with `--no-minify` so the JS output keeps the `veStudio…` binding names; CSS
+ * minification is exercised separately through the `build.cssMinify` option (see
+ * `test/variants.ts`).
+ */
+async function buildStudio(
+  implementation: PluginImplementation,
+  variant: BuildVariant,
+): Promise<BuildOutput> {
+  const outDir = path.join(outputRoot, 'build', `${implementation}-${variant.slug}`)
+  await rm(outDir, {recursive: true, force: true})
+  const result = await runSanityCommand(
+    ['build', outDir, '--no-minify'],
+    implementation,
+    variant.env,
+  )
+  expect(result.exitCode, `sanity build (${implementation}): ${describeResult(result)}`).toBe(0)
+  return {
+    css: await readBuildCss(outDir),
+    classNames: await readBuildClassNames(outDir),
+  }
+}
+
+function expectClassNameFormat(output: BuildOutput, variant: BuildVariant): void {
+  // Builds run in production mode, so plugin-default identifiers resolve to `short`
+  const {pattern, firstClassPrefixes} = classNameExpectation(variant.identifiers, 'short')
+  for (const [exportName, classList] of Object.entries(output.classNames)) {
+    for (const className of classList.split(' ')) {
+      expect(className, `${exportName} class ${className}`).toMatch(pattern)
+      expect(output.css, `expected a CSS rule for ${exportName} (.${className})`).toContain(
+        `.${className}`,
+      )
+    }
+    if (firstClassPrefixes) {
+      const prefix = firstClassPrefixes[exportName as keyof FixtureClassNames]
+      expect(classList, `${exportName} debug ID`).toMatch(new RegExp(`^${prefix}`))
+    }
+  }
+}
+
+function expectCssMarkers(output: BuildOutput, variant: BuildVariant): void {
+  const minified = variant.cssMinify === 'true' || variant.cssMinify === 'lightningcss'
+  if (minified) {
+    // Minifiers normalize the colour markers to hex
+    expect(output.css).toContain('#010203')
+    expect(output.css).toContain('#040506')
+  } else {
+    expect(output.css).toContain('rgb(1, 2, 3)')
+    expect(output.css).toContain('rgb(4, 5, 6)')
+  }
+  expect(output.css).toContain('40rem')
+
+  // The `veStudioOverlay` rule shows whether `cssTarget` lowering was applied
+  const overlayClass = output.classNames.overlay
+  const overlayRule = output.css.match(new RegExp(`\\.${overlayClass}[^{]*\\{([^}]*)\\}`))
+  expect(overlayRule, `expected a CSS rule for .${overlayClass}`).toBeTruthy()
+  if (variant.cssTarget === 'chrome61') {
+    // chrome61 predates the `inset` shorthand, so it must be lowered to `top`/`right`/…
+    expect(overlayRule![1]).not.toMatch(/inset\s*:/)
+    expect(overlayRule![1]).toMatch(/top\s*:/)
+  } else {
+    expect(overlayRule![1]).toMatch(/inset\s*:/)
+  }
+}
+
+describe('sanity build', () => {
+  test.each(buildVariants.map((variant) => [variant.slug, variant] as const))(
+    '%s: fork output matches the upstream reference',
+    async (_slug, variant) => {
+      // The upstream plugin is the reference for expected output
+      const upstream = await buildStudio('upstream', variant)
+      expectClassNameFormat(upstream, variant)
+      expectCssMarkers(upstream, variant)
+
+      const fork = await buildStudio('fork', variant)
+      expect(fork.classNames).toEqual(upstream.classNames)
+      expect(fork.css).toBe(upstream.css)
+    },
+  )
+})

--- a/integration/vanilla-extract-studio/test/dev.test.ts
+++ b/integration/vanilla-extract-studio/test/dev.test.ts
@@ -1,0 +1,94 @@
+import {describe, expect, test} from 'vitest'
+import {
+  extractDevClassNames,
+  extractVirtualCssImports,
+  startSanityDev,
+  type FixtureClassNames,
+  type PluginImplementation,
+} from './helpers.ts'
+import {classNameExpectation, devVariants, type StudioVariant} from './variants.ts'
+
+interface DevOutput {
+  css: string
+  classNames: FixtureClassNames
+}
+
+/**
+ * Starts `sanity dev`, requests the transformed `.css.ts` modules like the browser would, and
+ * follows their virtual `.vanilla.css` imports (with `?direct`, which serves the plain CSS
+ * text) to collect the CSS the studio receives during development.
+ */
+async function collectDevOutput(
+  implementation: PluginImplementation,
+  variant: StudioVariant,
+): Promise<DevOutput> {
+  const server = await startSanityDev(implementation, variant.env)
+  try {
+    const modules = await Promise.all([
+      server.fetchText('/src/styles.css.ts'),
+      server.fetchText('/src/button.css.ts'),
+    ])
+    const exports: Record<string, string> = {}
+    const cssImports = new Set<string>()
+    for (const code of modules) {
+      Object.assign(exports, extractDevClassNames(code))
+      for (const specifier of extractVirtualCssImports(code)) cssImports.add(specifier)
+    }
+    for (const exportName of ['veStudioDialog', 'veStudioOverlay', 'veStudioButton']) {
+      expect(exports[exportName], `expected ${exportName} in the transformed modules`).toBeTruthy()
+    }
+    expect(cssImports.size, 'expected virtual .vanilla.css imports in dev').toBeGreaterThan(0)
+    const css = (
+      await Promise.all(
+        [...cssImports]
+          .toSorted()
+          .map((specifier) =>
+            server.fetchText(specifier + (specifier.includes('?') ? '&direct' : '?direct')),
+          ),
+      )
+    ).join('\n')
+    return {
+      css,
+      classNames: {
+        dialog: exports['veStudioDialog']!,
+        overlay: exports['veStudioOverlay']!,
+        button: exports['veStudioButton']!,
+      },
+    }
+  } finally {
+    await server.stop()
+  }
+}
+
+describe('sanity dev', () => {
+  test.each(devVariants.map((variant) => [variant.slug, variant] as const))(
+    '%s: fork output matches the upstream reference',
+    async (_slug, variant) => {
+      // The upstream plugin is the reference for expected output
+      const upstream = await collectDevOutput('upstream', variant)
+
+      // Dev servers run in development mode, so plugin-default identifiers resolve to `debug`
+      const {pattern, firstClassPrefixes} = classNameExpectation(variant.identifiers, 'debug')
+      for (const [exportName, classList] of Object.entries(upstream.classNames)) {
+        for (const className of classList.split(' ')) {
+          expect(className, `${exportName} class ${className}`).toMatch(pattern)
+          expect(upstream.css, `expected a CSS rule for ${exportName} (.${className})`).toContain(
+            `.${className}`,
+          )
+        }
+        if (firstClassPrefixes) {
+          const prefix = firstClassPrefixes[exportName as keyof FixtureClassNames]
+          expect(classList, `${exportName} debug ID`).toMatch(new RegExp(`^${prefix}`))
+        }
+      }
+      // Dev CSS is never minified
+      expect(upstream.css).toContain('rgb(1, 2, 3)')
+      expect(upstream.css).toContain('rgb(4, 5, 6)')
+      expect(upstream.css).toContain('40rem')
+
+      const fork = await collectDevOutput('fork', variant)
+      expect(fork.classNames).toEqual(upstream.classNames)
+      expect(fork.css).toBe(upstream.css)
+    },
+  )
+})

--- a/integration/vanilla-extract-studio/test/helpers.ts
+++ b/integration/vanilla-extract-studio/test/helpers.ts
@@ -1,0 +1,246 @@
+import {spawn, type ChildProcess} from 'node:child_process'
+import {readdir, readFile} from 'node:fs/promises'
+import {createServer} from 'node:net'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+export const studioRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+export const outputRoot = path.join(studioRoot, 'output')
+
+const sanityBin = path.join(studioRoot, 'node_modules', '.bin', 'sanity')
+
+/** The two implementations under test; `upstream` is the reference for expected output. */
+export type PluginImplementation = 'fork' | 'upstream'
+
+/**
+ * The environment for a spawned `sanity` command. `NODE_ENV` is removed deliberately: the
+ * CLI is normally run from a terminal where it is unset, and the behaviour under test depends
+ * on it (`@vanilla-extract/css` ships `NODE_ENV`-switching CJS wrappers, and `vite build`
+ * flips `NODE_ENV` to `production` mid-process — a divergence a test-runner-provided
+ * `NODE_ENV=test` would mask).
+ */
+function commandEnv(
+  implementation: PluginImplementation,
+  variantEnv: Record<string, string>,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    DO_NOT_TRACK: '1',
+    VE_PLUGIN: implementation,
+    ...variantEnv,
+  }
+  delete env['NODE_ENV']
+  // Vitest propagates NODE_OPTIONS (e.g. debugger/loader hooks) that shouldn't leak into the
+  // studio commands under test.
+  delete env['NODE_OPTIONS']
+  return env
+}
+
+export interface SanityCommandResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+/** Runs a `sanity` CLI command to completion in the studio root. */
+export function runSanityCommand(
+  args: string[],
+  implementation: PluginImplementation,
+  variantEnv: Record<string, string>,
+): Promise<SanityCommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(sanityBin, args, {
+      cwd: studioRoot,
+      env: commandEnv(implementation, variantEnv),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => (stdout += chunk.toString()))
+    child.stderr.on('data', (chunk: Buffer) => (stderr += chunk.toString()))
+    child.on('error', reject)
+    child.on('close', (code) => {
+      resolve({exitCode: code ?? -1, stdout, stderr})
+    })
+  })
+}
+
+/** Formats a failed command for assertion messages. */
+export function describeResult(result: SanityCommandResult): string {
+  return `exit code ${result.exitCode}\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+}
+
+async function collectFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, {recursive: true, withFileTypes: true})
+  return entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => path.join(entry.parentPath, entry.name))
+}
+
+/**
+ * The concatenated CSS assets of a build output, ordered by their hash-stripped file names so
+ * content-hash differences between two builds don't affect the comparison.
+ */
+export async function readBuildCss(outDir: string): Promise<string> {
+  const files = (await collectFiles(outDir)).filter((file) => file.endsWith('.css'))
+  const withKeys = await Promise.all(
+    files.map(async (file) => ({
+      key: path.basename(file).replace(/-[\w]+\.css$/, '.css'),
+      css: await readFile(file, 'utf8'),
+    })),
+  )
+  return withKeys
+    .toSorted((a, b) => a.key.localeCompare(b.key))
+    .map((entry) => entry.css)
+    .join('\n')
+}
+
+/** The class lists of the fixture's `.css.ts` exports, keyed like the schema description. */
+export interface FixtureClassNames {
+  dialog: string
+  overlay: string
+  button: string
+}
+
+const classNamesPattern =
+  /dialog:(?<dialog>[^\s"'`$]+) overlay:(?<overlay>[^\s"'`$]+) button:(?<button>[^"'`\n$]+)/
+
+/** Parses the fixture class names out of a schema description occurrence in `source`. */
+export function parseFixtureClassNames(source: string): FixtureClassNames | undefined {
+  const match = source.match(classNamesPattern)
+  if (!match) return undefined
+  const {dialog, overlay, button} = match.groups!
+  return {dialog: dialog!, overlay: overlay!, button: button!.trim()}
+}
+
+/** Parses the `veStudio*` export bindings of the compiled `.css.ts` modules out of JS code. */
+export function parseFixtureBindings(source: string): FixtureClassNames | undefined {
+  const bindings: Record<string, string> = {}
+  for (const match of source.matchAll(/\b(veStudio[A-Za-z]+)\s*=\s*(["'])([^"'\n]+)\2/g)) {
+    bindings[match[1]!] = match[3]!
+  }
+  const {veStudioDialog, veStudioOverlay, veStudioButton} = bindings
+  if (!veStudioDialog || !veStudioOverlay || !veStudioButton) return undefined
+  return {dialog: veStudioDialog, overlay: veStudioOverlay, button: veStudioButton}
+}
+
+/**
+ * The fixture class names as they appear in the built JS. The builds run with `--no-minify`,
+ * so the compiled `.css.ts` modules keep their `veStudio…` binding names; if a future bundler
+ * folds the constants away instead, the schema-description literal of `sanity.config.ts`
+ * still carries them.
+ */
+export async function readBuildClassNames(outDir: string): Promise<FixtureClassNames> {
+  const files = (await collectFiles(outDir)).filter((file) => file.endsWith('.js'))
+  for (const file of files) {
+    const source = await readFile(file, 'utf8')
+    const classNames = parseFixtureBindings(source) ?? parseFixtureClassNames(source)
+    if (classNames) return classNames
+  }
+  throw new Error(`No fixture class names found in the JS output of ${outDir}`)
+}
+
+async function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (typeof address === 'object' && address) {
+        server.close(() => resolve(address.port))
+      } else {
+        server.close(() => reject(new Error('Could not allocate a port')))
+      }
+    })
+  })
+}
+
+export interface DevServerHandle {
+  port: number
+  output: () => string
+  fetchText: (pathname: string) => Promise<string>
+  stop: () => Promise<void>
+}
+
+/**
+ * Starts `sanity dev` and waits until it serves transformed modules. Always `stop()` the
+ * handle (the tests do so in `finally` blocks) so no dev server outlives its test.
+ */
+export async function startSanityDev(
+  implementation: PluginImplementation,
+  variantEnv: Record<string, string>,
+): Promise<DevServerHandle> {
+  const port = await findFreePort()
+  const child: ChildProcess = spawn(
+    sanityBin,
+    ['dev', '--host', '127.0.0.1', '--port', String(port)],
+    {
+      cwd: studioRoot,
+      env: commandEnv(implementation, variantEnv),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  )
+  let output = ''
+  child.stdout?.on('data', (chunk: Buffer) => (output += chunk.toString()))
+  child.stderr?.on('data', (chunk: Buffer) => (output += chunk.toString()))
+  let exited = false
+  const exitPromise = new Promise<void>((resolve) => {
+    child.on('close', () => {
+      exited = true
+      resolve()
+    })
+  })
+
+  const fetchText = async (pathname: string): Promise<string> => {
+    const response = await fetch(`http://127.0.0.1:${port}${pathname}`)
+    if (!response.ok) {
+      throw new Error(`GET ${pathname} responded with ${response.status}`)
+    }
+    return response.text()
+  }
+
+  const stop = async (): Promise<void> => {
+    if (exited) return
+    child.kill('SIGTERM')
+    const killTimer = setTimeout(() => child.kill('SIGKILL'), 5_000)
+    await exitPromise
+    clearTimeout(killTimer)
+  }
+
+  // Readiness: the dev server responds to a module transform request
+  const deadline = Date.now() + 120_000
+  for (;;) {
+    if (exited) {
+      throw new Error(`sanity dev exited before becoming ready\n${output}`)
+    }
+    try {
+      const code = await fetchText('/src/styles.css.ts')
+      if (code.includes('veStudioDialog')) break
+    } catch {
+      // not ready yet
+    }
+    if (Date.now() > deadline) {
+      await stop()
+      throw new Error(`sanity dev did not become ready in time\n${output}`)
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+
+  return {port, output: () => output, fetchText, stop}
+}
+
+/** The virtual `.vanilla.css` module specifiers imported by a transformed `.css.ts` module. */
+export function extractVirtualCssImports(code: string): string[] {
+  return [...code.matchAll(/import\s+["']([^"']+\.vanilla\.css[^"']*)["']/g)].map(
+    (match) => match[1]!,
+  )
+}
+
+/** The exported class names of a transformed `.css.ts` module served by the dev server. */
+export function extractDevClassNames(code: string): Record<string, string> {
+  const classNames: Record<string, string> = {}
+  for (const match of code.matchAll(/\b(veStudio[A-Za-z]+)\s*=\s*(["'])([^"']+)\2/g)) {
+    classNames[match[1]!] = match[3]!
+  }
+  return classNames
+}

--- a/integration/vanilla-extract-studio/test/helpers.ts
+++ b/integration/vanilla-extract-studio/test/helpers.ts
@@ -1,5 +1,6 @@
 import {spawn, type ChildProcess} from 'node:child_process'
 import {readdir, readFile} from 'node:fs/promises'
+import {createRequire} from 'node:module'
 import {createServer} from 'node:net'
 import path from 'node:path'
 import {fileURLToPath} from 'node:url'
@@ -7,7 +8,15 @@ import {fileURLToPath} from 'node:url'
 export const studioRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 export const outputRoot = path.join(studioRoot, 'output')
 
-const sanityBin = path.join(studioRoot, 'node_modules', '.bin', 'sanity')
+/**
+ * The `sanity` CLI entry, resolved to the package's real JS bin script and spawned through
+ * `process.execPath` — the `node_modules/.bin` shims are platform-specific (`sanity` on
+ * POSIX, `sanity.cmd` on Windows).
+ */
+const sanityBinScript = (() => {
+  const packageJsonPath = createRequire(import.meta.url).resolve('sanity/package.json')
+  return path.join(path.dirname(packageJsonPath), 'bin/sanity')
+})()
 
 /** The two implementations under test; `upstream` is the reference for expected output. */
 export type PluginImplementation = 'fork' | 'upstream'
@@ -49,7 +58,7 @@ export function runSanityCommand(
   variantEnv: Record<string, string>,
 ): Promise<SanityCommandResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(sanityBin, args, {
+    const child = spawn(process.execPath, [sanityBinScript, ...args], {
       cwd: studioRoot,
       env: commandEnv(implementation, variantEnv),
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -172,8 +181,8 @@ export async function startSanityDev(
 ): Promise<DevServerHandle> {
   const port = await findFreePort()
   const child: ChildProcess = spawn(
-    sanityBin,
-    ['dev', '--host', '127.0.0.1', '--port', String(port)],
+    process.execPath,
+    [sanityBinScript, 'dev', '--host', '127.0.0.1', '--port', String(port)],
     {
       cwd: studioRoot,
       env: commandEnv(implementation, variantEnv),

--- a/integration/vanilla-extract-studio/test/schema-extract.test.ts
+++ b/integration/vanilla-extract-studio/test/schema-extract.test.ts
@@ -1,0 +1,75 @@
+import {mkdir, readFile, rm} from 'node:fs/promises'
+import path from 'node:path'
+import {describe, expect, test} from 'vitest'
+import {
+  describeResult,
+  outputRoot,
+  parseFixtureClassNames,
+  runSanityCommand,
+  studioRoot,
+  type FixtureClassNames,
+  type PluginImplementation,
+} from './helpers.ts'
+import {classNameExpectation, schemaExtractVariants, type StudioVariant} from './variants.ts'
+
+/**
+ * `sanity schema extract` evaluates `sanity.config.ts` (and through it the `.css.ts` modules)
+ * in the CLI's Node.js worker, where the vanilla-extract plugin runs inside a Vite server
+ * configured with `ssr.noExternal: true` — a very different environment from `sanity dev` /
+ * `sanity build`. The fixture schema embeds the generated class names in a field description,
+ * so the extracted schema also compares identifier output across implementations.
+ */
+async function extractSchema(
+  implementation: PluginImplementation,
+  variant: StudioVariant,
+): Promise<{schema: unknown; classNames: FixtureClassNames}> {
+  const schemaPath = path.join(outputRoot, 'schema', `${implementation}-${variant.slug}.json`)
+  await mkdir(path.dirname(schemaPath), {recursive: true})
+  await rm(schemaPath, {force: true})
+  const result = await runSanityCommand(
+    // The CLI resolves `--path` against the working directory (absolute paths included)
+    ['schema', 'extract', '--path', path.relative(studioRoot, schemaPath)],
+    implementation,
+    variant.env,
+  )
+  expect(
+    result.exitCode,
+    `sanity schema extract (${implementation}): ${describeResult(result)}`,
+  ).toBe(0)
+
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8')) as unknown
+  const documentType = (schema as {name?: string}[]).find(
+    (type) => type.name === 'veStyledDocument',
+  )
+  expect(documentType, 'expected the veStyledDocument type in the extracted schema').toBeTruthy()
+  const classNames = parseFixtureClassNames(JSON.stringify(documentType))
+  expect(classNames, 'expected the class-name description in the extracted schema').toBeTruthy()
+  return {schema, classNames: classNames!}
+}
+
+describe('sanity schema extract', () => {
+  test.each(schemaExtractVariants.map((variant) => [variant.slug, variant] as const))(
+    '%s: fork output matches the upstream reference',
+    async (_slug, variant) => {
+      // The upstream plugin is the reference for expected output
+      const upstream = await extractSchema('upstream', variant)
+
+      // The schema-extraction worker runs in development mode, so plugin-default identifiers
+      // resolve to `debug`
+      const {pattern, firstClassPrefixes} = classNameExpectation(variant.identifiers, 'debug')
+      for (const [exportName, classList] of Object.entries(upstream.classNames)) {
+        for (const className of classList.split(' ')) {
+          expect(className, `${exportName} class ${className}`).toMatch(pattern)
+        }
+        if (firstClassPrefixes) {
+          const prefix = firstClassPrefixes[exportName as keyof FixtureClassNames]
+          expect(classList, `${exportName} debug ID`).toMatch(new RegExp(`^${prefix}`))
+        }
+      }
+
+      const fork = await extractSchema('fork', variant)
+      expect(fork.classNames).toEqual(upstream.classNames)
+      expect(fork.schema).toEqual(upstream.schema)
+    },
+  )
+})

--- a/integration/vanilla-extract-studio/test/variants.ts
+++ b/integration/vanilla-extract-studio/test/variants.ts
@@ -1,0 +1,132 @@
+/**
+ * The option matrix the studio commands are compared across. Every variant runs once with the
+ * fork (`@sanity/vanilla-extract-vite-plugin`) and once with the upstream reference
+ * (`@vanilla-extract/vite-plugin`); `sanity.cli.ts` maps the `env` entries onto the plugin
+ * options and the Vite CSS build options.
+ */
+
+/** How the generated identifiers are expected to look in the compared output. */
+export type IdentifierVariant = 'default' | 'short' | 'debug' | 'prefix'
+
+export interface StudioVariant {
+  slug: string
+  /** `VE_*` environment variables consumed by `sanity.cli.ts`. */
+  env: Record<string, string>
+  identifiers: IdentifierVariant
+}
+
+export interface BuildVariant extends StudioVariant {
+  cssMinify: 'default' | 'true' | 'false' | 'lightningcss'
+  cssTarget?: string
+}
+
+function variantEnv(
+  identifiers: IdentifierVariant,
+  cssMinify?: BuildVariant['cssMinify'],
+  cssTarget?: string,
+): Record<string, string> {
+  const env: Record<string, string> = {}
+  if (identifiers !== 'default') env['VE_IDENTIFIERS'] = identifiers
+  if (cssMinify && cssMinify !== 'default') env['VE_CSS_MINIFY'] = cssMinify
+  if (cssTarget) env['VE_CSS_TARGET'] = cssTarget
+  return env
+}
+
+/**
+ * `sanity build` variants. The builds run with `--no-minify` so the JS output stays greppable
+ * for class names; CSS minification is driven explicitly through `build.cssMinify`, so the
+ * minifier still runs against the extracted CSS where the variant asks for it.
+ */
+export const buildVariants: BuildVariant[] = [
+  {
+    slug: 'defaults',
+    env: variantEnv('default'),
+    identifiers: 'default',
+    cssMinify: 'default',
+  },
+  {
+    slug: 'debug-identifiers',
+    env: variantEnv('debug'),
+    identifiers: 'debug',
+    cssMinify: 'default',
+  },
+  {
+    slug: 'prefix-identifiers',
+    env: variantEnv('prefix'),
+    identifiers: 'prefix',
+    cssMinify: 'default',
+  },
+  {
+    slug: 'css-minify',
+    env: variantEnv('short', 'true'),
+    identifiers: 'short',
+    cssMinify: 'true',
+  },
+  {
+    slug: 'css-minify-lightningcss',
+    env: variantEnv('debug', 'lightningcss'),
+    identifiers: 'debug',
+    cssMinify: 'lightningcss',
+  },
+  {
+    // `cssTarget` lowering is applied by lightningcss, so the target variant enables it as
+    // the minifier to make the lowering observable (`inset` → `top`/`right`/`bottom`/`left`)
+    slug: 'css-target',
+    env: variantEnv('debug', 'lightningcss', 'chrome61'),
+    identifiers: 'debug',
+    cssMinify: 'lightningcss',
+    cssTarget: 'chrome61',
+  },
+]
+
+/** `sanity dev` and `sanity schema extract` variants: the CSS build options don't apply. */
+export const devVariants: StudioVariant[] = [
+  {slug: 'defaults', env: variantEnv('default'), identifiers: 'default'},
+  {slug: 'short-identifiers', env: variantEnv('short'), identifiers: 'short'},
+  {slug: 'prefix-identifiers', env: variantEnv('prefix'), identifiers: 'prefix'},
+]
+
+export const schemaExtractVariants: StudioVariant[] = devVariants
+
+export interface ClassNameExpectation {
+  /** Every class of every export must match. */
+  pattern: RegExp
+  /**
+   * For `debug` identifiers: the expected `<fileName>_<debugId>__` prefix of each export's
+   * own class (composed styles append their dependencies' classes after it).
+   */
+  firstClassPrefixes?: {dialog: string; overlay: string; button: string}
+}
+
+/**
+ * The expected class-name shape for an identifier variant. `defaultFormat` is what the
+ * plugin defaults resolve to for the command under test: `short` for production builds,
+ * `debug` for dev servers and the schema-extraction worker.
+ */
+export function classNameExpectation(
+  identifiers: IdentifierVariant,
+  defaultFormat: 'short' | 'debug',
+): ClassNameExpectation {
+  const format = identifiers === 'default' ? defaultFormat : identifiers
+  switch (format) {
+    case 'short':
+      // A bare hash (underscore-prefixed when it starts with a digit), no debug info
+      return {pattern: /^_?[a-z0-9]+$/i}
+    case 'debug':
+      // `<fileName>_<debugId>__<hash>`, where the debug ID is the local binding name
+      return {
+        pattern: /^(styles|button)_\w+__[a-z0-9]+$/i,
+        firstClassPrefixes: {
+          dialog: 'styles_veStudioDialog__',
+          overlay: 'styles_veStudioOverlay__',
+          button: 'button_veStudioButton__',
+        },
+      }
+    case 'prefix':
+      // The custom identifier function of `sanity.cli.ts`: `ve_<hash>` (no debug IDs are
+      // injected for custom identifier functions, matching upstream)
+      return {pattern: /^ve_[a-z0-9]+$/i}
+    default:
+      throw new Error(`Unsupported identifier variant: ${String(format)}`)
+  }
+}

--- a/integration/vanilla-extract-studio/tsconfig.json
+++ b/integration/vanilla-extract-studio/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@sanity/tsconfig/strictest",
+  "include": ["src", "test", "sanity.cli.ts", "sanity.config.ts", "vitest.config.ts"],
+  "exclude": ["output", "dist", ".sanity"],
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "rootDir": ".",
+    "types": ["node"]
+  }
+}

--- a/integration/vanilla-extract-studio/vitest.config.ts
+++ b/integration/vanilla-extract-studio/vitest.config.ts
@@ -1,0 +1,13 @@
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    // Every test spawns full `sanity` CLI commands against the same studio directory
+    // (shared `.sanity` runtime and Vite caches), so they must run one at a time.
+    fileParallelism: false,
+    maxWorkers: 1,
+    testTimeout: 600_000,
+    hookTimeout: 120_000,
+  },
+})

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -3,6 +3,7 @@
   "treatConfigHintsAsErrors": true,
   "ignoreWorkspaces": [
     "benchmarks/*",
+    "integration/*",
     "playground/*",
     "css-playground/*",
     "packages/@sanity/tsdown-config/test/fixtures/**",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "css-playground:test": "pnpm --filter './css-playground/**' test",
     "css-playground:typecheck": "pnpm --filter './css-playground/**' typecheck",
     "format": "prettier --write --cache --ignore-unknown . && oxlint --type-aware --fix --quiet",
+    "integration:test": "pnpm --filter './integration/**' test",
+    "integration:typecheck": "pnpm --filter './integration/**' typecheck",
     "knip": "knip",
     "lint": "oxlint --type-aware",
     "playground:build": "pnpm --filter './playground/**' build",

--- a/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
@@ -229,8 +229,32 @@ async function createCompilerServer({
 }) {
   const pkg = getPackageInfo(root)
 
+  // The compiler evaluates `.css.ts` modules in Node, so its module resolution must stay
+  // Node-shaped regardless of what the consuming app's config says — `ssr` and `environments`
+  // are deliberately not forwarded (destructured off), and the resolve conditions are pinned:
+  //
+  // - `ssr.resolve.externalConditions` must prefer the `module` (ESM) builds of externalized
+  //   dependencies. Vite's default (`['node', 'module-sync']`) falls through to the `default`
+  //   (CJS) exports of the `@vanilla-extract/*` packages, whose wrappers pick their dev or
+  //   prod build off `NODE_ENV` at first load. A CLI host (e.g. `sanity build`) typically
+  //   imports this plugin before `vite build` flips `NODE_ENV` to `production`, so the host
+  //   and the module runner would otherwise load two different copies of
+  //   `@vanilla-extract/css/adapter` — the evaluated modules then bind the compilation
+  //   adapter to one copy while `style()` appends CSS through the other (the mock adapter),
+  //   silently dropping all CSS while the class-name exports keep working.
+  // - The parent `ssr` options must not leak in: `ssr.noExternal: true` (set e.g. by the
+  //   `sanity schema extract` worker) would inline CJS dependencies, which Vite's native
+  //   `ModuleRunner` (unlike the legacy `vite-node`) cannot evaluate, and
+  //   `ssr.target: 'webworker'` would flip the SSR environment to browser-leaning resolution.
+  //
+  // Covered end-to-end by the `@integration/vanilla-extract-studio` suite, which compares
+  // `sanity dev` / `sanity build` / `sanity schema extract` output against
+  // `@vanilla-extract/vite-plugin`.
+  const {ssr: _ssr, environments: _environments, ...inheritedViteConfig} = viteConfig
+  const nodeResolveConditions = ['node', 'import', 'module', 'default']
+
   const server = await createServer({
-    ...viteConfig,
+    ...inheritedViteConfig,
     // The compiler server should not rewrite imported asset URLs within vanilla-extract
     // stylesheets. Doing so interferes with Vite's resolution and bundling of these assets at
     // build time.
@@ -253,6 +277,17 @@ async function createCompilerServer({
     },
     build: {
       assetsInlineLimit: viteConfig.build?.assetsInlineLimit,
+    },
+    resolve: {
+      ...viteConfig.resolve,
+      conditions: nodeResolveConditions,
+      mainFields: ['module', 'jsnext:main', 'jsnext', 'main'],
+    },
+    ssr: {
+      resolve: {
+        conditions: nodeResolveConditions,
+        externalConditions: nodeResolveConditions,
+      },
     },
     // Vite's default SSR externalization applies: project files and linked packages are
     // evaluated through the runner (so they're cached in the module graph), while node_modules

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/node-env-transition-build.mts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/node-env-transition-build.mts
@@ -1,0 +1,43 @@
+/**
+ * Child-process half of `node-env-transition.test.ts`; spawned without `NODE_ENV` so the
+ * `NODE_ENV`-switching CJS wrappers of `@vanilla-extract/css` are first loaded (through this
+ * plugin's own imports, like a CLI host loading its config would) before `vite build` flips
+ * `NODE_ENV` to `production` mid-process. Prints the build's CSS assets and entry chunk as
+ * JSON for the parent test to assert on.
+ */
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {vanillaExtractPlugin} from '../../src/index.ts'
+
+if (process.env['NODE_ENV']) {
+  throw new Error(`expected NODE_ENV to be unset, got ${JSON.stringify(process.env['NODE_ENV'])}`)
+}
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'app')
+
+// Imported after the plugin (and through it `@vanilla-extract/css`), mirroring a CLI host
+const {build} = await import('vite')
+
+const result = await build({
+  root: appRoot,
+  configFile: false,
+  logLevel: 'silent',
+  plugins: [vanillaExtractPlugin()],
+  build: {write: false},
+})
+
+if (Array.isArray(result) || !('output' in result)) {
+  throw new Error('expected a single build output')
+}
+let css = ''
+let entry = ''
+for (const assetOrChunk of result.output) {
+  if (assetOrChunk.type === 'asset' && assetOrChunk.fileName.endsWith('.css')) {
+    const {source} = assetOrChunk
+    css += typeof source === 'string' ? source : new TextDecoder().decode(source)
+  } else if (assetOrChunk.type === 'chunk' && assetOrChunk.isEntry) {
+    entry = assetOrChunk.code
+  }
+}
+
+process.stdout.write(JSON.stringify({css, entry}))

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/node-env-transition.test.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/node-env-transition.test.ts
@@ -1,0 +1,54 @@
+import {execFile} from 'node:child_process'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {promisify} from 'node:util'
+import {expect, test} from 'vitest'
+
+const execFileAsync = promisify(execFile)
+
+const scriptPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixtures/node-env-transition-build.mts',
+)
+
+/**
+ * Regression test for CSS silently dropped from builds inside CLI hosts like `sanity build`
+ * (https://github.com/sanity-io/pkg-utils/issues/3073).
+ *
+ * The mechanism needs a `NODE_ENV` transition, which an in-process vitest build can't
+ * reproduce (the test runner pins `NODE_ENV` before anything loads): the `@vanilla-extract/*`
+ * CJS wrappers pick their dev or prod build off `NODE_ENV` at first load. A CLI host imports
+ * this plugin (and through it `@vanilla-extract/css`) with `NODE_ENV` unset, then `vite build`
+ * flips `NODE_ENV` to `production` mid-process — so when the compiler's module runner
+ * resolved the externalized `@vanilla-extract/css` to its CJS `default` export (Vite's
+ * default `externalConditions` don't include `module`), the evaluated `.css.ts` modules
+ * bound the compilation adapter to the dev copy while `style()` appended CSS through the prod
+ * copy's mock adapter: class names kept working, CSS vanished. The compiler now pins Node
+ * resolve conditions (preferring the single-file ESM builds), keeping one adapter instance.
+ */
+test('emits CSS when the plugin is loaded before `vite build` sets NODE_ENV', async () => {
+  const env = {...process.env}
+  delete env['NODE_ENV']
+  // Don't leak test-runner Node options (e.g. loader hooks) into the child
+  delete env['NODE_OPTIONS']
+
+  const {stdout} = await execFileAsync(
+    process.execPath,
+    [
+      // The child imports this package's TypeScript sources directly; older Node needs the
+      // flag for that (a no-op wherever type stripping is on by default)
+      ...(process.features.typescript ? [] : ['--experimental-strip-types']),
+      scriptPath,
+    ],
+    {env, maxBuffer: 64 * 1024 * 1024},
+  )
+
+  const {css, entry} = JSON.parse(stdout) as {css: string; entry: string}
+
+  // The entry exports the class names either way — the regression was CSS-only
+  expect(entry).toContain('className')
+
+  // Both `.css.ts` modules' rules must survive into the emitted CSS
+  expect(css.includes('rgb(1, 2, 3)') || css.includes('#010203'), `css was: ${css}`).toBe(true)
+  expect(css.includes('rgb(4, 5, 6)') || css.includes('#040506'), `css was: ${css}`).toBe(true)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,7 +311,7 @@ importers:
         version: link:../sanity-css-vanilla-extract-test
       tap:
         specifier: ^21.7.4
-        version: 21.7.4(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+        version: 21.7.4(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -625,6 +625,51 @@ importers:
       webpack-dev-server:
         specifier: ^6.0.0
         version: 6.0.0(tslib@2.8.1)(webpack-cli@7.2.1)(webpack@5.108.4)
+
+  integration/vanilla-extract-studio:
+    devDependencies:
+      '@sanity/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/@sanity/tsconfig
+      '@sanity/vanilla-extract-vite-plugin':
+        specifier: workspace:*
+        version: link:../../packages/@sanity/vanilla-extract-vite-plugin
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@vanilla-extract/css':
+        specifier: ^1.21.1
+        version: 1.21.1
+      '@vanilla-extract/vite-plugin':
+        specifier: ^5.2.5
+        version: 5.2.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      sanity:
+        specifier: ^6.5.0
+        version: 6.5.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.14)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(@sanity/cli-core@2.4.0(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.2.0)(styled-components@6.4.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.49.0)(typescript@7.0.2)
+      styled-components:
+        specifier: ^6.1.19
+        version: 6.4.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite:
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/@sanity/parse-package-json:
     dependencies:
@@ -16742,6 +16787,16 @@ snapshots:
 
   '@inquirer/ansi@2.0.7': {}
 
+  '@inquirer/checkbox@4.3.2(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/checkbox@4.3.2(@types/node@26.1.1)':
     dependencies:
       '@inquirer/ansi': 1.0.2
@@ -16752,6 +16807,15 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
 
+  '@inquirer/checkbox@5.2.1(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/checkbox@5.2.1(@types/node@26.1.1)':
     dependencies:
       '@inquirer/ansi': 2.0.7
@@ -16761,6 +16825,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
 
+  '@inquirer/confirm@5.1.21(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/confirm@5.1.21(@types/node@26.1.1)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@26.1.1)
@@ -16768,12 +16839,32 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
 
+  '@inquirer/confirm@6.1.1(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/confirm@6.1.1(@types/node@26.1.1)':
     dependencies:
       '@inquirer/core': 11.2.1(@types/node@26.1.1)
       '@inquirer/type': 4.0.7(@types/node@26.1.1)
     optionalDependencies:
       '@types/node': 26.1.1
+
+  '@inquirer/core@10.3.2(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.13.3
 
   '@inquirer/core@10.3.2(@types/node@26.1.1)':
     dependencies:
@@ -16788,6 +16879,18 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
 
+  '@inquirer/core@11.2.1(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/core@11.2.1(@types/node@26.1.1)':
     dependencies:
       '@inquirer/ansi': 2.0.7
@@ -16800,6 +16903,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
 
+  '@inquirer/editor@4.2.23(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/editor@4.2.23(@types/node@26.1.1)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@26.1.1)
@@ -16807,6 +16918,14 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@26.1.1)
     optionalDependencies:
       '@types/node': 26.1.1
+
+  '@inquirer/editor@5.2.2(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/external-editor': 3.0.3(@types/node@24.13.3)
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
 
   '@inquirer/editor@5.2.2(@types/node@26.1.1)':
     dependencies:
@@ -16816,6 +16935,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
 
+  '@inquirer/expand@4.0.23(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/expand@4.0.23(@types/node@26.1.1)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@26.1.1)
@@ -16823,6 +16950,13 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 26.1.1
+
+  '@inquirer/expand@5.1.1(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
 
   '@inquirer/expand@5.1.1(@types/node@26.1.1)':
     dependencies:
@@ -16845,6 +16979,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
 
+  '@inquirer/external-editor@3.0.3(@types/node@24.13.3)':
+    dependencies:
+      chardet: 2.2.0
+      iconv-lite: 0.7.3
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/external-editor@3.0.3(@types/node@26.1.1)':
     dependencies:
       chardet: 2.2.0
@@ -16856,12 +16997,26 @@ snapshots:
 
   '@inquirer/figures@2.0.7': {}
 
+  '@inquirer/input@4.3.1(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/input@4.3.1(@types/node@26.1.1)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@26.1.1)
       '@inquirer/type': 3.0.10(@types/node@26.1.1)
     optionalDependencies:
       '@types/node': 26.1.1
+
+  '@inquirer/input@5.1.2(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
 
   '@inquirer/input@5.1.2(@types/node@26.1.1)':
     dependencies:
@@ -16870,6 +17025,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
 
+  '@inquirer/number@3.0.23(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/number@3.0.23(@types/node@26.1.1)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@26.1.1)
@@ -16877,12 +17039,27 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
 
+  '@inquirer/number@4.1.1(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/number@4.1.1(@types/node@26.1.1)':
     dependencies:
       '@inquirer/core': 11.2.1(@types/node@26.1.1)
       '@inquirer/type': 4.0.7(@types/node@26.1.1)
     optionalDependencies:
       '@types/node': 26.1.1
+
+  '@inquirer/password@4.0.23(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
 
   '@inquirer/password@4.0.23(@types/node@26.1.1)':
     dependencies:
@@ -16892,6 +17069,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
 
+  '@inquirer/password@5.1.1(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/password@5.1.1(@types/node@26.1.1)':
     dependencies:
       '@inquirer/ansi': 2.0.7
@@ -16899,6 +17084,21 @@ snapshots:
       '@inquirer/type': 4.0.7(@types/node@26.1.1)
     optionalDependencies:
       '@types/node': 26.1.1
+
+  '@inquirer/prompts@7.10.1(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@24.13.3)
+      '@inquirer/confirm': 5.1.21(@types/node@24.13.3)
+      '@inquirer/editor': 4.2.23(@types/node@24.13.3)
+      '@inquirer/expand': 4.0.23(@types/node@24.13.3)
+      '@inquirer/input': 4.3.1(@types/node@24.13.3)
+      '@inquirer/number': 3.0.23(@types/node@24.13.3)
+      '@inquirer/password': 4.0.23(@types/node@24.13.3)
+      '@inquirer/rawlist': 4.1.11(@types/node@24.13.3)
+      '@inquirer/search': 3.2.2(@types/node@24.13.3)
+      '@inquirer/select': 4.4.2(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
 
   '@inquirer/prompts@7.10.1(@types/node@26.1.1)':
     dependencies:
@@ -16915,6 +17115,21 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
 
+  '@inquirer/prompts@8.5.2(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/checkbox': 5.2.1(@types/node@24.13.3)
+      '@inquirer/confirm': 6.1.1(@types/node@24.13.3)
+      '@inquirer/editor': 5.2.2(@types/node@24.13.3)
+      '@inquirer/expand': 5.1.1(@types/node@24.13.3)
+      '@inquirer/input': 5.1.2(@types/node@24.13.3)
+      '@inquirer/number': 4.1.1(@types/node@24.13.3)
+      '@inquirer/password': 5.1.1(@types/node@24.13.3)
+      '@inquirer/rawlist': 5.3.1(@types/node@24.13.3)
+      '@inquirer/search': 4.2.1(@types/node@24.13.3)
+      '@inquirer/select': 5.2.1(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/prompts@8.5.2(@types/node@26.1.1)':
     dependencies:
       '@inquirer/checkbox': 5.2.1(@types/node@26.1.1)
@@ -16930,6 +17145,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
 
+  '@inquirer/rawlist@4.1.11(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/rawlist@4.1.11(@types/node@26.1.1)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@26.1.1)
@@ -16938,12 +17161,28 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
 
+  '@inquirer/rawlist@5.3.1(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/rawlist@5.3.1(@types/node@26.1.1)':
     dependencies:
       '@inquirer/core': 11.2.1(@types/node@26.1.1)
       '@inquirer/type': 4.0.7(@types/node@26.1.1)
     optionalDependencies:
       '@types/node': 26.1.1
+
+  '@inquirer/search@3.2.2(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.13.3
 
   '@inquirer/search@3.2.2(@types/node@26.1.1)':
     dependencies:
@@ -16954,6 +17193,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
 
+  '@inquirer/search@4.2.1(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/search@4.2.1(@types/node@26.1.1)':
     dependencies:
       '@inquirer/core': 11.2.1(@types/node@26.1.1)
@@ -16961,6 +17208,16 @@ snapshots:
       '@inquirer/type': 4.0.7(@types/node@26.1.1)
     optionalDependencies:
       '@types/node': 26.1.1
+
+  '@inquirer/select@4.4.2(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.13.3
 
   '@inquirer/select@4.4.2(@types/node@26.1.1)':
     dependencies:
@@ -16972,6 +17229,15 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
 
+  '@inquirer/select@5.2.1(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/select@5.2.1(@types/node@26.1.1)':
     dependencies:
       '@inquirer/ansi': 2.0.7
@@ -16981,9 +17247,17 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
 
+  '@inquirer/type@3.0.10(@types/node@24.13.3)':
+    optionalDependencies:
+      '@types/node': 24.13.3
+
   '@inquirer/type@3.0.10(@types/node@26.1.1)':
     optionalDependencies:
       '@types/node': 26.1.1
+
+  '@inquirer/type@4.0.7(@types/node@24.13.3)':
+    optionalDependencies:
+      '@types/node': 24.13.3
 
   '@inquirer/type@4.0.7(@types/node@26.1.1)':
     optionalDependencies:
@@ -17006,14 +17280,14 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@5.9.3)':
+  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@5.9.3)':
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node14': 14.1.8
       '@tsconfig/node16': 16.1.8
       '@tsconfig/node18': 18.2.6
       '@tsconfig/node20': 20.1.9
-      '@types/node': 24.13.3
+      '@types/node': 26.1.1
       acorn: 8.17.0
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -17024,14 +17298,14 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.43(@swc/helpers@0.5.23)
 
-  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@6.0.3)':
+  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@6.0.3)':
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node14': 14.1.8
       '@tsconfig/node16': 16.1.8
       '@tsconfig/node18': 18.2.6
       '@tsconfig/node20': 20.1.9
-      '@types/node': 24.13.3
+      '@types/node': 26.1.1
       acorn: 8.17.0
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -17568,6 +17842,18 @@ snapshots:
       empathic: 2.0.0
       exsolve: 1.0.8
 
+  '@module-federation/vite@1.16.14(typescript@7.0.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@module-federation/dts-plugin': 2.7.0(typescript@7.0.2)
+      '@module-federation/runtime': 2.7.0
+      '@module-federation/sdk': 2.7.0
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+
   '@module-federation/vite@1.16.14(typescript@7.0.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@module-federation/dts-plugin': 2.7.0(typescript@7.0.2)
@@ -18079,6 +18365,15 @@ snapshots:
   '@oclif/plugin-help@6.2.53':
     dependencies:
       '@oclif/core': 4.11.14
+
+  '@oclif/plugin-not-found@3.2.88(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/prompts': 7.10.1(@types/node@24.13.3)
+      '@oclif/core': 4.11.14
+      ansis: 3.17.0
+      fast-levenshtein: 3.0.0
+    transitivePeerDependencies:
+      - '@types/node'
 
   '@oclif/plugin-not-found@3.2.88(@types/node@26.1.1)':
     dependencies:
@@ -20097,6 +20392,15 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.2.0':
     optional: true
 
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      picomatch: 4.0.5
+      rolldown: 1.2.0
+    optionalDependencies:
+      '@babel/runtime': 7.29.7
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+
   '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
@@ -20404,6 +20708,61 @@ snapshots:
 
   '@sanity/browserslist-config@1.0.5': {}
 
+  '@sanity/cli-build@4.1.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)':
+    dependencies:
+      '@oclif/core': 4.11.14
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@sanity/cli-core': 2.4.0(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)
+      '@sanity/generate-help-url': 4.0.0
+      '@sanity/schema': 6.5.0(@types/react@19.2.17)
+      '@sanity/telemetry': 1.1.0(react@19.2.7)
+      '@sanity/types': 6.5.0(@types/react@19.2.17)
+      '@sanity/workbench-cli': 1.4.0(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
+      '@vitejs/plugin-react': 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      chokidar: 5.0.0
+      cjs-module-lexer: 2.2.0
+      debug: 4.4.3(supports-color@8.1.1)
+      empathic: 2.0.1
+      lodash-es: 4.18.1
+      node-html-parser: 7.1.0
+      oneline: 2.0.0
+      picomatch: 4.0.5
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      semver: 7.8.5
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      zod: 4.4.3
+    optionalDependencies:
+      babel-plugin-react-compiler: 1.0.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/plugin-transform-runtime'
+      - '@babel/runtime'
+      - '@noble/hashes'
+      - '@types/node'
+      - '@types/react'
+      - '@vitejs/devtools'
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - canvas
+      - esbuild
+      - jiti
+      - less
+      - react-native-b4a
+      - rolldown
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+      - yaml
+
   '@sanity/cli-build@4.1.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@26.1.1)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)':
     dependencies:
       '@oclif/core': 4.11.14
@@ -20459,6 +20818,44 @@ snapshots:
       - vue-tsc
       - yaml
 
+  '@sanity/cli-core@2.4.0(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)':
+    dependencies:
+      '@inquirer/prompts': 8.5.2(@types/node@24.13.3)
+      '@oclif/core': 4.11.14
+      '@sanity/client': 7.23.2
+      boxen: 8.0.1
+      debug: 4.4.3(supports-color@8.1.1)
+      empathic: 2.0.1
+      get-it: 8.8.0
+      get-tsconfig: 4.14.0
+      import-meta-resolve: 4.2.0
+      jiti: 2.7.0
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
+      json-lexer: 1.2.0
+      log-symbols: 7.0.1
+      ora: 9.4.1
+      rxjs: 7.8.2
+      tsx: 4.23.1
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite-node: 6.0.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      zod: 4.4.3
+    optionalDependencies:
+      babel-plugin-react-compiler: 1.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - canvas
+      - esbuild
+      - less
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - yaml
+
   '@sanity/cli-core@2.4.0(@noble/hashes@2.2.0)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@26.1.1)
@@ -20496,6 +20893,106 @@ snapshots:
       - supports-color
       - terser
       - yaml
+
+  '@sanity/cli@7.9.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.0)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.4)':
+    dependencies:
+      '@oclif/core': 4.11.14
+      '@oclif/plugin-help': 6.2.53
+      '@oclif/plugin-not-found': 3.2.88(@types/node@24.13.3)
+      '@sanity/cli-build': 4.1.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
+      '@sanity/cli-core': 2.4.0(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)
+      '@sanity/client': 7.23.2
+      '@sanity/codegen': 7.0.3(@oclif/core@4.11.14)(@sanity/cli-core@2.4.0(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))(react@19.2.7)
+      '@sanity/descriptors': 1.3.0
+      '@sanity/export': 6.2.0
+      '@sanity/generate-help-url': 4.0.0
+      '@sanity/id-utils': 1.0.0
+      '@sanity/import': 6.0.3(@sanity/client@7.23.2)(@types/react@19.2.17)
+      '@sanity/migrate': 7.0.3(@oclif/core@4.11.14)(@sanity/cli-core@2.4.0(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))(@types/react@19.2.17)(xstate@5.32.4)
+      '@sanity/runtime-cli': 17.1.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      '@sanity/schema': 6.5.0(@types/react@19.2.17)
+      '@sanity/telemetry': 1.1.0(react@19.2.7)
+      '@sanity/template-validator': 3.1.0
+      '@sanity/types': 6.5.0(@types/react@19.2.17)
+      '@sanity/workbench-cli': 1.4.0(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
+      '@sanity/worker-channels': 2.0.0
+      '@vercel/frameworks': 3.29.0
+      chokidar: 5.0.0
+      console-table-printer: 2.16.1
+      date-fns: 4.4.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+      eventsource: 4.1.0
+      execa: 9.6.1
+      form-data: 4.0.6
+      get-latest-version: 6.0.1
+      groq-js: 1.30.3
+      gunzip-maybe: 1.4.2
+      import-meta-resolve: 4.2.0
+      is-installed-globally: 1.0.0
+      isomorphic-dompurify: 2.36.0(@noble/hashes@2.2.0)
+      json5: 2.2.3
+      jsonc-parser: 3.3.1
+      lodash-es: 4.18.1
+      minimist: 1.2.8
+      nanoid: 5.1.16
+      oneline: 2.0.0
+      open: 11.0.0
+      p-map: 7.0.5
+      package-directory: 8.2.0
+      peek-stream: 1.1.3
+      picomatch: 4.0.5
+      pluralize-esm: 9.0.5
+      pretty-ms: 9.3.0
+      promise-props-recursive: 2.0.2
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-is: 19.2.7
+      rxjs: 7.8.2
+      semver: 7.8.5
+      skills: 1.5.16
+      smol-toml: 1.7.0
+      tar: 7.5.20
+      tar-fs: 3.1.3
+      tar-stream: 3.2.0
+      tinyglobby: 0.2.17
+      tsx: 4.23.1
+      typeid-js: 1.2.0
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      which: 6.0.1
+      yaml: 2.9.0
+      zod: 4.4.3
+    optionalDependencies:
+      babel-plugin-react-compiler: 1.0.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/plugin-transform-runtime'
+      - '@babel/runtime'
+      - '@noble/hashes'
+      - '@rolldown/plugin-babel'
+      - '@types/node'
+      - '@types/react'
+      - '@vitejs/devtools'
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - canvas
+      - esbuild
+      - jiti
+      - less
+      - oxfmt
+      - react-native-b4a
+      - rolldown
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+      - xstate
 
   '@sanity/cli@7.9.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(@types/node@26.1.1)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.0)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.4)':
     dependencies:
@@ -20603,6 +21100,35 @@ snapshots:
       get-it: 8.8.0
       nanoid: 3.3.16
       rxjs: 7.8.2
+
+  '@sanity/codegen@7.0.3(@oclif/core@4.11.14)(@sanity/cli-core@2.4.0(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))(react@19.2.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-react': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/register': 7.29.7(@babel/core@7.29.7)
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@oclif/core': 4.11.14
+      '@sanity/cli-core': 2.4.0(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)
+      '@sanity/telemetry': 1.1.0(react@19.2.7)
+      '@sanity/worker-channels': 2.0.0
+      chokidar: 3.6.0
+      debug: 4.4.3(supports-color@8.1.1)
+      globby: 11.1.0
+      groq: 6.5.0
+      groq-js: 1.30.3
+      json5: 2.2.3
+      lodash-es: 4.18.1
+      prettier: 3.9.5
+      reselect: 5.2.0
+      tsconfig-paths: 4.2.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - react
+      - supports-color
 
   '@sanity/codegen@7.0.3(@oclif/core@4.11.14)(@sanity/cli-core@2.4.0(@noble/hashes@2.2.0)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))(react@19.2.7)':
     dependencies:
@@ -20745,6 +21271,25 @@ snapshots:
     dependencies:
       '@sanity/comlink': 4.0.1
 
+  '@sanity/migrate@7.0.3(@oclif/core@4.11.14)(@sanity/cli-core@2.4.0(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))(@types/react@19.2.17)(xstate@5.32.4)':
+    dependencies:
+      '@oclif/core': 4.11.14
+      '@sanity/cli-core': 2.4.0(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)
+      '@sanity/client': 7.23.2
+      '@sanity/mutate': 0.18.1(xstate@5.32.4)
+      '@sanity/types': 6.5.0(@types/react@19.2.17)
+      '@sanity/util': 6.5.0(@types/react@19.2.17)
+      arrify: 2.0.1
+      console-table-printer: 2.16.1
+      debug: 4.4.3(supports-color@8.1.1)
+      fast-fifo: 1.3.2
+      groq-js: 1.30.3
+      p-map: 7.0.5
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
+      - xstate
+
   '@sanity/migrate@7.0.3(@oclif/core@4.11.14)(@sanity/cli-core@2.4.0(@noble/hashes@2.2.0)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))(@types/react@19.2.17)(xstate@5.32.4)':
     dependencies:
       '@oclif/core': 4.11.14
@@ -20810,6 +21355,49 @@ snapshots:
   '@sanity/prism-groq@1.1.2(prismjs@1.30.0)':
     optionalDependencies:
       prismjs: 1.30.0
+
+  '@sanity/runtime-cli@17.1.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)':
+    dependencies:
+      '@architect/hydrate': 6.0.2
+      '@architect/inventory': 6.0.0
+      '@inquirer/prompts': 8.5.2(@types/node@24.13.3)
+      '@oclif/core': 4.11.14
+      '@oclif/plugin-help': 6.2.53
+      '@sanity-labs/design-tokens': 0.0.2-alpha.4
+      '@sanity/blueprints': 0.20.2
+      '@sanity/blueprints-parser': 0.4.0
+      '@sanity/client': 7.23.2
+      adm-zip: 0.5.18
+      array-treeify: 0.1.5
+      cardinal: 2.1.1
+      empathic: 2.0.1
+      eventsource: 4.1.0
+      groq-js: 1.30.3
+      jiti: 2.7.0
+      mime-types: 3.0.2
+      ora: 9.4.1
+      tar-stream: 3.2.0
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      ws: 8.21.0
+      xdg-basedir: 5.1.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@vitejs/devtools'
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - esbuild
+      - less
+      - react-native-b4a
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - yaml
 
   '@sanity/runtime-cli@17.1.0(@types/node@26.1.1)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)':
     dependencies:
@@ -20980,6 +21568,41 @@ snapshots:
       '@sanity/client': 7.23.2
     optionalDependencies:
       '@sanity/types': 6.5.0(@types/react@19.2.17)
+
+  '@sanity/workbench-cli@1.4.0(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)':
+    dependencies:
+      '@module-federation/vite': 1.16.14(typescript@7.0.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@sanity/cli-core': 2.4.0(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)
+      '@vitejs/plugin-react': 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      form-data: 4.0.6
+      tar-fs: 3.1.3
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - '@rolldown/plugin-babel'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - babel-plugin-react-compiler
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - canvas
+      - esbuild
+      - jiti
+      - less
+      - react-native-b4a
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+      - yaml
 
   '@sanity/workbench-cli@1.4.0(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)':
     dependencies:
@@ -21460,19 +22083,19 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.162.0': {}
 
-  '@tapjs/after-each@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/after-each@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       function-loop: 4.0.0
 
-  '@tapjs/after@3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/after@3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       is-actual-promise: 1.0.2
 
-  '@tapjs/asserts@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tapjs/asserts@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/stack': 4.3.3
       is-actual-promise: 1.0.2
       tcompare: 9.3.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -21481,35 +22104,35 @@ snapshots:
       - react
       - react-dom
 
-  '@tapjs/before-each@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/before-each@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       function-loop: 4.0.0
 
-  '@tapjs/before@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/before@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       is-actual-promise: 1.0.2
 
-  '@tapjs/chdir@3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/chdir@3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  '@tapjs/config@5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/config@5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       chalk: 5.6.2
       jackspeak: 4.2.3
       polite-json: 5.0.0
       tap-yaml: 4.4.2
       walk-up-path: 4.0.0
 
-  '@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@tapjs/processinfo': 3.1.12
       '@tapjs/stack': 4.3.3
-      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       async-hook-domain: 4.0.1
       diff: 8.0.4
       is-actual-promise: 1.0.2
@@ -21530,33 +22153,33 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@tapjs/filter@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/filter@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  '@tapjs/fixture@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/fixture@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       mkdirp: 3.0.1
       rimraf: 6.1.3
 
-  '@tapjs/intercept@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/intercept@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/stack': 4.3.3
 
-  '@tapjs/mock@4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/mock@4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/stack': 4.3.3
       resolve-import: 2.4.0
       walk-up-path: 4.0.0
 
-  '@tapjs/node-serialize@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/node-serialize@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/error-serdes': 4.3.2
       '@tapjs/stack': 4.3.3
       tap-parser: 18.3.4
@@ -21569,10 +22192,10 @@ snapshots:
       signal-exit: 4.1.0
       uuid: 14.0.1
 
-  '@tapjs/reporter@4.4.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))':
+  '@tapjs/reporter@4.4.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))':
     dependencies:
-      '@tapjs/config': 5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/config': 5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/stack': 4.3.3
       chalk: 5.6.2
       ink: 5.2.1(@types/react@19.2.17)(react@18.3.1)
@@ -21593,18 +22216,18 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  '@tapjs/run@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tapjs/run@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@isaacs/which': 7.0.4
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/config': 5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/config': 5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tapjs/processinfo': 3.1.12
-      '@tapjs/reporter': 4.4.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))
-      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/reporter': 4.4.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))
+      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       c8: 10.1.3
       chalk: 5.6.2
       chokidar: 4.0.3
@@ -21637,9 +22260,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@tapjs/snapshot@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tapjs/snapshot@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       is-actual-promise: 1.0.2
       tcompare: 9.3.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       trivial-deferred: 2.0.0
@@ -21647,36 +22270,36 @@ snapshots:
       - react
       - react-dom
 
-  '@tapjs/spawn@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/spawn@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   '@tapjs/stack@4.3.3': {}
 
-  '@tapjs/stdin@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/stdin@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  '@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tapjs/test@4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@5.9.3)
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/after-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/asserts': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/before-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/chdir': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/filter': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/fixture': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/intercept': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/mock': 4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/node-serialize': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/snapshot': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/typescript': 3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(typescript@5.9.3)
-      '@tapjs/worker': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@5.9.3)
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/after-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/asserts': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/before-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/chdir': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/filter': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/fixture': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/intercept': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/mock': 4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/node-serialize': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/snapshot': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/typescript': 3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(typescript@5.9.3)
+      '@tapjs/worker': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       glob: 13.0.6
       jackspeak: 4.2.3
       mkdirp: 3.0.1
@@ -21695,29 +22318,29 @@ snapshots:
       - react
       - react-dom
 
-  '@tapjs/typescript@3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(typescript@5.9.3)':
+  '@tapjs/typescript@3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(typescript@5.9.3)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@5.9.3)
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@5.9.3)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
       - typescript
 
-  '@tapjs/typescript@3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(typescript@6.0.3)':
+  '@tapjs/typescript@3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(typescript@6.0.3)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@6.0.3)
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@6.0.3)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
       - typescript
 
-  '@tapjs/worker@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@tapjs/worker@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   '@tsconfig/node14@14.1.8': {}
 
@@ -21920,7 +22543,7 @@ snapshots:
 
   '@types/prompts@2.4.9':
     dependencies:
-      '@types/node': 24.13.3
+      '@types/node': 26.1.1
       kleur: 3.0.3
 
   '@types/qs@6.15.1': {}
@@ -22342,6 +22965,14 @@ snapshots:
       vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitejs/plugin-react@6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+    optionalDependencies:
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      babel-plugin-react-compiler: 1.0.0
 
   '@vitejs/plugin-react@6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
@@ -24114,7 +24745,7 @@ snapshots:
 
   eval@0.1.8:
     dependencies:
-      '@types/node': 24.13.3
+      '@types/node': 26.1.1
       require-like: 0.1.2
 
   event-source-polyfill@1.0.31: {}
@@ -28158,6 +28789,153 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sanity@6.5.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.14)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(@sanity/cli-core@2.4.0(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.2.0)(styled-components@6.4.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.49.0)(typescript@7.0.2):
+    dependencies:
+      '@algorithm.ts/lcs': 4.0.6
+      '@date-fns/tz': 1.5.0
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/modifiers': 9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/sortable': 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      '@isaacs/ttlcache': 1.4.1
+      '@mux/mux-player-react': 3.13.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)
+      '@portabletext/html': 1.1.1
+      '@portabletext/patches': 2.0.5
+      '@portabletext/plugin-dnd': 1.0.19(@portabletext/editor@7.10.7(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+      '@portabletext/plugin-list-index': 1.0.19(@portabletext/editor@7.10.7(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+      '@portabletext/plugin-markdown-shortcuts': 8.0.35(@portabletext/editor@7.10.7(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@portabletext/plugin-one-line': 7.0.34(@portabletext/editor@7.10.7(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+      '@portabletext/plugin-paste-link': 4.0.34(@portabletext/editor@7.10.7(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+      '@portabletext/plugin-typography': 8.0.35(@portabletext/editor@7.10.7(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@portabletext/react': 6.2.0(react@19.2.7)
+      '@portabletext/sanity-bridge': 3.2.2(@types/react@19.2.17)
+      '@portabletext/to-html': 5.0.2
+      '@portabletext/toolkit': 5.0.2
+      '@rexxars/react-json-inspector': 9.0.1(react@19.2.7)
+      '@sanity/asset-utils': 2.3.0
+      '@sanity/bifur-client': 1.0.0
+      '@sanity/cli': 7.9.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.0)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.4)
+      '@sanity/client': 7.23.2
+      '@sanity/color': 3.0.6
+      '@sanity/comlink': 4.0.1
+      '@sanity/diff': 6.5.0
+      '@sanity/diff-match-patch': 3.2.0
+      '@sanity/diff-patch': 5.0.0
+      '@sanity/eventsource': 5.0.4
+      '@sanity/icons': 5.1.0(react@19.2.7)
+      '@sanity/id-utils': 1.0.0
+      '@sanity/image-url': 2.1.1
+      '@sanity/insert-menu': 3.0.9(@emotion/is-prop-valid@1.4.0)(@sanity/types@6.5.0(@types/react@19.2.17))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@sanity/logos': 2.2.2(react@19.2.7)
+      '@sanity/media-library-types': 1.6.0
+      '@sanity/message-protocol': 0.23.0
+      '@sanity/migrate': 7.0.3(@oclif/core@4.11.14)(@sanity/cli-core@2.4.0(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))(@types/react@19.2.17)(xstate@5.32.4)
+      '@sanity/mutate': 0.18.1(xstate@5.32.4)
+      '@sanity/mutator': 6.5.0(@types/react@19.2.17)
+      '@sanity/presentation-comlink': 2.1.0(@sanity/client@7.23.2)(@sanity/types@6.5.0(@types/react@19.2.17))
+      '@sanity/preview-url-secret': 4.0.8(@sanity/client@7.23.2)
+      '@sanity/prism-groq': 1.1.2(prismjs@1.30.0)
+      '@sanity/schema': 6.5.0(@types/react@19.2.17)
+      '@sanity/sdk': 2.16.0(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.4)
+      '@sanity/telemetry': 1.1.0(react@19.2.7)
+      '@sanity/types': 6.5.0(@types/react@19.2.17)
+      '@sanity/ui': 3.3.5(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@sanity/util': 6.5.0(@types/react@19.2.17)
+      '@sanity/uuid': 3.0.3
+      '@sentry/react': 10.65.0(react@19.2.7)
+      '@tanstack/react-table': 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-virtual': 3.14.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@xstate/react': 6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.4)
+      clsx: 2.1.1
+      color2k: 2.0.4
+      dataloader: 2.2.3
+      date-fns: 4.4.0
+      debug: 4.4.3(supports-color@8.1.1)
+      exif-component: 1.0.1
+      fast-deep-equal: 3.1.3
+      groq-js: 1.30.3
+      history: 5.3.0
+      i18next: 26.3.6(typescript@7.0.2)
+      is-hotkey-esm: 1.0.0
+      is-network-error: 1.3.2
+      isomorphic-dompurify: 2.36.0(@noble/hashes@2.2.0)
+      json-reduce: 3.0.0
+      json-stable-stringify: 1.3.0
+      lodash-es: 4.18.1
+      mendoza: 3.0.8
+      motion: 12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      nano-pubsub: 3.0.0
+      nanoid: 5.1.16
+      observable-callback: 1.0.3(rxjs@7.8.2)
+      path-to-regexp: 6.3.0
+      player.style: 0.3.4(react@19.2.7)
+      polished: 4.3.1
+      quick-lru: 7.3.0
+      raf: 3.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-fast-compare: 3.2.2
+      react-focus-lock: 2.13.7(@types/react@19.2.17)(react@19.2.7)
+      react-i18next: 17.0.9(i18next@26.3.6(typescript@7.0.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2)
+      react-is: 19.2.7
+      react-refractor: 4.0.0(react@19.2.7)
+      react-rx: 4.2.3(react@19.2.7)(rxjs@7.8.2)
+      refractor: 5.0.0
+      rxjs: 7.8.2
+      rxjs-exhaustmap-with-trailing: 2.1.1(rxjs@7.8.2)
+      rxjs-mergemap-array: 0.1.0(rxjs@7.8.2)
+      scroll-into-view-if-needed: 3.1.0
+      scrollmirror: 1.2.4
+      semver: 7.8.5
+      shallow-equals: 1.0.0
+      speakingurl: 14.0.1
+      styled-components: 6.4.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      swr: 2.4.2(react@19.2.7)
+      urlpattern-polyfill: 10.1.0
+      use-device-pixel-ratio: 1.1.2(react@19.2.7)
+      use-hot-module-reload: 2.0.0(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+      uuid: 14.0.1
+      web-vitals: 5.3.0
+      xstate: 5.32.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/plugin-transform-runtime'
+      - '@babel/runtime'
+      - '@emotion/is-prop-valid'
+      - '@noble/hashes'
+      - '@oclif/core'
+      - '@rolldown/plugin-babel'
+      - '@sanity/cli-core'
+      - '@types/node'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@vitejs/devtools'
+      - babel-plugin-react-compiler
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - canvas
+      - esbuild
+      - immer
+      - jiti
+      - less
+      - oxfmt
+      - prismjs
+      - react-native
+      - react-native-b4a
+      - rolldown
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+
   sanity@6.5.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.14)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))(@sanity/cli-core@2.4.0(@noble/hashes@2.2.0)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(prismjs@1.30.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.2.0)(styled-components@6.4.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.49.0)(typescript@7.0.2):
     dependencies:
       '@algorithm.ts/lcs': 4.0.6
@@ -28951,27 +29729,27 @@ snapshots:
       yaml: 2.9.0
       yaml-types: 0.4.0(yaml@2.9.0)
 
-  tap@21.7.4(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
+  tap@21.7.4(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
     dependencies:
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/after-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/asserts': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/before-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/chdir': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/filter': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/fixture': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/intercept': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/mock': 4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/node-serialize': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/run': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/snapshot': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
-      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tapjs/typescript': 3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@24.13.3)(typescript@6.0.3)
-      '@tapjs/worker': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/after-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/asserts': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/before-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/chdir': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/filter': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/fixture': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/intercept': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/mock': 4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/node-serialize': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/run': 4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/snapshot': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@tapjs/test': 4.4.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tapjs/typescript': 3.5.10(@swc/core@1.15.43(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@26.1.1)(typescript@6.0.3)
+      '@tapjs/worker': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       resolve-import: 2.4.0
     transitivePeerDependencies:
       - '@swc/core'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - benchmarks/*
+  - integration/*
   - packages/@sanity/*
   - playground/*
   - css-playground/*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When `@vanilla-extract/vite-plugin` was forked into `@sanity/vanilla-extract-vite-plugin`, no integration tests ensured a Sanity Studio could run `sanity dev`, `sanity build`, and `sanity schema extract` without regressions or output drift versus the original. This PR sets that up — testing both plugins with the original as the reference for expected output — and fixes the two fork regressions the new suite immediately caught (closes #3073).

## Integration suite (`integration/vanilla-extract-studio`)

A real studio fixture driven through the `sanity` CLI, once per plugin implementation, comparing output byte-for-byte with upstream as reference:

- **`sanity build`** across plugin-default / `short` / `debug` / custom-prefix-function identifiers, `build.cssMinify` (`default`/`true`/`'lightningcss'`), and `build.cssTarget` (`chrome61`): asserts emitted CSS (markers, minify normalization, `inset` target-lowering), class names in the built JS, a CSS rule for every class name (class names without rules was the production bug), and fork ≡ upstream equality of CSS and class names.
- **`sanity dev`** across identifier variants: fetches transformed `.css.ts` modules over HTTP, follows their virtual `.vanilla.css` imports, compares served CSS and exports.
- **`sanity schema extract`** across identifier variants: the fixture schema embeds the generated class names in a string-literal list option, so the extracted schema doubles as identifier output; schemas must be deep-equal.

The CLI is deliberately spawned **without `NODE_ENV`** (like a real terminal) — that's load-bearing for reproducing the build regression, which a test-runner-provided `NODE_ENV=test` masks. Wired into CI as a dedicated `integration` job (`pnpm integration:test`, ~2 min, no Sanity auth/network needed).

## Regressions found and fixed (all 9 fork-vs-upstream comparisons failed before, all 12 tests pass after)

1. **`sanity build` silently dropped all vanilla-extract CSS** (class names survived, rules vanished — the `@sanity/google-maps-input` bug from #3073, patched downstream in [sanity-io/plugins#1615](https://github.com/sanity-io/plugins/pull/1615)). Root cause — proven with instrumented builds, and different from the browser-condition theory in the issue: Vite 8's default `ssr.resolve.externalConditions` (`['node', 'module-sync']`) resolves the externalized `@vanilla-extract/*` packages to their CJS `default` exports, whose wrappers pick a dev or prod build off `NODE_ENV` **at first load**. A CLI host imports the plugin (and through it `@vanilla-extract/css`) while `NODE_ENV` is unset, then `vite build` flips it to `production` mid-process — so the evaluated `.css.ts` modules bound the compilation adapter to the dev copy while `style()` appended CSS through the prod copy's mock adapter. Upstream was immune because `vite-node` resolves the single-file ESM builds.
2. **`sanity schema extract` crashed** (`Error: module is not defined`): the CLI's extraction worker sets `ssr.noExternal: true`, which the fork's compiler server inherited — inlining CJS deps that Vite's native `ModuleRunner` (unlike `vite-node`) cannot evaluate.

**Fix** (`createCompilerServer` in `packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts`): pin Node-shaped resolution — `resolve.conditions`/`ssr.resolve.conditions`/`ssr.resolve.externalConditions` to `['node', 'import', 'module', 'default']` (prefers the single-file ESM builds → one adapter instance) — and stop forwarding the parent `ssr`/`environments` options. Once released, the pnpm patch in sanity-io/plugins can be dropped.

Also adds an in-package child-process regression test (`test/node-env-transition.test.ts`) reproducing the `NODE_ENV` transition without the sanity CLI: fails pre-fix (empty CSS), passes post-fix.

## Benchmarks

Per `AGENTS.md`, the full vanilla-extract benchmark suite was re-run (the vite plugin changed) and the README "Latest results" refreshed — no build-time shift from this fix; the previously predicted rolldown 1.2.0 library-build gains are now reflected (2.87–2.99x).

## Testing

- ✅ `pnpm integration:test` — 12/12 (was 9/12 failing pre-fix: 6 build, 3 schema-extract)
- ✅ `pnpm --filter @sanity/vanilla-extract-vite-plugin test` — 16/16 (new regression test fails pre-fix, passes post-fix)
- ✅ `pnpm build`, `pnpm typecheck`, `pnpm integration:typecheck`, `pnpm lint`, `pnpm test` (392 passed), `pnpm knip` (3 known warnings)
- ✅ `pnpm benchmark:vanilla-extract` (full suite, results in README)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e442082-bcdc-4a30-a4fc-3ce0c0c246bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e442082-bcdc-4a30-a4fc-3ce0c0c246bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

