### PR TITLE
fix: emit only one .d.ts for the bundle.css shim

### DIFF
--- a/.changeset/single-bundle-css-dts.md
+++ b/.changeset/single-bundle-css-dts.md
@@ -1,0 +1,12 @@
+---
+"@sanity/vanilla-extract-rolldown-plugin": patch
+"@sanity/vanilla-extract-tsdown-plugin": patch
+"@sanity/pkg-utils": patch
+"@sanity/tsdown-config": patch
+---
+
+Stop emitting a redundant `bundle.css.d.ts` alongside the vanilla-extract CSS shim.
+
+The conditional `./bundle.css` export already has an explicit `types` condition pointing at `bundle-css.d.ts`, so TypeScript never needs a sibling declaration for the CSS file itself. Compat mode now emits only that one declaration (plus `bundle-css.js` and `bundle.css`).
+
+`cssFileDtsFileName` is no longer exported from `@sanity/vanilla-extract-rolldown-plugin`.

--- a/.changeset/single-bundle-css-dts.md
+++ b/.changeset/single-bundle-css-dts.md
@@ -1,5 +1,5 @@
 ---
-"@sanity/vanilla-extract-rolldown-plugin": patch
+"@sanity/vanilla-extract-rolldown-plugin": minor
 "@sanity/vanilla-extract-tsdown-plugin": patch
 "@sanity/pkg-utils": patch
 "@sanity/tsdown-config": patch
@@ -9,4 +9,4 @@ Stop emitting a redundant `bundle.css.d.ts` alongside the vanilla-extract CSS sh
 
 The conditional `./bundle.css` export already has an explicit `types` condition pointing at `bundle-css.d.ts`, so TypeScript never needs a sibling declaration for the CSS file itself. Compat mode now emits only that one declaration (plus `bundle-css.js` and `bundle.css`).
 
-`cssFileDtsFileName` is no longer exported from `@sanity/vanilla-extract-rolldown-plugin`.
+`cssFileDtsFileName` is no longer exported from `@sanity/vanilla-extract-rolldown-plugin` (0.x breaking API change → minor).

--- a/benchmarks/vanilla-extract/README.md
+++ b/benchmarks/vanilla-extract/README.md
@@ -79,15 +79,12 @@ Keep this section current: re-run the full suite and update the tables whenever 
 `vanilla-extract` dependencies are bumped or any of the `@sanity/vanilla-extract-*` plugins
 change (see [AGENTS.md](../../AGENTS.md)).
 
-Last run: 2026-07-16 (after pinning Node resolve conditions in
-`@sanity/vanilla-extract-vite-plugin`'s compiler server — the GH-3073 fix, no measurable
-build-time shift expected or observed — with every rolldown copy now on the 1.2.0 that vite
-8.1.5 pins), full default suite (`pnpm benchmark:vanilla-extract`) on Node.js 24.18.0, Linux
-x64, Intel Xeon, **4 cores**; Rollup 4.62.2, Rolldown 1.2.0, Vite 8.1.5, Vitest 4.1.10,
-yuku-parser 0.6.4. Values are mean wall-clock milliseconds from that runner and are
-machine-specific — compare ratios, not absolute numbers. (The previous run's prediction for
-the rolldown 1.2.0 bump held: the library-build gap widened from 2.65–2.76x to 2.87–2.99x on
-the short-identifier variants.)
+Last run: 2026-07-17 (after stopping the redundant `bundle.css.d.ts` emission from the
+rolldown CSS shim — no measurable build-time shift expected or observed), full default suite
+(`pnpm benchmark:vanilla-extract`) on Node.js 24.18.0, Linux x64, Intel Xeon, **4 cores**;
+Rollup 4.62.2, Rolldown 1.2.0, Vite 8.1.5, Vitest 4.1.10, yuku-parser 0.6.5. Values are mean
+wall-clock milliseconds from that runner and are machine-specific — compare ratios, not
+absolute numbers.
 
 ### Core count shifts the build ratios
 
@@ -109,14 +106,14 @@ Sanity on leaf edits, 1.05x official on theme edits, rme up to ±20%); hook-filt
 
 | Variant                  | Rollup + `@vanilla-extract/rollup-plugin` | Rolldown + `@sanity/vanilla-extract-rolldown-plugin` | Relative result     |
 | ------------------------ | ----------------------------------------: | ---------------------------------------------------: | ------------------- |
-| No minify, no target     |                               1,060.27 ms |                                            354.90 ms | Sanity 2.99x faster |
-| Minify                   |                               1,057.25 ms |                                            368.74 ms | Sanity 2.87x faster |
-| Target chrome61          |                               1,067.24 ms |                                            371.69 ms | Sanity 2.87x faster |
-| Minify + target chrome61 |                               1,068.42 ms |                                            370.25 ms | Sanity 2.89x faster |
-| Debug identifiers        |                               1,339.04 ms |                                            419.54 ms | Sanity 3.19x faster |
+| No minify, no target     |                               1,102.15 ms |                                            376.05 ms | Sanity 2.93x faster |
+| Minify                   |                               1,118.94 ms |                                            384.19 ms | Sanity 2.91x faster |
+| Target chrome61          |                               1,091.34 ms |                                            385.25 ms | Sanity 2.83x faster |
+| Minify + target chrome61 |                               1,146.47 ms |                                            385.06 ms | Sanity 2.98x faster |
+| Debug identifiers        |                               1,379.36 ms |                                            436.01 ms | Sanity 3.16x faster |
 
-Debug identifiers cost each pipeline `debug − baseline`: **+278.8 ms** for the official
-babel-based transform, **+64.6 ms** for the Sanity `yuku-parser` pass — the transform runs
+Debug identifiers cost each pipeline `debug − baseline`: **+277.2 ms** for the official
+babel-based transform, **+60.0 ms** for the Sanity `yuku-parser` pass — the transform runs
 once per `.css.ts` module and scales with file size, so the production-shaped modules widen
 the gap the near-empty fixtures used to understate.
 
@@ -124,29 +121,29 @@ the gap the near-empty fixtures used to understate.
 
 | Identifiers | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result     |
 | ----------- | -----------------------------: | ------------------------------------: | ------------------- |
-| Short       |                      940.70 ms |                             740.58 ms | Sanity 1.27x faster |
-| Debug       |                    1,237.05 ms |                             813.99 ms | Sanity 1.52x faster |
+| Short       |                      968.75 ms |                             765.22 ms | Sanity 1.27x faster |
+| Debug       |                    1,299.32 ms |                             856.10 ms | Sanity 1.52x faster |
 
 ### Vite build kitchen sink, 5,000 TS + 500 CSS modules, debug identifiers, css minify + target chrome61 (5 samples each)
 
 | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result     |
 | -----------------------------: | ------------------------------------: | ------------------- |
-|                    4,263.46 ms |                           3,203.07 ms | Sanity 1.33x faster |
+|                    4,558.54 ms |                           3,410.68 ms | Sanity 1.34x faster |
 
 ### Vite dev HMR (10 samples each)
 
 | Scenario                               | Official plugin | Sanity plugin | Relative result       |
 | -------------------------------------- | --------------: | ------------: | --------------------- |
-| Single `.css.ts` leaf edit             |        19.39 ms |      22.11 ms | Official 1.14x faster |
-| Shared theme edit, 100 style importers |       156.25 ms |     165.64 ms | Official 1.06x faster |
+| Single `.css.ts` leaf edit             |        20.68 ms |      23.82 ms | Official 1.15x faster |
+| Shared theme edit, 100 style importers |       167.45 ms |     191.09 ms | Official 1.14x faster |
 
 ### Hook-filter stress, `vite build` with 1 CSS module (3 samples each)
 
 | Unrelated modules | Official plugin | Sanity plugin | Relative result     |
 | ----------------: | --------------: | ------------: | ------------------- |
-|                 0 |       417.27 ms |     240.41 ms | Sanity 1.74x faster |
-|             1,000 |       426.57 ms |     253.74 ms | Sanity 1.68x faster |
-|             5,000 |       605.06 ms |     386.79 ms | Sanity 1.56x faster |
+|                 0 |       465.06 ms |     276.72 ms | Sanity 1.68x faster |
+|             1,000 |       481.71 ms |     267.60 ms | Sanity 1.80x faster |
+|             5,000 |       673.54 ms |     406.44 ms | Sanity 1.66x faster |
 
 The untimed hook diagnostic shows why: the official plugin's unfiltered hooks enter JavaScript
 once per module, while the Sanity plugin's native hook filters reject unrelated ids before the

--- a/packages/@sanity/pkg-utils/src/node/tasks/rollup/bundleCssShim.ts
+++ b/packages/@sanity/pkg-utils/src/node/tasks/rollup/bundleCssShim.ts
@@ -7,9 +7,8 @@ import {cssShimDtsFileName, cssShimFileName} from '../../core/pkg/cssShimFileNam
  * `import "<pkg>/<css>"` resolves to a harmless module in runtimes that cannot import `.css`
  * files, instead of throwing `Error: Unknown file extension ".css"`.
  *
- * Matching `.d.ts` declarations are emitted for both export targets:
- * - `<css>.d.ts` for the extracted CSS file (`browser` / `style` conditions)
- * - `<css-shim>.d.ts` (e.g. `bundle-css.d.ts`) for the JS shim (`node` / `default` conditions)
+ * A matching `.d.ts` declaration is emitted for the shim (`bundle-css.d.ts`); the conditional
+ * `./<css>` export's `types` condition points at it, so a separate `<css>.d.ts` is unnecessary.
  *
  * The shim is named `bundle-css.js` rather than `bundle.css.js` so it does not match
  * vanilla-extract's `cssFileFilter` (`/\.css\.(js|…)$/`).
@@ -28,11 +27,6 @@ export function bundleCssShim(options: {cssName: string}): Plugin {
         type: 'asset',
         fileName: shimFileName,
         source: `// No-op shim for \`${cssName}\` in runtimes that cannot import \`.css\` files directly.\nexport default ""\n`,
-      })
-      this.emitFile({
-        type: 'asset',
-        fileName: `${cssName}.d.ts`,
-        source: `// Type declarations for \`${cssName}\` and its no-op JS shim.\ndeclare const _default: string\nexport default _default\n`,
       })
       this.emitFile({
         type: 'asset',

--- a/packages/@sanity/pkg-utils/test/bundleCssShim.test.ts
+++ b/packages/@sanity/pkg-utils/test/bundleCssShim.test.ts
@@ -24,17 +24,16 @@ describe('bundleCssShim', () => {
     expect(shim?.source).toContain('export default ""')
   })
 
-  test('emits `.d.ts` companions for both the CSS file and the shim', () => {
+  test('emits a single `.d.ts` for the shim (the export `types` target)', () => {
     const emitted = runGenerateBundle('bundle.css')
-    const cssDts = emitted.find((file) => file.fileName === 'bundle.css.d.ts')
     const shimDts = emitted.find((file) => file.fileName === 'bundle-css.d.ts')
-    expect(cssDts).toBeDefined()
     expect(shimDts).toBeDefined()
-    for (const dts of [cssDts, shimDts]) {
-      expect(dts?.type).toBe('asset')
-      expect(dts?.source).toContain('declare const _default: string')
-      expect(dts?.source).toContain('export default _default')
-    }
+    expect(shimDts?.type).toBe('asset')
+    expect(shimDts?.source).toContain('declare const _default: string')
+    expect(shimDts?.source).toContain('export default _default')
+    // The conditional export's `types` condition points at the shim's `.d.ts`, so a separate
+    // `bundle.css.d.ts` for the CSS file itself is unnecessary.
+    expect(emitted.some((file) => file.fileName === 'bundle.css.d.ts')).toBe(false)
   })
 
   test('respects a custom css name', () => {
@@ -42,7 +41,6 @@ describe('bundleCssShim', () => {
     expect(emitted.map((file) => file.fileName).toSorted()).toEqual([
       'styles-css.d.ts',
       'styles-css.js',
-      'styles.css.d.ts',
     ])
   })
 })

--- a/packages/@sanity/pkg-utils/test/cli.test.ts
+++ b/packages/@sanity/pkg-utils/test/cli.test.ts
@@ -552,7 +552,6 @@ describe.skipIf(process.platform === 'win32')('cli', () => {
       distIndexDts,
       distBundleCss,
       distBundleCssShim,
-      distBundleCssDts,
       distBundleCssShimDts,
       pkg,
     ] = await Promise.all([
@@ -561,7 +560,6 @@ describe.skipIf(process.platform === 'win32')('cli', () => {
       project.readFile('dist/index.d.ts'),
       project.readFile('dist/bundle.css'),
       project.readFile('dist/bundle-css.js'),
-      project.readFile('dist/bundle.css.d.ts'),
       project.readFile('dist/bundle-css.d.ts'),
       project.readFile('package.json'),
     ])
@@ -576,11 +574,11 @@ describe.skipIf(process.platform === 'win32')('cli', () => {
     // …emits a no-op JS shim for CSS-unaware runtimes (named `bundle-css.js`, not
     // `bundle.css.js`, so vanilla-extract's `cssFileFilter` does not match it)
     expect(distBundleCssShim).toContain('export default ""')
-    // …emits matching `.d.ts` files for both the CSS and shim export targets
-    expect(distBundleCssDts).toContain('declare const _default: string')
-    expect(distBundleCssDts).toContain('export default _default')
+    // …emits the shim's `.d.ts` (the conditional export's `types` target); no separate
+    // `bundle.css.d.ts` is needed
     expect(distBundleCssShimDts).toContain('declare const _default: string')
     expect(distBundleCssShimDts).toContain('export default _default')
+    await expect(project.readFile('dist/bundle.css.d.ts')).rejects.toThrow()
     // …and declares the conditional `./bundle.css` export in package.json
     expect(JSON.parse(pkg).exports['./bundle.css']).toEqual({
       types: './dist/bundle-css.d.ts',

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -97,8 +97,8 @@ automatically:
 
 - injects the self-referential `import "<pkg>/bundle.css"` into the entry chunks that use
   vanilla-extract styles,
-- emits a no-op `bundle-css.js` shim (plus `bundle.css.d.ts` / `bundle-css.d.ts`) for runtimes
-  that cannot import `.css` files, and
+- emits a no-op `bundle-css.js` shim (plus `bundle-css.d.ts`) for runtimes that cannot import
+  `.css` files, and
 - writes the conditional `"./bundle.css"` export to `package.json` (`types` → the shim's `.d.ts`,
   `browser`/`style` → the real CSS, `node`/`default` → the shim).
 

--- a/packages/@sanity/tsdown-config/test/vanilla-extract.test.ts
+++ b/packages/@sanity/tsdown-config/test/vanilla-extract.test.ts
@@ -63,10 +63,9 @@ describe('vanilla-extract-library', () => {
     expect(bundleCss).toContain('top:')
   })
 
-  test('emits the no-op JS shim and its type declarations', async () => {
-    const [shim, cssDts, shimDts] = await Promise.all([
+  test('emits the no-op JS shim and its type declaration', async () => {
+    const [shim, shimDts] = await Promise.all([
       readFile(path.join(fixtureDir, 'dist/bundle-css.js'), 'utf-8'),
-      readFile(path.join(fixtureDir, 'dist/bundle.css.d.ts'), 'utf-8'),
       readFile(path.join(fixtureDir, 'dist/bundle-css.d.ts'), 'utf-8'),
     ])
 
@@ -74,8 +73,10 @@ describe('vanilla-extract-library', () => {
     // regardless of the package `type` (the cjs-library fixture covers this at runtime)
     expect(shim).toContain('No-op shim')
     expect(shim.replaceAll(/^\/\/[^\n]*$/gm, '').trim()).toBe('')
-    expect(cssDts).toContain('export {}')
+    // The conditional export's `types` condition points at the shim's `.d.ts`; a separate
+    // `bundle.css.d.ts` for the CSS file itself is unnecessary.
     expect(shimDts).toContain('export {}')
+    await expect(readFile(path.join(fixtureDir, 'dist/bundle.css.d.ts'), 'utf-8')).rejects.toThrow()
   })
 
   test('injects the self-referential CSS import into the entry chunks', async () => {

--- a/packages/@sanity/vanilla-extract-rolldown-plugin/README.md
+++ b/packages/@sanity/vanilla-extract-rolldown-plugin/README.md
@@ -20,11 +20,12 @@ Like `css.inject` in `@tsdown/css`, the `inject` option is disabled by default; 
 injects a relative `import "./bundle.css"` into the entry chunks that use vanilla-extract styles —
 through rolldown's native magic-string, so sourcemaps stay intact. `inject: {nodeCompat: true}`
 instead injects the self-referential `import "<pkg>/bundle.css"` of the conditional CSS export
-pattern and emits a no-op `bundle-css.js` shim (plus `bundle.css.d.ts` / `bundle-css.d.ts`) for
-the `node`/`default` conditions of that export to point at, so the import is harmless in runtimes
-that cannot import `.css` files. The shim is named with a hyphen (`bundle-css.js`) rather than a
-`.css.js` suffix so it does not match vanilla-extract's `cssFileFilter`. Writing the conditional
-`"./bundle.css"` export to `package.json` is the host tool's job — with tsdown,
+pattern and emits a no-op `bundle-css.js` shim (plus `bundle-css.d.ts` for the export's `types`
+condition) for the `node`/`default` conditions of that export to point at, so the import is
+harmless in runtimes that cannot import `.css` files. The shim is named with a hyphen
+(`bundle-css.js`) rather than a `.css.js` suffix so it does not match vanilla-extract's
+`cssFileFilter`. Writing the conditional `"./bundle.css"` export to `package.json` is the host
+tool's job — with tsdown,
 [`@sanity/vanilla-extract-tsdown-plugin`](https://github.com/sanity-io/pkg-utils/tree/main/packages/@sanity/vanilla-extract-tsdown-plugin#readme)
 maintains it automatically.
 

--- a/packages/@sanity/vanilla-extract-rolldown-plugin/src/cssShimFileName.ts
+++ b/packages/@sanity/vanilla-extract-rolldown-plugin/src/cssShimFileName.ts
@@ -15,20 +15,10 @@ export function cssShimFileName(cssFileName: string): string {
 
 /**
  * The `.d.ts` companion for {@link cssShimFileName}. `bundle.css` → `bundle-css.d.ts`.
- * Emitted alongside {@link cssFileDtsFileName} so both the `browser`/`style` (`bundle.css`)
- * and `node`/`default` (`bundle-css.js`) export targets resolve a declaration file.
+ * The conditional `./<css>` export's `types` condition points at this file.
  *
  * @public
  */
 export function cssShimDtsFileName(cssFileName: string): string {
   return `${cssFileName.replace(/\.css$/, '-css')}.d.ts`
-}
-
-/**
- * The `.d.ts` companion for the extracted CSS file itself. `bundle.css` → `bundle.css.d.ts`.
- *
- * @public
- */
-export function cssFileDtsFileName(cssFileName: string): string {
-  return `${cssFileName}.d.ts`
 }

--- a/packages/@sanity/vanilla-extract-rolldown-plugin/src/index.ts
+++ b/packages/@sanity/vanilla-extract-rolldown-plugin/src/index.ts
@@ -10,10 +10,10 @@ import {
 } from '@sanity/vanilla-extract-integration'
 import {transform, type CustomAtRules, type Targets, type TransformOptions} from 'lightningcss'
 import type {OutputChunk, Plugin, RenderedChunk} from 'rolldown'
-import {cssFileDtsFileName, cssShimDtsFileName, cssShimFileName} from './cssShimFileName.ts'
+import {cssShimDtsFileName, cssShimFileName} from './cssShimFileName.ts'
 import {esbuildTargetToLightningCSS} from './targets.ts'
 
-export {cssFileDtsFileName, cssShimDtsFileName, cssShimFileName} from './cssShimFileName.ts'
+export {cssShimDtsFileName, cssShimFileName} from './cssShimFileName.ts'
 export {esbuildTargetToLightningCSS} from './targets.ts'
 
 /**
@@ -92,13 +92,13 @@ export interface Options {
    *   libraries load their CSS automatically.
    * - `{nodeCompat: true}` additionally makes the import safe for runtimes that cannot import
    *   `.css` files: the injected import becomes the self-referential `"<pkg-name>/<fileName>"`
-   *   bare specifier, and a no-op shim (e.g. `bundle-css.js`, plus `bundle.css.d.ts` /
-   *   `bundle-css.d.ts` declarations) is emitted for the `node`/`default` conditions of the
-   *   conditional `"./<fileName>"` export to point at. The shim is named with a hyphen
-   *   (`bundle-css.js`) rather than a `.css.js` suffix so it does not match vanilla-extract's
-   *   `cssFileFilter`. Writing that conditional export to `package.json` is the host's job —
-   *   `@sanity/vanilla-extract-tsdown-plugin` maintains it automatically through tsdown's
-   *   [`exports` feature](https://tsdown.dev/options/package-exports).
+   *   bare specifier, and a no-op shim (e.g. `bundle-css.js`, plus a `bundle-css.d.ts`
+   *   declaration for the export's `types` condition) is emitted for the `node`/`default`
+   *   conditions of the conditional `"./<fileName>"` export to point at. The shim is named with
+   *   a hyphen (`bundle-css.js`) rather than a `.css.js` suffix so it does not match
+   *   vanilla-extract's `cssFileFilter`. Writing that conditional export to `package.json` is
+   *   the host's job — `@sanity/vanilla-extract-tsdown-plugin` maintains it automatically
+   *   through tsdown's [`exports` feature](https://tsdown.dev/options/package-exports).
    *
    * `@sanity/tsdown-config` defaults this to `{nodeCompat: true}`.
    * @defaultValue false
@@ -389,19 +389,12 @@ export function vanillaExtractPlugin(options: Options = {}): VanillaExtractPlugi
           // does not treat it as a stylesheet module when a consumer resolves `./bundle.css`.
           source: `// No-op shim for \`${fileName}\`, resolved by the \`node\`/\`default\` conditions of the\n// conditional CSS export so the self-referential import is harmless in runtimes that cannot\n// load \`.css\` files. Intentionally has no JS syntax: it parses as both CommonJS and an ES\n// module, regardless of the package \`type\`.\n`,
         })
-        // Emit declaration companions for both export targets: `browser`/`style` resolve the
-        // CSS file (`bundle.css` → `bundle.css.d.ts`), while `node`/`default` resolve the shim
-        // (`bundle-css.js` → `bundle-css.d.ts`).
-        const dtsSource = `// Type declarations for \`${fileName}\` and its no-op JS shim.\nexport {}\n`
-        this.emitFile({
-          type: 'asset',
-          fileName: cssFileDtsFileName(fileName),
-          source: dtsSource,
-        })
+        // Emit the shim's declaration file; the conditional export's `types` condition points
+        // at it, so a separate `<css>.d.ts` for the CSS file itself is unnecessary.
         this.emitFile({
           type: 'asset',
           fileName: cssShimDtsFileName(fileName),
-          source: dtsSource,
+          source: `// Type declarations for \`${fileName}\` and its no-op JS shim.\nexport {}\n`,
         })
       }
     },

--- a/packages/@sanity/vanilla-extract-rolldown-plugin/test/cssShimFileName.test.ts
+++ b/packages/@sanity/vanilla-extract-rolldown-plugin/test/cssShimFileName.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from 'vitest'
-import {cssFileDtsFileName, cssShimDtsFileName, cssShimFileName} from '../src/cssShimFileName.ts'
+import {cssShimDtsFileName, cssShimFileName} from '../src/cssShimFileName.ts'
 
 describe('cssShimFileName', () => {
   test('turns `bundle.css` into `bundle-css.js` (not `bundle.css.js`)', () => {
@@ -8,8 +8,8 @@ describe('cssShimFileName', () => {
     expect(cssShimFileName('styles.css')).toBe('styles-css.js')
   })
 
-  test('derives matching declaration file names for both export targets', () => {
-    expect(cssFileDtsFileName('bundle.css')).toBe('bundle.css.d.ts')
+  test('derives the shim declaration file name for the export `types` target', () => {
     expect(cssShimDtsFileName('bundle.css')).toBe('bundle-css.d.ts')
+    expect(cssShimDtsFileName('styles.css')).toBe('styles-css.d.ts')
   })
 })

--- a/packages/@sanity/vanilla-extract-rolldown-plugin/test/plugin.test.ts
+++ b/packages/@sanity/vanilla-extract-rolldown-plugin/test/plugin.test.ts
@@ -96,7 +96,7 @@ describe('vanillaExtractPlugin', () => {
     expect(findAsset(output, 'bundle.css')).toContain('rgb(1, 2, 3)')
     expect(code).not.toContain('bundle.css')
     expect(output.some((assetOrChunk) => assetOrChunk.fileName === 'bundle-css.js')).toBe(false)
-    expect(output.some((assetOrChunk) => assetOrChunk.fileName === 'bundle.css.d.ts')).toBe(false)
+    expect(output.some((assetOrChunk) => assetOrChunk.fileName === 'bundle-css.d.ts')).toBe(false)
 
     // The styles must not be inlined or imported in the JS output either
     expect(code).not.toContain('.vanilla.css')
@@ -161,9 +161,9 @@ describe('vanillaExtractPlugin', () => {
     const shim = findAsset(output, 'bundle-css.js')
     expect(shim).toContain('No-op shim')
     expect(shim.replaceAll(/^\/\/[^\n]*$/gm, '').trim()).toBe('')
-    // Declarations for both export targets: CSS file + shim
-    expect(findAsset(output, 'bundle.css.d.ts')).toContain('export {}')
+    // Declaration for the export's `types` target (the shim); no separate CSS `.d.ts`
     expect(findAsset(output, 'bundle-css.d.ts')).toContain('export {}')
+    expect(output.some((assetOrChunk) => assetOrChunk.fileName === 'bundle.css.d.ts')).toBe(false)
   })
 
   test('respects a custom `fileName`', async () => {
@@ -171,8 +171,8 @@ describe('vanillaExtractPlugin', () => {
 
     expect(findAsset(output, 'styles.css')).toContain('rgb(1, 2, 3)')
     expect(findAsset(output, 'styles-css.js')).toContain('No-op shim')
-    expect(findAsset(output, 'styles.css.d.ts')).toContain('export {}')
     expect(findAsset(output, 'styles-css.d.ts')).toContain('export {}')
+    expect(output.some((assetOrChunk) => assetOrChunk.fileName === 'styles.css.d.ts')).toBe(false)
     expect(findEntryChunk(output).code).toContain(
       'import "@sanity/vanilla-extract-rolldown-plugin/styles.css";',
     )
@@ -276,7 +276,6 @@ describe('vanillaExtractPlugin', () => {
       'bundle-css.d.ts',
       'bundle-css.js',
       'bundle.css',
-      'bundle.css.d.ts',
       'index.js',
     ])
     expect(findAsset(withNodeCompat, 'bundle.css')).toBe('')

--- a/packages/@sanity/vanilla-extract-tsdown-plugin/README.md
+++ b/packages/@sanity/vanilla-extract-tsdown-plugin/README.md
@@ -32,9 +32,9 @@ injects a relative `import "./bundle.css"` into the entry chunks that use vanill
 through rolldown's native magic-string, so sourcemaps stay intact. `inject: {nodeCompat: true}`
 additionally wires up the whole conditional CSS export pattern: the injected import becomes the
 self-referential `import "<pkg>/bundle.css"`, a no-op `bundle-css.js` shim (plus
-`bundle.css.d.ts` / `bundle-css.d.ts`) is emitted for the `node`/`default` conditions of the
-export to point at, so the import is harmless in runtimes that cannot import `.css` files, and
-when tsdown's
+`bundle-css.d.ts` for the export's `types` condition) is emitted for the `node`/`default`
+conditions of the export to point at, so the import is harmless in runtimes that cannot import
+`.css` files, and when tsdown's
 [`exports` feature](https://tsdown.dev/options/package-exports) is enabled, the conditional
 `"./bundle.css"` export is written to `package.json` (`types` → the shim's `.d.ts`,
 `browser`/`style` → the real CSS, `node`/`default` → the shim) through the plugin's


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The conditional `./bundle.css` export already has an explicit `types` condition pointing at `bundle-css.d.ts`, so TypeScript never needs a sibling `bundle.css.d.ts` for the CSS file itself (as seen in packages like [sanity-plugin-bynder-input 5.0.0](https://npmdiff.dev/sanity-plugin-bynder-input/4.1.7/5.0.0)).

## Changes

- `@sanity/pkg-utils` and `@sanity/vanilla-extract-rolldown-plugin` now emit only `bundle-css.d.ts` (plus `bundle-css.js` / `bundle.css`)
- Remove the unused public `cssFileDtsFileName` helper from the rolldown plugin (**0.x minor**)
- Update docs/tests accordingly
- Refresh `benchmarks/vanilla-extract` Latest results after the plugin change

```json
"./bundle.css": {
  "types": "./dist/bundle-css.d.ts",
  "browser": "./dist/bundle.css",
  "style": "./dist/bundle.css",
  "node": "./dist/bundle-css.js",
  "default": "./dist/bundle-css.js"
}
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-051b03b4-89de-4840-a89c-771529564283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-051b03b4-89de-4840-a89c-771529564283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

