### PR TITLE
feat(tsdown-config): keep function/class names in the default minify compress pass

### DIFF
--- a/.changeset/keep-function-class-names.md
+++ b/.changeset/keep-function-class-names.md
@@ -5,7 +5,7 @@
 The default `minify` compress pass now preserves function and class names
 (`compress: {keepNames: {function: true, class: true}}`, previously `compress: true`).
 
-The compress pass otherwise strips otherwise-unreferenced names - most notably the inner name
+The compress pass strips otherwise-unreferenced names - most notably the inner name
 in `forwardRef(function Button(…) {…})`, which React DevTools reads via `Function.name`. That
 name is the tree-shakeable alternative to a top-level `Button.displayName = '…'` assignment (a
 side effect that pins unused components into consumer bundles, see

--- a/.changeset/keep-function-class-names.md
+++ b/.changeset/keep-function-class-names.md
@@ -1,0 +1,26 @@
+---
+'@sanity/tsdown-config': minor
+---
+
+The default `minify` compress pass now preserves function and class names
+(`compress: {keepNames: {function: true, class: true}}`, previously `compress: true`).
+
+The compress pass otherwise strips otherwise-unreferenced names - most notably the inner name
+in `forwardRef(function Button(…) {…})`, which React DevTools reads via `Function.name`. That
+name is the tree-shakeable alternative to a top-level `Button.displayName = '…'` assignment (a
+side effect that pins unused components into consumer bundles, see
+[sanity-io/ui#2435](https://github.com/sanity-io/ui/pull/2435)), and once stripped at publish
+time it is unrecoverable in userland. Keeping the names costs a fraction of a kilobyte in the
+published dist and nothing in final app bundles - consumers' production builds minify
+`node_modules` again anyway (and can opt into their own `keepNames`/`keep_fnames` for readable
+production profiling, which only works if the library kept the names in the first place).
+
+Packages that already apply this override on top of `defineConfig` (like `@sanity/ui`) can
+remove it. To restore the previous behavior, merge over the returned config:
+
+```ts
+import {defineConfig} from '@sanity/tsdown-config'
+import {mergeConfig} from 'tsdown'
+
+export default mergeConfig(await defineConfig(), {minify: {compress: true}})
+```

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -296,6 +296,42 @@ export default defineConfig({
 })
 ```
 
+## minify
+
+tsdown's [`minify` option](https://tsdown.dev/options/output#minify) defaults to compression
+only, with function and class names preserved:
+
+```ts
+{
+  compress: {keepNames: {function: true, class: true}},
+  mangle: false,
+  codegen: false,
+}
+```
+
+Consumers' production builds minify `node_modules` again anyway, so mangling identifiers or
+stripping whitespace in the published dist would not shrink final app bundles - it would only
+hurt debuggability. The compress pass still applies constant folding and dead code elimination
+(e.g. evaluating [`define`](#define)d branches away), and `keepNames` stops it from stripping
+otherwise-unreferenced function/class names such as the inner name in
+`forwardRef(function Button(…) {…})`. React DevTools reads that name via `Function.name` - the
+tree-shakeable alternative to a top-level `Button.displayName = '…'` assignment, which is a side
+effect that pins unused components into consumer bundles
+([sanity-io/ui#2435](https://github.com/sanity-io/ui/pull/2435)). Names stripped at publish time
+are unrecoverable in userland, while keeping them costs a fraction of a kilobyte.
+
+Override it by merging over the returned config, like [everything else](#everything-else-mergeconfig):
+
+```ts
+import {defineConfig} from '@sanity/tsdown-config'
+import {mergeConfig} from 'tsdown'
+
+export default mergeConfig(await defineConfig({tsconfig: 'tsconfig.dist.json'}), {
+  // e.g. drop the names again for the smallest possible dist:
+  minify: {compress: true},
+})
+```
+
 ## deps
 
 tsdown's [`deps` option](https://tsdown.dev/options/dependencies) is forwarded. When `platform` is

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -298,7 +298,7 @@ export default defineConfig({
 
 ## minify
 
-tsdown's [`minify` option](https://tsdown.dev/options/output#minify) defaults to compression
+@sanity/tsdown-config sets tsdown's [`minify` option](https://tsdown.dev/options/output#minify) to compression
 only, with function and class names preserved:
 
 ```ts

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -370,6 +370,20 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
     sourcemap,
     target,
     tsconfig,
-    minify: {compress: true, codegen: false, mangle: false},
+    // Compress the output (constant folding, dead code elimination) without mangling
+    // identifiers or stripping whitespace: consumers' production builds minify `node_modules`
+    // again anyway, so full minification here would only hurt debuggability, not final app
+    // bundle sizes. `keepNames` preserves the function and class names the compress pass
+    // would otherwise strip as unreferenced - e.g. the inner name in
+    // `forwardRef(function Button(…) {…})`, which React DevTools reads via `Function.name`.
+    // That name is the tree-shakeable alternative to a top-level `Button.displayName = '…'`
+    // assignment (a side effect that pins unused components into consumer bundles, see
+    // https://github.com/sanity-io/ui/pull/2435), and names stripped at publish time are
+    // unrecoverable in userland.
+    minify: {
+      compress: {keepNames: {function: true, class: true}},
+      codegen: false,
+      mangle: false,
+    },
   })
 }

--- a/packages/@sanity/tsdown-config/test/fixtures/styled-components-library/src/Button.tsx
+++ b/packages/@sanity/tsdown-config/test/fixtures/styled-components-library/src/Button.tsx
@@ -1,3 +1,4 @@
+import {forwardRef} from 'react'
 import {styled} from 'styled-components'
 
 const StyledButton = styled.button`
@@ -15,3 +16,15 @@ export function Button({
 }): React.JSX.Element {
   return <StyledButton type={type}>{children}</StyledButton>
 }
+
+// The `@sanity/ui` component pattern: a named function expression inside a pure-annotated
+// `forwardRef(…)` call, where the inner name (shown by React DevTools via `Function.name`)
+// is otherwise unreferenced and would be stripped by the minifier's compress pass
+export const IconButton: React.ForwardRefExoticComponent<
+  {children?: React.ReactNode} & React.RefAttributes<HTMLButtonElement>
+> = forwardRef(function IconButton(
+  {children}: {children?: React.ReactNode},
+  ref: React.Ref<HTMLButtonElement>,
+) {
+  return <StyledButton ref={ref}>{children}</StyledButton>
+})

--- a/packages/@sanity/tsdown-config/test/options.test.ts
+++ b/packages/@sanity/tsdown-config/test/options.test.ts
@@ -200,6 +200,22 @@ describe('checks option', () => {
   })
 })
 
+describe('minify default', () => {
+  test('compresses with keepNames, without mangling or codegen minification', async () => {
+    // Consumers' production builds minify `node_modules` again anyway, so the dist only gets
+    // the compress pass — with `keepNames`, since the inner name in patterns like
+    // `forwardRef(function Button(…) {…})` is what React DevTools shows via `Function.name`
+    // (the tree-shakeable alternative to top-level `displayName` assignments, see
+    // https://github.com/sanity-io/ui/pull/2435). Names stripped at publish time are
+    // unrecoverable in userland.
+    expect((await defineConfig()).minify).toEqual({
+      compress: {keepNames: {function: true, class: true}},
+      codegen: false,
+      mangle: false,
+    })
+  })
+})
+
 describe('unexposed options', () => {
   test('lean on tsdown defaults, customizable in userland through `mergeConfig`', async () => {
     // Options not in `PackageOptions` (e.g. `hash`, with its collision-preventing hashed chunk

--- a/packages/@sanity/tsdown-config/test/styled-components.test.ts
+++ b/packages/@sanity/tsdown-config/test/styled-components.test.ts
@@ -62,4 +62,23 @@ describe('styled-components-library', () => {
       expect(output).toContain('`cursor:pointer;border-radius:2px;padding:0;`')
     }
   })
+
+  test('keeps inner function names, so React DevTools can read `Function.name`', async () => {
+    const [distIndexJs, distIndexCjs] = await Promise.all([
+      readFile(path.join(fixtureDir, 'dist/index.js'), 'utf-8'),
+      readFile(path.join(fixtureDir, 'dist/index.cjs'), 'utf-8'),
+    ])
+
+    for (const output of [distIndexJs, distIndexCjs]) {
+      // The default minify (`compress: {keepNames}`) preserves the otherwise-unreferenced
+      // inner name in `forwardRef(function IconButton(…) {…})` - without `keepNames` the
+      // compress pass strips it to `forwardRef(function(…) {…})`, leaving the component
+      // anonymous in React DevTools wherever the dist runs unminified (e.g. every consumer's
+      // dev server). The name is the tree-shakeable alternative to a top-level
+      // `IconButton.displayName = '…'` assignment (https://github.com/sanity-io/ui/pull/2435).
+      // The CJS output calls it as `(0, react.forwardRef)(function IconButton(…)`, hence the
+      // optional `)` in the pattern
+      expect(output).toMatch(/forwardRef\)?\(function IconButton\(/)
+    }
+  })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adopts the minify settings from [sanity-io/ui#2435](https://github.com/sanity-io/ui/pull/2435) as the `@sanity/tsdown-config` default. The delta is smaller than it looks: that PR's `mangle: false` / `codegen: false` were already this config's defaults — the only missing piece is the compress pass's `keepNames`:

```diff
-minify: {compress: true, codegen: false, mangle: false}
+minify: {compress: {keepNames: {function: true, class: true}}, codegen: false, mangle: false}
```

With `@sanity/ui` on this default, its post-`defineConfig` `config.minify` override becomes redundant and can be deleted.

## Why it should be the default

- **The compress pass anonymizes React components.** Building the styled-components fixture with the current default emits `forwardRef(function({ children }, ref)` — the inner `IconButton` name is stripped as unreferenced. React DevTools reads `Function.name`, and with top-level `displayName` assignments off the table (they're side effects that pin unused components into consumer bundles — the whole point of ui#2435), the function name is the only thing left. A stripped name is unrecoverable in userland, and the published dist runs unminified in every consumer's dev server.
- **Userland minifies `node_modules` again anyway**, so keeping the names costs final app bundles nothing — their minifier strips/mangles them by default, and apps that *want* readable production profiles can opt into their own `keepNames`/`keep_fnames`, which only works if the library kept the names in the first place.
- **The dist cost is ~zero.** Rebuilding the workspace's own packages (`@sanity/vanilla-extract-vite-plugin`, `@sanity/vanilla-extract-integration`) with old vs new default produced byte-identical dists (21208 B and 27311 B respectively) — function *declarations* were never at risk since `mangle` is off; only otherwise-unreferenced function/class *expression* names are affected (~11 B per React component; ui#2435 measured ~0.5 kB across 60+ components). Since names are kept in place (not renamed), oxc needs no helpers — unlike esbuild's `keepNames`.

## Why the same change is _not_ made to `@sanity/pkg-utils`

While investigating, I found pkg-utils' rollup path strips these names too — its esbuild plugin runs `minifySyntax: true` even at the default `minify: false`, and `esbuild.transform(src, {minifySyntax: true})` drops the `Button` name from `forwardRef(function Button(...))`. But esbuild's only counter-measure, `keepNames: true`, injects `__defProp`/`__name` helpers, wrapping arrows and — critically — emitting top-level `__name(declared, "declared")` statements after exported function declarations:

```js
var __defProp = Object.defineProperty;
var __name = (target, value) => __defProp(target, "name", { value, configurable: !0 });
export function declared() { return 1; }
__name(declared, "declared");
```

That's exactly the top-level-side-effect-after-definition pattern ui#2435 removed, so it would *regress* tree-shaking for every pkg-utils dist. There's no zero-cost option on the esbuild/rollup stack; React component packages that need name preservation should migrate to `@sanity/tsdown-config` (the direction of travel anyway).

## Changes

- `packages/@sanity/tsdown-config/src/index.ts`: `compress: true` → `compress: {keepNames: {function: true, class: true}}` in the `minify` default.
- `packages/@sanity/tsdown-config/test/options.test.ts`: unit test asserting the default shape.
- `packages/@sanity/tsdown-config/test/fixtures/styled-components-library/src/Button.tsx` + `test/styled-components.test.ts`: the fixture now ships an `@sanity/ui`-style `forwardRef(function IconButton(…))` component, and a new test asserts the inner name survives into both the ESM and CJS dist (it fails against the old default, where the dist reads `forwardRef(function({ children }, ref)`).
- `packages/@sanity/tsdown-config/README.md`: new `minify` section documenting the default and the `mergeConfig` override (verified: `mergeConfig(config, {minify: {compress: true}})` restores the previous behavior exactly).
- `.changeset/keep-function-class-names.md`: minor bump for `@sanity/tsdown-config`.

## Verification

- `pnpm vitest run --project @sanity/tsdown-config`: 78/78 pass (global setup rebuilds all fixtures for real).
- Full root `pnpm test`: 34 files, 394 passed / 15 skipped, no type errors — includes the pkg-utils playground-build suite, unaffected as expected.
- `pnpm build` (all `packages/@sanity/*` on the new default), `pnpm lint --deny-warnings`, `pnpm typecheck`, `pnpm knip` (only the 3 expected catalog warnings), prettier check on changed files: all clean.
- Before/after on the same fixture build: `forwardRef(function({ children }, ref)` → `forwardRef(function IconButton({ children }, ref)`.
- Benchmarks not re-run: no `vanilla-extract-*` package source changed, and the benchmark workspace resolves the plugins via dev exports (source files), so results cannot shift.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc508616-41e5-41e2-a1ea-c0a1ab248179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc508616-41e5-41e2-a1ea-c0a1ab248179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

