### PR TITLE
feat(tsdown-config): add `reactCompiler.reactServer` for dual React Server Components builds

### DIFF
--- a/.changeset/react-server-condition.md
+++ b/.changeset/react-server-condition.md
@@ -13,13 +13,13 @@ export default defineConfig({
 })
 ```
 
-React Server Components refuse to load React Compiler output (`react/compiler-runtime` throws in the `react-server` environment), so libraries that ship compiled code are expected to [publish two entrypoints](https://github.com/facebook/react/issues/31702). `reactServer: true` bakes that pattern in: every entry is built twice from the same source, and the only difference is that React Compiler auto-memoization is applied to the non-`react-server` output. The uncompiled build lands next to the compiled one (`dist/index.js` ↔ `dist/index.server.js`), and when the `exports` feature is enabled every entry export gains a `react-server` condition:
+React Server Components refuse to load React Compiler output (`react/compiler-runtime` throws in the `react-server` environment), so libraries that ship compiled code are expected to [publish two entrypoints](https://github.com/facebook/react/issues/31702). `reactServer: true` bakes that pattern in: every entry is built twice from the same source, and the only difference is that React Compiler auto-memoization is applied to the non-`react-server` output. The uncompiled build lands next to the compiled one (`dist/index.js` ↔ `dist/index.react-server.js`), and when the `exports` feature is enabled every entry export gains a `react-server` condition:
 
 ```json
 {
   "exports": {
     ".": {
-      "react-server": "./dist/index.server.js",
+      "react-server": "./dist/index.react-server.js",
       "default": "./dist/index.js"
     }
   }

--- a/.changeset/react-server-condition.md
+++ b/.changeset/react-server-condition.md
@@ -19,6 +19,7 @@ React Server Components refuse to load React Compiler output (`react/compiler-ru
 {
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "react-server": "./dist/index.react-server.js",
       "default": "./dist/index.js"
     }

--- a/.changeset/react-server-condition.md
+++ b/.changeset/react-server-condition.md
@@ -2,7 +2,7 @@
 '@sanity/tsdown-config': minor
 ---
 
-Add `reactServer` to the `reactCompiler` options, for libraries that render in React Server Components:
+Add `reactServer` to the `reactCompiler` options, for libraries that render in React Server Components. It's experimental (`@alpha`) and not covered by semver: it can change behavior or be removed entirely in a minor version.
 
 ```ts
 import {defineConfig} from '@sanity/tsdown-config'

--- a/.changeset/react-server-condition.md
+++ b/.changeset/react-server-condition.md
@@ -1,0 +1,29 @@
+---
+'@sanity/tsdown-config': minor
+---
+
+Add `reactServer` to the `reactCompiler` options, for libraries that render in React Server Components:
+
+```ts
+import {defineConfig} from '@sanity/tsdown-config'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  reactCompiler: {target: '19', reactServer: true},
+})
+```
+
+React Server Components refuse to load React Compiler output (`react/compiler-runtime` throws in the `react-server` environment), so libraries that ship compiled code are expected to [publish two entrypoints](https://github.com/facebook/react/issues/31702). `reactServer: true` bakes that pattern in: every entry is built twice from the same source, and the only difference is that React Compiler auto-memoization is applied to the non-`react-server` output. The uncompiled build lands next to the compiled one (`dist/index.js` ↔ `dist/index.server.js`), and when the `exports` feature is enabled every entry export gains a `react-server` condition:
+
+```json
+{
+  "exports": {
+    ".": {
+      "react-server": "./dist/index.server.js",
+      "default": "./dist/index.js"
+    }
+  }
+}
+```
+
+Nothing is stripped from either output, so pair it with deleting manual `useMemo`/`useCallback` calls from the source: server components stop paying for memoization that cannot pay off (they render exactly once), and client components get the compiler's finer-grained auto-memoization instead.

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -43,6 +43,62 @@ export default defineConfig({
 })
 ```
 
+### React Server Components (`reactServer`)
+
+React Server Components refuse to load React Compiler output — `react/compiler-runtime` throws
+in the `react-server` environment, since memoization can never pay off for components that
+render exactly once. The React team's guidance for libraries that ship compiled code is to
+[publish two entrypoints](https://github.com/facebook/react/issues/31702): the compiled one for
+the client, and an uncompiled one under the `react-server` export condition.
+
+The `reactServer` option of `reactCompiler` (an option of this config, never forwarded to the
+compiler) bakes that pattern in:
+
+```ts
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  reactCompiler: {target: '19', reactServer: true},
+})
+```
+
+Every entry is built twice from the same source, and the only difference is that React Compiler
+auto-memoization is applied to the non-`react-server` output. The uncompiled build lands next to
+the compiled one with `.server` inserted before the extension (`dist/index.js` ↔
+`dist/index.server.js`), only the compiled build emits the `.d.ts` files (TypeScript resolves
+types through the `default` condition), and — when the [`exports` feature](#exports) is enabled —
+every entry export gains a `react-server` condition:
+
+```json
+{
+  "exports": {
+    ".": {
+      "react-server": "./dist/index.server.js",
+      "default": "./dist/index.js"
+    }
+  }
+}
+```
+
+React Server Components resolve the uncompiled build, everything else (client components, SSR,
+plain Node) resolves the compiled one. The `.server.` files never become export subpaths of
+their own.
+
+Nothing is stripped from either output, so pair `reactServer` with deleting manual
+`useMemo`/`useCallback` calls from the source: server components stop paying for memoization
+that cannot pay off, and client components get the compiler's finer-grained auto-memoization
+instead of the hand-written hooks.
+
+`reactServer` is meant for isomorphic libraries that render in both worlds without a
+`'use client'` directive (pure renderers like `@portabletext/react`). Client-only packages that
+ship `'use client'` don't need it — they always load through the `default` condition anyway.
+Also note the general dual-entrypoint caveat: the two conditions are two module instances, so
+module-scope identity (e.g. `createContext`) is not shared between server and client trees —
+which is exactly the boundary React draws for such libraries anyway.
+
+With `reactServer` the config resolves to two tsdown configs, so the
+[isolated declarations annotation](#isolated-declarations) becomes
+`satisfies Promise<UserConfig[]>`.
+
 ## styled-components
 
 If your package uses `styled-components`, enable the same `styledComponents` transform that `@sanity/pkg-utils` has:
@@ -252,6 +308,8 @@ Without the annotation, type-checking `tsdown.config.ts` with the `@sanity/tscon
 enable `declaration`) fails with TS2883 in pnpm projects: the inferred type of the default export
 can only be named through `@sanity/tsdown-config`'s own copy of `tsdown`, which isn't portable.
 `satisfies Promise<UserConfig>` names the type through your own `tsdown` dependency instead.
+With [`reactCompiler.reactServer`](#react-server-components-reactserver) the config resolves to
+two tsdown configs, so the annotation becomes `satisfies Promise<UserConfig[]>`.
 
 Keep the `isolated-declarations` preset scoped to the tsconfig that tsdown builds with (e.g. a
 `tsconfig.dist.json` that only includes `./src`). If `isolatedDeclarations` covers

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -64,8 +64,8 @@ export default defineConfig({
 
 Every entry is built twice from the same source, and the only difference is that React Compiler
 auto-memoization is applied to the non-`react-server` output. The uncompiled build lands next to
-the compiled one with `.server` inserted before the extension (`dist/index.js` ↔
-`dist/index.server.js`), only the compiled build emits the `.d.ts` files (TypeScript resolves
+the compiled one with `.react-server` inserted before the extension (`dist/index.js` ↔
+`dist/index.react-server.js`), only the compiled build emits the `.d.ts` files (TypeScript resolves
 types through the `default` condition), and — when the [`exports` feature](#exports) is enabled —
 every entry export gains a `react-server` condition:
 
@@ -73,7 +73,7 @@ every entry export gains a `react-server` condition:
 {
   "exports": {
     ".": {
-      "react-server": "./dist/index.server.js",
+      "react-server": "./dist/index.react-server.js",
       "default": "./dist/index.js"
     }
   }
@@ -81,7 +81,7 @@ every entry export gains a `react-server` condition:
 ```
 
 React Server Components resolve the uncompiled build, everything else (client components, SSR,
-plain Node) resolves the compiled one. The `.server.` files never become export subpaths of
+plain Node) resolves the compiled one. The `.react-server.` files never become export subpaths of
 their own.
 
 Nothing is stripped from either output, so pair `reactServer` with deleting manual

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -52,7 +52,8 @@ render exactly once. The React team's guidance for libraries that ship compiled 
 the client, and an uncompiled one under the `react-server` export condition.
 
 The `reactServer` option of `reactCompiler` (an option of this config, never forwarded to the
-compiler) bakes that pattern in:
+compiler) bakes that pattern in. It's experimental (`@alpha`) and not covered by semver: it can
+change behavior or be removed entirely in a minor version.
 
 ```ts
 export default defineConfig({

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -65,14 +65,17 @@ export default defineConfig({
 Every entry is built twice from the same source, and the only difference is that React Compiler
 auto-memoization is applied to the non-`react-server` output. The uncompiled build lands next to
 the compiled one with `.react-server` inserted before the extension (`dist/index.js` ↔
-`dist/index.react-server.js`), only the compiled build emits the `.d.ts` files (TypeScript resolves
-types through the `default` condition), and — when the [`exports` feature](#exports) is enabled —
-every entry export gains a `react-server` condition:
+`dist/index.react-server.js`), only the compiled build emits the `.d.ts` files, and — when the
+[`exports` feature](#exports) is enabled — every entry export gains a `react-server` condition,
+with a `types` condition specified before it (the `.react-server.` files have no declaration
+siblings, so the explicit `types` condition points every resolution mode — including consumers
+with `react-server` in their `customConditions` — at the compiled build's declarations):
 
 ```json
 {
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "react-server": "./dist/index.react-server.js",
       "default": "./dist/index.js"
     }

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -70,12 +70,12 @@ export interface StyledComponentsOptions {
  */
 export type ReactCompilerOptions = Partial<ReactCompilerPluginOptions> & {
   /**
-   * Also emit an uncompiled build of every entry (`<name>.server.js` next to `<name>.js`),
+   * Also emit an uncompiled build of every entry (`<name>.react-server.js` next to `<name>.js`),
    * wired to the `react-server` export condition in `package.json`:
    *
    * ```json
    * ".": {
-   *   "react-server": "./dist/index.server.js",
+   *   "react-server": "./dist/index.react-server.js",
    *   "default": "./dist/index.js"
    * }
    * ```
@@ -445,7 +445,7 @@ async function resolvePackageConfig(
     if (variant === 'default' && exports) {
       // The compiled variant owns `exports` generation for the dual build, so the
       // `react-server` conditions are composed into its `customExports`: every entry export
-      // gains a `react-server` condition pointing at the `.server.` sibling that the
+      // gains a `react-server` condition pointing at the `.react-server.` sibling that the
       // `react-server` variant emits.
       exports = withReactServerExports(exports)
     }
@@ -467,8 +467,8 @@ async function resolvePackageConfig(
     format,
     inputOptions,
     outDir,
-    // The `react-server` variant writes its files next to the compiled ones, with `.server`
-    // inserted before tsdown's default extension (`index.js` ↔ `index.server.js`). Hashed
+    // The `react-server` variant writes its files next to the compiled ones, with `.react-server`
+    // inserted before tsdown's default extension (`index.js` ↔ `index.react-server.js`). Hashed
     // chunk filenames get the suffix too, so the two variants' chunks never collide in the
     // shared `outDir`.
     outExtensions: isReactServer ? reactServerOutExtensions : undefined,
@@ -485,9 +485,9 @@ async function resolvePackageConfig(
 
 /**
  * The `outExtensions` of the `react-server` variant: tsdown's default extension for the
- * format and package type (see `resolveJsOutputExtension` in tsdown), with `.server` inserted
- * so the variant's entries sit next to the compiled ones (`index.js` ↔ `index.server.js`,
- * `index.cjs` ↔ `index.server.cjs`, and `.mjs` accordingly for CommonJS packages).
+ * format and package type (see `resolveJsOutputExtension` in tsdown), with `.react-server` inserted
+ * so the variant's entries sit next to the compiled ones (`index.js` ↔ `index.react-server.js`,
+ * `index.cjs` ↔ `index.react-server.cjs`, and `.mjs` accordingly for CommonJS packages).
  */
 const reactServerOutExtensions: NonNullable<UserConfig['outExtensions']> = ({
   format,
@@ -496,11 +496,11 @@ const reactServerOutExtensions: NonNullable<UserConfig['outExtensions']> = ({
   js:
     format === 'cjs'
       ? pkgType === 'module'
-        ? '.server.cjs'
-        : '.server.js'
+        ? '.react-server.cjs'
+        : '.react-server.js'
       : pkgType === 'module'
-        ? '.server.js'
-        : '.server.mjs',
+        ? '.react-server.js'
+        : '.react-server.mjs',
 })
 
 type ExportsOptions = Extract<NonNullable<UserConfig['exports']>, object>
@@ -556,9 +556,9 @@ const RUNTIME_CONDITIONS = new Set(['import', 'require', 'default'])
 
 /**
  * Inserts a `react-server` condition into every entry export of an `exports`-shaped map,
- * pointing at the `.server.` sibling emitted by the `react-server` variant — e.g.
+ * pointing at the `.react-server.` sibling emitted by the `react-server` variant — e.g.
  * `"./dist/index.js"` becomes
- * `{"react-server": "./dist/index.server.js", "default": "./dist/index.js"}`.
+ * `{"react-server": "./dist/index.react-server.js", "default": "./dist/index.js"}`.
  *
  * Entries are recognized by matching path leaves against the compiled variant's entry chunk
  * filenames, so non-entry exports (`./package.json`, the conditional `./bundle.css` export of
@@ -568,7 +568,7 @@ const RUNTIME_CONDITIONS = new Set(['import', 'require', 'default'])
  */
 function addReactServerConditions(exportsMap: ExportsMap, chunks: ChunksByFormat): ExportsMap {
   // Entry JS chunk filenames of the compiled variant; the `react-server` variant's files sit
-  // next to them with `.server` inserted before the extension
+  // next to them with `.react-server` inserted before the extension
   const entryFileNames: string[] = []
   for (const [format, formatChunks] of Object.entries(chunks)) {
     // Only `es` and `cjs` chunks become package exports (mirroring tsdown's own generation)
@@ -632,7 +632,7 @@ function withReactServerCondition(
   return next
 }
 
-/** `./dist/index.js` → `./dist/index.server.js` (and `.mjs`/`.cjs` accordingly). */
+/** `./dist/index.js` → `./dist/index.react-server.js` (and `.mjs`/`.cjs` accordingly). */
 function toServerFile(file: string): string {
-  return file.replace(RE_JS_FILE, '.server.$1')
+  return file.replace(RE_JS_FILE, '.react-server.$1')
 }

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -1,9 +1,11 @@
+import path from 'node:path'
 import type {Options as VanillaExtractPluginOptions} from '@sanity/vanilla-extract-tsdown-plugin'
 import type {PluginOptions as ReactCompilerPluginOptions} from 'babel-plugin-react-compiler'
 import {detect} from 'package-manager-detector/detect'
 import {
   defineConfig as defineTsdownConfig,
   mergeConfig,
+  type PackageJsonWithPath,
   type Rolldown,
   type UserConfig,
 } from 'tsdown'
@@ -511,8 +513,6 @@ type CustomExportsFunction = Extract<
   (...args: never[]) => unknown
 >
 type ExportsMap = Parameters<CustomExportsFunction>[0]
-type ChunksByFormat = Parameters<CustomExportsFunction>[1]['chunks']
-
 /**
  * Wires the `react-server` conditions into tsdown's `exports` feature by composing into
  * `exports.customExports` (the same composition `@sanity/vanilla-extract-tsdown-plugin` uses
@@ -545,7 +545,7 @@ function withReactServerExports(
         : previousCustomExports
           ? {...exportsMap, ...previousCustomExports}
           : exportsMap
-    return addReactServerConditions(base, context.chunks)
+    return addReactServerConditions(base, context)
   }
   return exportsOptions
 }
@@ -569,38 +569,48 @@ const RUNTIME_CONDITIONS = new Set(['import', 'require', 'default'])
  * actually exist among the compiled variant's chunks, and an already-present `types`
  * condition is left in place.
  *
- * Entries are recognized by matching path leaves against the compiled variant's entry chunk
- * filenames, so non-entry exports (`./package.json`, the conditional `./bundle.css` export of
- * `vanillaExtract`, `devExports` source paths like `./src/index.ts`) pass through untouched.
- * The `react-server` files themselves never enter the map — the `react-server` variant builds
- * with `exports: false` — so they don't become export subpaths of their own.
+ * Entries are recognized by comparing export targets against the compiled variant's entry
+ * chunks — reconstructed in the exact `./<outDir relative to the package root>/<fileName>`
+ * form tsdown writes into the exports map, so entries that share a leaf name (`index.js` vs
+ * `features/index.js`) can never shadow each other, and non-entry exports (`./package.json`,
+ * the conditional `./bundle.css` export of `vanillaExtract`, `devExports` source paths like
+ * `./src/index.ts`) pass through untouched. The `react-server` files themselves never enter
+ * the map — the `react-server` variant builds with `exports: false` — so they don't become
+ * export subpaths of their own.
  */
-function addReactServerConditions(exportsMap: ExportsMap, chunks: ChunksByFormat): ExportsMap {
-  // Entry JS and declaration chunk filenames of the compiled variant; the `react-server`
-  // variant's files sit next to the entries with `.react-server` inserted before the extension
-  const entryFileNames: string[] = []
-  const dtsFileNames = new Set<string>()
-  for (const [format, formatChunks] of Object.entries(chunks)) {
+function addReactServerConditions(
+  exportsMap: ExportsMap,
+  context: Parameters<CustomExportsFunction>[1],
+): ExportsMap {
+  // tsdown always resolves the package with its path here: its own exports generation reads
+  // `packageJsonPath` unconditionally from the same object it passes to `customExports` -
+  // only the declared context type is the plain `PackageJson` shape.
+  const pkg: Partial<PackageJsonWithPath> = context.pkg
+  const pkgRoot = path.dirname(pkg.packageJsonPath ?? 'package.json')
+  // Export targets of the compiled variant's entry JS and declaration chunks; the
+  // `react-server` variant's files sit next to the entries with `.react-server` inserted
+  // before the extension
+  const entryFiles = new Set<string>()
+  const dtsFiles = new Set<string>()
+  for (const [format, formatChunks] of Object.entries(context.chunks)) {
     // Only `es` and `cjs` chunks become package exports (mirroring tsdown's own generation)
     if (format !== 'es' && format !== 'cjs') continue
     for (const chunk of formatChunks) {
       if (chunk.type !== 'chunk') continue
+      const target = exportTarget(pkgRoot, chunk.outDir, chunk.fileName)
       if (chunk.isEntry && RE_JS_FILE.test(chunk.fileName)) {
-        entryFileNames.push(chunk.fileName)
+        entryFiles.add(target)
       } else if (RE_DTS_FILE.test(chunk.fileName)) {
-        dtsFileNames.add(chunk.fileName)
+        dtsFiles.add(target)
       }
     }
   }
   const isEntryFile = (value: unknown): value is string =>
-    typeof value === 'string' && entryFileNames.some((fileName) => value.endsWith(`/${fileName}`))
-  // The `types` file for an entry export path, when the compiled variant emitted it
+    typeof value === 'string' && entryFiles.has(value)
+  // The `types` file for an entry export target, when the compiled variant emitted it
   const dtsFor = (value: string): string | undefined => {
-    const entryFileName = entryFileNames.find((fileName) => value.endsWith(`/${fileName}`))
-    if (entryFileName === undefined || !dtsFileNames.has(toDtsFile(entryFileName))) {
-      return undefined
-    }
-    return toDtsFile(value)
+    const dtsFile = toDtsFile(value)
+    return dtsFiles.has(dtsFile) ? dtsFile : undefined
   }
 
   const result: ExportsMap = {}
@@ -608,6 +618,15 @@ function addReactServerConditions(exportsMap: ExportsMap, chunks: ChunksByFormat
     result[key] = withReactServerCondition(value, isEntryFile, dtsFor)
   }
   return result
+}
+
+/**
+ * Mirrors tsdown's own `join` for exports targets:
+ * `./<outDir relative to the package root>/<fileName>`, with POSIX separators.
+ */
+function exportTarget(pkgRoot: string, outDir: string, fileName: string): string {
+  const outDirRelative = path.relative(pkgRoot, outDir).replaceAll('\\', '/')
+  return `${outDirRelative ? `./${outDirRelative}` : '.'}/${fileName.replaceAll('\\', '/')}`
 }
 
 function withReactServerCondition(

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -62,9 +62,40 @@ export interface StyledComponentsOptions {
  * The typings resolve in userland once `babel-plugin-react-compiler` (an optional peer
  * dependency, required to use `reactCompiler`) is installed, and always match the installed
  * version of the compiler.
+ *
+ * On top of the compiler's own options, `reactServer` opts into the dual React Server
+ * Components build — it's handled by this config and never forwarded to
+ * `babel-plugin-react-compiler`.
  * @public
  */
-export type ReactCompilerOptions = Partial<ReactCompilerPluginOptions>
+export type ReactCompilerOptions = Partial<ReactCompilerPluginOptions> & {
+  /**
+   * Also emit an uncompiled build of every entry (`<name>.server.js` next to `<name>.js`),
+   * wired to the `react-server` export condition in `package.json`:
+   *
+   * ```json
+   * ".": {
+   *   "react-server": "./dist/index.server.js",
+   *   "default": "./dist/index.js"
+   * }
+   * ```
+   *
+   * React Server Components refuse to load React Compiler output (`react/compiler-runtime`
+   * throws in the `react-server` environment), so a library that ships compiled code
+   * publishes two entrypoints: the compiled one (the `default` condition) and an uncompiled
+   * one (the `react-server` condition) — see
+   * https://github.com/facebook/react/issues/31702.
+   *
+   * Both builds come from the same source, and the only difference is that React Compiler
+   * auto-memoization is applied to the non-`react-server` output; nothing is stripped from
+   * either output. Pair it with deleting manual `useMemo`/`useCallback` calls from the
+   * source: server components stop paying for memoization that can never pay off (they
+   * render exactly once), and client components get the compiler's finer-grained
+   * memoization instead.
+   * @defaultValue false
+   */
+  reactServer?: boolean
+}
 
 /**
  * @public
@@ -150,6 +181,11 @@ export interface PackageOptions extends Pick<
    * This is the same feature as the `babel: {reactCompiler: true}` and `reactCompilerOptions`
    * options in `@sanity/pkg-utils`. Unlike `styledComponents` there's no oxc native port of the
    * React Compiler yet, so `babel-plugin-react-compiler` needs to be installed.
+   *
+   * The options object also accepts `reactServer: true` (an option of this config, not the
+   * compiler), which additionally emits an uncompiled build of every entry wired to the
+   * `react-server` export condition, for libraries that render in React Server Components —
+   * see {@link ReactCompilerOptions.reactServer}.
    * @defaultValue false
    */
   reactCompiler?: boolean | ReactCompilerOptions
@@ -184,20 +220,69 @@ export interface PackageOptions extends Pick<
 /**
  * @public
  */
-export async function defineConfig(options: PackageOptions = {}): Promise<UserConfig> {
+export function defineConfig(
+  options: PackageOptions & {reactCompiler: ReactCompilerOptions & {reactServer: true}},
+): Promise<UserConfig[]>
+/**
+ * @public
+ */
+export function defineConfig(options?: PackageOptions): Promise<UserConfig>
+/**
+ * @public
+ */
+export async function defineConfig(
+  options: PackageOptions = {},
+): Promise<UserConfig | UserConfig[]> {
+  const reactCompiler = options.reactCompiler ?? false
+  // `reactCompiler.reactServer` opts into the dual React Server Components build: the same
+  // config twice, where the only difference is that React Compiler auto-memoization is applied
+  // to the non-`react-server` variant. Both variants build in one `tsdown` run — tsdown builds
+  // the configs in parallel, cleans the shared `outDir` once before either variant emits, and
+  // runs `exports` generation and `publint` per `package.json` only after every build for that
+  // package has finished (so the `react-server` files exist by the time they're validated).
+  if (typeof reactCompiler === 'object' && reactCompiler.reactServer === true) {
+    return Promise.all([
+      resolvePackageConfig(options, 'default'),
+      resolvePackageConfig(options, 'react-server'),
+    ])
+  }
+  return resolvePackageConfig(options, 'standalone')
+}
+
+/**
+ * The build variants {@link defineConfig} produces: the classic single build
+ * (`'standalone'`), or — with `reactCompiler.reactServer` — the compiled `'default'` variant
+ * and the uncompiled `'react-server'` variant of the dual React Server Components build.
+ */
+type PackageConfigVariant = 'standalone' | 'default' | 'react-server'
+
+async function resolvePackageConfig(
+  options: PackageOptions,
+  variant: PackageConfigVariant,
+): Promise<UserConfig> {
   // `tsconfig`, `entry`, `dts`, `define`, `target`, `outDir`, `clean` and `css` are passed
   // through to tsdown as-is. When left undefined, tsdown keeps its default behavior
   // (`tsconfig` is auto-detected from the project, `dts` from `package.json`, `define`
   // replaces nothing, `target` applies no syntax downleveling, `outDir` defaults to `'dist'`,
   // `clean` defaults to `true` — cleaning `outDir` before each build — and `css` stays off
   // unless `@tsdown/css` is installed and the option is set).
-  const {entry, tsconfig, dts, define, target, outDir, clean, css} = options
+  const {entry, tsconfig, define, target, outDir, css} = options
+  const isReactServer = variant === 'react-server'
+  // The `react-server` variant skips d.ts generation (the compiled variant's declarations
+  // serve both entries — TypeScript resolves types through the `default` condition), never
+  // cleans (tsdown collects the clean paths of all configs and cleans once, before either
+  // variant emits, so the compiled variant's `clean` already covers the run), and skips
+  // `publint` (it runs once, from the compiled variant, after both builds finish).
+  const dts = isReactServer ? false : options.dts
+  const clean = isReactServer ? false : options.clean
+  const publint = !isReactServer
   const platform = options.platform ?? 'neutral'
   const sourcemap = options.sourcemap ?? true
-  const reactCompiler = options.reactCompiler ?? false
+  // The React Compiler is what the `react-server` variant exists to avoid: compiled output
+  // loads `react/compiler-runtime`, which throws in the `react-server` environment.
+  const reactCompiler = isReactServer ? false : (options.reactCompiler ?? false)
   const styledComponents = options.styledComponents ?? false
   const report = {gzip: false} as const satisfies UserConfig['report']
-  const publint = true
   const format = options.format ?? 'esm'
   // When `platform` is `'neutral'`, restore the conventional `module`/`main` fallback that
   // rolldown's strict neutral defaults drop - needed for inlined deps without an `exports` map.
@@ -273,9 +358,13 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
       import('@rolldown/plugin-babel'),
       import('@vitejs/plugin-react'),
     ])
+    // `reactServer` belongs to this config, not the compiler — drop it before handing the
+    // options over to the babel preset.
+    const {reactServer: _reactServer, ...reactCompilerOptions} =
+      typeof reactCompiler === 'object' ? reactCompiler : {}
     plugins.push(
       await pluginBabel({
-        presets: [reactCompilerPreset(typeof reactCompiler === 'object' ? reactCompiler : {})],
+        presets: [reactCompilerPreset(reactCompilerOptions)],
       }),
     )
   }
@@ -331,21 +420,34 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
     )
   }
 
-  const packageManager = await detect({cwd: process.cwd()})
-  // tsdown's `exports` feature is enabled with Sanity-flavored defaults, and userland values
-  // apply with tsdown's own `mergeConfig` semantics: an object deep-merges over the defaults,
-  // anything else (`false`, a CI condition) replaces them.
-  const {exports} = mergeConfig(
-    {
-      exports: {
-        enabled: 'local-only',
-        // Only opt in by default when pnpm is detected: support for replacing package fields
-        // from `publishConfig` is not reliable across package managers.
-        ...(packageManager?.name === 'pnpm' && {devExports: true}),
+  // The `react-server` variant does not participate in `exports` generation: its files are
+  // wired in through the compiled variant's `react-server` conditions instead of becoming
+  // export subpaths of their own.
+  let exports: UserConfig['exports'] = false
+  if (!isReactServer) {
+    const packageManager = await detect({cwd: process.cwd()})
+    // tsdown's `exports` feature is enabled with Sanity-flavored defaults, and userland values
+    // apply with tsdown's own `mergeConfig` semantics: an object deep-merges over the defaults,
+    // anything else (`false`, a CI condition) replaces them.
+    ;({exports} = mergeConfig(
+      {
+        exports: {
+          enabled: 'local-only',
+          // Only opt in by default when pnpm is detected: support for replacing package fields
+          // from `publishConfig` is not reliable across package managers.
+          ...(packageManager?.name === 'pnpm' && {devExports: true}),
+        },
       },
-    },
-    {exports: options.exports},
-  )
+      {exports: options.exports},
+    ))
+    if (variant === 'default' && exports) {
+      // The compiled variant owns `exports` generation for the dual build, so the
+      // `react-server` conditions are composed into its `customExports`: every entry export
+      // gains a `react-server` condition pointing at the `.server.` sibling that the
+      // `react-server` variant emits.
+      exports = withReactServerExports(exports)
+    }
+  }
 
   return defineTsdownConfig({
     // Rolldown defaults `circularDependency` to `false`; enable it so Sanity library builds
@@ -363,6 +465,11 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
     format,
     inputOptions,
     outDir,
+    // The `react-server` variant writes its files next to the compiled ones, with `.server`
+    // inserted before tsdown's default extension (`index.js` ↔ `index.server.js`). Hashed
+    // chunk filenames get the suffix too, so the two variants' chunks never collide in the
+    // shared `outDir`.
+    outExtensions: isReactServer ? reactServerOutExtensions : undefined,
     platform,
     plugins,
     publint,
@@ -372,4 +479,158 @@ export async function defineConfig(options: PackageOptions = {}): Promise<UserCo
     tsconfig,
     minify: {compress: true, codegen: false, mangle: false},
   })
+}
+
+/**
+ * The `outExtensions` of the `react-server` variant: tsdown's default extension for the
+ * format and package type (see `resolveJsOutputExtension` in tsdown), with `.server` inserted
+ * so the variant's entries sit next to the compiled ones (`index.js` ↔ `index.server.js`,
+ * `index.cjs` ↔ `index.server.cjs`, and `.mjs` accordingly for CommonJS packages).
+ */
+const reactServerOutExtensions: NonNullable<UserConfig['outExtensions']> = ({
+  format,
+  pkgType,
+}) => ({
+  js:
+    format === 'cjs'
+      ? pkgType === 'module'
+        ? '.server.cjs'
+        : '.server.js'
+      : pkgType === 'module'
+        ? '.server.js'
+        : '.server.mjs',
+})
+
+type ExportsOptions = Extract<NonNullable<UserConfig['exports']>, object>
+type CustomExportsFunction = Extract<
+  NonNullable<ExportsOptions['customExports']>,
+  (...args: never[]) => unknown
+>
+type ExportsMap = Parameters<CustomExportsFunction>[0]
+type ChunksByFormat = Parameters<CustomExportsFunction>[1]['chunks']
+
+/**
+ * Wires the `react-server` conditions into tsdown's `exports` feature by composing into
+ * `exports.customExports` (the same composition `@sanity/vanilla-extract-tsdown-plugin` uses
+ * for its conditional CSS export): a pre-existing `customExports` applies first — both its
+ * function and record forms, mirroring how tsdown itself applies them — and the
+ * `react-server` conditions are inserted into the result. The composed function runs for both
+ * the local `exports` map and `publishConfig.exports`; with `devExports` the local map points
+ * at source files, which the entry-file matching leaves untouched (source resolves for every
+ * condition in development, which is correct — uncompiled source is exactly what the
+ * `react-server` condition ships).
+ */
+function withReactServerExports(
+  exportsOption: Exclude<NonNullable<UserConfig['exports']>, false>,
+): ExportsOptions {
+  // Normalize the `boolean | CIOption | object` forms of the `exports` option into the
+  // object form, preserving the enabled-ness (`true` and bare CI conditions mean enabled)
+  const exportsOptions: ExportsOptions =
+    exportsOption === true
+      ? {}
+      : typeof exportsOption === 'string'
+        ? {enabled: exportsOption}
+        : exportsOption
+  const previousCustomExports = exportsOptions.customExports
+  exportsOptions.customExports = async (exportsMap, context) => {
+    // Apply a pre-existing `customExports` first (both its function and record forms,
+    // mirroring how tsdown itself applies them), then insert the `react-server` conditions
+    const base =
+      typeof previousCustomExports === 'function'
+        ? await previousCustomExports(exportsMap, context)
+        : previousCustomExports
+          ? {...exportsMap, ...previousCustomExports}
+          : exportsMap
+    return addReactServerConditions(base, context.chunks)
+  }
+  return exportsOptions
+}
+
+/** Matches the JS output extensions tsdown emits for `es`/`cjs` chunks. */
+const RE_JS_FILE = /\.(m?js|cjs)$/
+
+/** The conditions tsdown generates that resolve at runtime, in contrast to `types` etc. */
+const RUNTIME_CONDITIONS = ['import', 'require', 'default']
+
+/**
+ * Inserts a `react-server` condition into every entry export of an `exports`-shaped map,
+ * pointing at the `.server.` sibling emitted by the `react-server` variant — e.g.
+ * `"./dist/index.js"` becomes
+ * `{"react-server": "./dist/index.server.js", "default": "./dist/index.js"}`.
+ *
+ * Entries are recognized by matching path leaves against the compiled variant's entry chunk
+ * filenames, so non-entry exports (`./package.json`, the conditional `./bundle.css` export of
+ * `vanillaExtract`, `devExports` source paths like `./src/index.ts`) pass through untouched.
+ * The `react-server` files themselves never enter the map — the `react-server` variant builds
+ * with `exports: false` — so they don't become export subpaths of their own.
+ */
+function addReactServerConditions(exportsMap: ExportsMap, chunks: ChunksByFormat): ExportsMap {
+  // Entry JS chunk filenames of the compiled variant; the `react-server` variant's files sit
+  // next to them with `.server` inserted before the extension
+  const entryFileNames: string[] = []
+  for (const [format, formatChunks] of Object.entries(chunks)) {
+    // Only `es` and `cjs` chunks become package exports (mirroring tsdown's own generation)
+    if (format !== 'es' && format !== 'cjs') continue
+    for (const chunk of formatChunks) {
+      if (chunk.type === 'chunk' && chunk.isEntry && RE_JS_FILE.test(chunk.fileName)) {
+        entryFileNames.push(chunk.fileName)
+      }
+    }
+  }
+  const isEntryFile = (value: unknown): value is string =>
+    typeof value === 'string' && entryFileNames.some((fileName) => value.endsWith(`/${fileName}`))
+
+  const result: ExportsMap = {}
+  for (const [key, value] of Object.entries(exportsMap as Record<string, unknown>)) {
+    result[key] = withReactServerCondition(value, isEntryFile)
+  }
+  return result
+}
+
+function withReactServerCondition(
+  value: unknown,
+  isEntryFile: (value: unknown) => value is string,
+): unknown {
+  // A bare-string entry export (e.g. the pure-ESM publish shape `".": "./dist/index.js"`)
+  // becomes a conditional export with `react-server` resolving first
+  if (isEntryFile(value)) {
+    return {'react-server': toServerFile(value), 'default': value}
+  }
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return value
+  const conditions = Object.entries(value)
+  const matched = conditions.filter(
+    (entry): entry is [string, string] =>
+      RUNTIME_CONDITIONS.includes(entry[0]) && isEntryFile(entry[1]),
+  )
+  const [firstMatch] = matched
+  if (!firstMatch) return value
+  // A single runtime file maps to a plain path; a dual-format entry nests its `import` and
+  // `require` files under the `react-server` condition
+  const serverTarget =
+    matched.length === 1
+      ? toServerFile(firstMatch[1])
+      : Object.fromEntries(
+          matched.map(([condition, target]) => [condition, toServerFile(target)]),
+        )
+  // Conditions match in order, so `react-server` is inserted right before the first runtime
+  // condition (`import`/`require`/`default`), keeping `types` and custom development
+  // conditions (`devExports`) ahead of it
+  const next: Record<string, unknown> = {}
+  let inserted = false
+  for (const [condition, target] of conditions) {
+    if (!inserted && RUNTIME_CONDITIONS.includes(condition)) {
+      next['react-server'] = serverTarget
+      inserted = true
+    }
+    next[condition] = target
+  }
+  if (!inserted) {
+    next['react-server'] = serverTarget
+  }
+  return next
+}
+
+/** `./dist/index.js` → `./dist/index.server.js` (and `.mjs`/`.cjs` accordingly). */
+function toServerFile(file: string): string {
+  return file.replace(RE_JS_FILE, '.server.$1')
 }

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -550,7 +550,7 @@ function withReactServerExports(
 const RE_JS_FILE = /\.(m?js|cjs)$/
 
 /** The conditions tsdown generates that resolve at runtime, in contrast to `types` etc. */
-const RUNTIME_CONDITIONS = ['import', 'require', 'default']
+const RUNTIME_CONDITIONS = new Set(['import', 'require', 'default'])
 
 /**
  * Inserts a `react-server` condition into every entry export of an `exports`-shaped map,
@@ -600,7 +600,7 @@ function withReactServerCondition(
   const conditions = Object.entries(value)
   const matched = conditions.filter(
     (entry): entry is [string, string] =>
-      RUNTIME_CONDITIONS.includes(entry[0]) && isEntryFile(entry[1]),
+      RUNTIME_CONDITIONS.has(entry[0]) && isEntryFile(entry[1]),
   )
   const [firstMatch] = matched
   if (!firstMatch) return value
@@ -618,7 +618,7 @@ function withReactServerCondition(
   const next: Record<string, unknown> = {}
   let inserted = false
   for (const [condition, target] of conditions) {
-    if (!inserted && RUNTIME_CONDITIONS.includes(condition)) {
+    if (!inserted && RUNTIME_CONDITIONS.has(condition)) {
       next['react-server'] = serverTarget
       inserted = true
     }

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -75,6 +75,7 @@ export type ReactCompilerOptions = Partial<ReactCompilerPluginOptions> & {
    *
    * ```json
    * ".": {
+   *   "types": "./dist/index.d.ts",
    *   "react-server": "./dist/index.react-server.js",
    *   "default": "./dist/index.js"
    * }
@@ -271,10 +272,11 @@ async function resolvePackageConfig(
   const {entry, tsconfig, define, target, outDir, css} = options
   const isReactServer = variant === 'react-server'
   // The `react-server` variant skips d.ts generation (the compiled variant's declarations
-  // serve both entries — TypeScript resolves types through the `default` condition), never
-  // cleans (tsdown collects the clean paths of all configs and cleans once, before either
-  // variant emits, so the compiled variant's `clean` already covers the run), and skips
-  // `publint` (it runs once, from the compiled variant, after both builds finish).
+  // serve both entries — a `types` condition specified before `react-server` points every
+  // resolution mode at them), never cleans (tsdown collects the clean paths of all configs
+  // and cleans once, before either variant emits, so the compiled variant's `clean` already
+  // covers the run), and skips `publint` (it runs once, from the compiled variant, after
+  // both builds finish).
   const dts = isReactServer ? false : options.dts
   const clean = isReactServer ? false : options.clean
   const publint = !isReactServer
@@ -558,7 +560,14 @@ const RUNTIME_CONDITIONS = new Set(['import', 'require', 'default'])
  * Inserts a `react-server` condition into every entry export of an `exports`-shaped map,
  * pointing at the `.react-server.` sibling emitted by the `react-server` variant — e.g.
  * `"./dist/index.js"` becomes
- * `{"react-server": "./dist/index.react-server.js", "default": "./dist/index.js"}`.
+ * `{"types": "./dist/index.d.ts", "react-server": "./dist/index.react-server.js", "default": "./dist/index.js"}`.
+ *
+ * The `react-server` variant emits no `.d.ts` siblings, so TypeScript's adjacent-file lookup
+ * cannot resolve types for `./dist/index.react-server.js` — a `types` condition pointing at
+ * the compiled variant's declarations is specified before `react-server` instead (conditions
+ * match in order, so it covers every resolution mode). It's only added when the declarations
+ * actually exist among the compiled variant's chunks, and an already-present `types`
+ * condition is left in place.
  *
  * Entries are recognized by matching path leaves against the compiled variant's entry chunk
  * filenames, so non-entry exports (`./package.json`, the conditional `./bundle.css` export of
@@ -567,24 +576,36 @@ const RUNTIME_CONDITIONS = new Set(['import', 'require', 'default'])
  * with `exports: false` — so they don't become export subpaths of their own.
  */
 function addReactServerConditions(exportsMap: ExportsMap, chunks: ChunksByFormat): ExportsMap {
-  // Entry JS chunk filenames of the compiled variant; the `react-server` variant's files sit
-  // next to them with `.react-server` inserted before the extension
+  // Entry JS and declaration chunk filenames of the compiled variant; the `react-server`
+  // variant's files sit next to the entries with `.react-server` inserted before the extension
   const entryFileNames: string[] = []
+  const dtsFileNames = new Set<string>()
   for (const [format, formatChunks] of Object.entries(chunks)) {
     // Only `es` and `cjs` chunks become package exports (mirroring tsdown's own generation)
     if (format !== 'es' && format !== 'cjs') continue
     for (const chunk of formatChunks) {
-      if (chunk.type === 'chunk' && chunk.isEntry && RE_JS_FILE.test(chunk.fileName)) {
+      if (chunk.type !== 'chunk') continue
+      if (chunk.isEntry && RE_JS_FILE.test(chunk.fileName)) {
         entryFileNames.push(chunk.fileName)
+      } else if (RE_DTS_FILE.test(chunk.fileName)) {
+        dtsFileNames.add(chunk.fileName)
       }
     }
   }
   const isEntryFile = (value: unknown): value is string =>
     typeof value === 'string' && entryFileNames.some((fileName) => value.endsWith(`/${fileName}`))
+  // The `types` file for an entry export path, when the compiled variant emitted it
+  const dtsFor = (value: string): string | undefined => {
+    const entryFileName = entryFileNames.find((fileName) => value.endsWith(`/${fileName}`))
+    if (entryFileName === undefined || !dtsFileNames.has(toDtsFile(entryFileName))) {
+      return undefined
+    }
+    return toDtsFile(value)
+  }
 
   const result: ExportsMap = {}
   for (const [key, value] of Object.entries(exportsMap as Record<string, unknown>)) {
-    result[key] = withReactServerCondition(value, isEntryFile)
+    result[key] = withReactServerCondition(value, isEntryFile, dtsFor)
   }
   return result
 }
@@ -592,11 +613,18 @@ function addReactServerConditions(exportsMap: ExportsMap, chunks: ChunksByFormat
 function withReactServerCondition(
   value: unknown,
   isEntryFile: (value: unknown) => value is string,
+  dtsFor: (value: string) => string | undefined,
 ): unknown {
   // A bare-string entry export (e.g. the pure-ESM publish shape `".": "./dist/index.js"`)
-  // becomes a conditional export with `react-server` resolving first
+  // becomes a conditional export, with `types` specified before `react-server` so type
+  // resolution never reaches the declaration-less `.react-server.` file
   if (isEntryFile(value)) {
-    return {'react-server': toServerFile(value), 'default': value}
+    const types = dtsFor(value)
+    return {
+      ...(types === undefined ? {} : {types}),
+      'react-server': toServerFile(value),
+      'default': value,
+    }
   }
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return value
   const conditions = Object.entries(value)
@@ -606,13 +634,26 @@ function withReactServerCondition(
   )
   const [firstMatch] = matched
   if (!firstMatch) return value
-  // A single runtime file maps to a plain path; a dual-format entry nests its `import` and
-  // `require` files under the `react-server` condition
+  const hasTypes = conditions.some(([condition]) => condition === 'types')
+  // A single runtime file maps to a plain path (with a `types` condition inserted ahead of
+  // `react-server` below, unless one is already specified). A dual-format entry nests its
+  // `import` and `require` files under the `react-server` condition, each with its own
+  // format-matched `types` — a single top-level `types` file cannot serve both resolution
+  // modes, which is also why tsdown's own dual-format output relies on adjacent-file lookup.
+  const missingTypes = hasTypes ? undefined : dtsFor(firstMatch[1])
   const serverTarget =
     matched.length === 1
       ? toServerFile(firstMatch[1])
       : Object.fromEntries(
-          matched.map(([condition, target]) => [condition, toServerFile(target)]),
+          matched.map(([condition, target]) => {
+            const types = hasTypes ? undefined : dtsFor(target)
+            return [
+              condition,
+              types === undefined
+                ? toServerFile(target)
+                : {types, default: toServerFile(target)},
+            ]
+          }),
         )
   // Conditions match in order, so `react-server` is inserted right before the first runtime
   // condition (`import`/`require`/`default`), keeping `types` and custom development
@@ -621,6 +662,9 @@ function withReactServerCondition(
   let inserted = false
   for (const [condition, target] of conditions) {
     if (!inserted && RUNTIME_CONDITIONS.has(condition)) {
+      if (matched.length === 1 && missingTypes !== undefined) {
+        next['types'] = missingTypes
+      }
       next['react-server'] = serverTarget
       inserted = true
     }
@@ -632,7 +676,17 @@ function withReactServerCondition(
   return next
 }
 
+/** Matches the declaration file extensions tsdown emits next to `es`/`cjs` chunks. */
+const RE_DTS_FILE = /\.d\.(ts|mts|cts)$/
+
 /** `./dist/index.js` → `./dist/index.react-server.js` (and `.mjs`/`.cjs` accordingly). */
 function toServerFile(file: string): string {
   return file.replace(RE_JS_FILE, '.react-server.$1')
+}
+
+/** `./dist/index.js` → `./dist/index.d.ts` (`.mjs` → `.d.mts`, `.cjs` → `.d.cts`). */
+function toDtsFile(file: string): string {
+  return file.replace(RE_JS_FILE, (extension) =>
+    extension === '.mjs' ? '.d.mts' : extension === '.cjs' ? '.d.cts' : '.d.ts',
+  )
 }

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -93,6 +93,8 @@ export type ReactCompilerOptions = Partial<ReactCompilerPluginOptions> & {
    * render exactly once), and client components get the compiler's finer-grained
    * memoization instead.
    * @defaultValue false
+   * @alpha This option is experimental and not covered by semver: it can change behavior or
+   * be removed entirely in a minor version.
    */
   reactServer?: boolean
 }

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -223,11 +223,29 @@ export interface PackageOptions extends Pick<
 }
 
 /**
+ * With `reactCompiler.reactServer` the config resolves to two tsdown configs: the compiled
+ * `default` variant and the uncompiled `react-server` variant.
  * @public
  */
 export function defineConfig(
   options: PackageOptions & {reactCompiler: ReactCompilerOptions & {reactServer: true}},
 ): Promise<UserConfig[]>
+/**
+ * Without `reactCompiler.reactServer` the config resolves to a single tsdown config.
+ * @public
+ */
+export function defineConfig(
+  options: PackageOptions & {reactCompiler: ReactCompilerOptions & {reactServer?: false}},
+): Promise<UserConfig>
+/**
+ * When TypeScript can't tell whether `reactCompiler.reactServer` is set (a widened `boolean`,
+ * e.g. through a `ReactCompilerOptions`-typed variable), the config resolves to either shape —
+ * check `Array.isArray` on the result.
+ * @public
+ */
+export function defineConfig(
+  options: PackageOptions & {reactCompiler: ReactCompilerOptions},
+): Promise<UserConfig | UserConfig[]>
 /**
  * @public
  */

--- a/packages/@sanity/tsdown-config/test/fixtures/react-server-library/package.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/react-server-library/package.json
@@ -27,6 +27,7 @@
   "publishConfig": {
     "exports": {
       ".": {
+        "types": "./dist/index.d.ts",
         "react-server": "./dist/index.react-server.js",
         "default": "./dist/index.js"
       },

--- a/packages/@sanity/tsdown-config/test/fixtures/react-server-library/package.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/react-server-library/package.json
@@ -27,7 +27,7 @@
   "publishConfig": {
     "exports": {
       ".": {
-        "react-server": "./dist/index.server.js",
+        "react-server": "./dist/index.react-server.js",
         "default": "./dist/index.js"
       },
       "./package.json": "./package.json"

--- a/packages/@sanity/tsdown-config/test/fixtures/react-server-library/package.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/react-server-library/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@fixtures/react-server-library",
+  "version": "0.0.0-development",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "babel-plugin-react-compiler": "^1.0.0",
+    "react": "^19.2.7"
+  },
+  "peerDependencies": {
+    "react": "^19.2"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "react-server": "./dist/index.server.js",
+        "default": "./dist/index.js"
+      },
+      "./package.json": "./package.json"
+    }
+  }
+}

--- a/packages/@sanity/tsdown-config/test/fixtures/react-server-library/src/PortableText.tsx
+++ b/packages/@sanity/tsdown-config/test/fixtures/react-server-library/src/PortableText.tsx
@@ -32,15 +32,14 @@ export function PortableText(props: {
 }): JSX.Element {
   const {value, components: overrides} = props
   const components = {...defaultComponents, ...overrides}
-  const blocks = value.map((block) => {
-    const lines = block.text.split('\n')
-    return (
+  const blocks = value.map((block) =>
+    block.text === '' ? (
+      <components.hardBreak key={block._key} />
+    ) : (
       <components.block key={block._key} style={block.style ?? 'normal'}>
-        {lines.flatMap((line, index) =>
-          index === 0 ? [line] : [<components.hardBreak key={`break-${index}`} />, line],
-        )}
+        {block.text.split('\n').join(' ')}
       </components.block>
-    )
-  })
+    ),
+  )
   return <>{blocks}</>
 }

--- a/packages/@sanity/tsdown-config/test/fixtures/react-server-library/src/PortableText.tsx
+++ b/packages/@sanity/tsdown-config/test/fixtures/react-server-library/src/PortableText.tsx
@@ -1,0 +1,46 @@
+import type {JSX, ReactNode} from 'react'
+
+/** @public */
+export interface Block {
+  _key: string
+  text: string
+  style?: 'normal' | 'h1'
+}
+
+/** @public */
+export interface PortableTextComponents {
+  block: (props: {children: ReactNode; style: string}) => JSX.Element
+  hardBreak: () => JSX.Element
+}
+
+const defaultComponents: PortableTextComponents = {
+  block: ({children, style}) => (style === 'h1' ? <h1>{children}</h1> : <p>{children}</p>),
+  hardBreak: () => <br />,
+}
+
+/**
+ * A `@portabletext/react`-shaped renderer without any manual `useMemo`/`useCallback` calls:
+ * the derived values below are exactly what a hand-written `useMemo` would have wrapped. The
+ * compiled variant memoizes them with the React Compiler, while the `react-server` variant
+ * runs the source as-is — React Server Components render exactly once, so memoization there
+ * would be pure overhead.
+ * @public
+ */
+export function PortableText(props: {
+  value: Block[]
+  components?: Partial<PortableTextComponents>
+}): JSX.Element {
+  const {value, components: overrides} = props
+  const components = {...defaultComponents, ...overrides}
+  const blocks = value.map((block) => {
+    const lines = block.text.split('\n')
+    return (
+      <components.block key={block._key} style={block.style ?? 'normal'}>
+        {lines.flatMap((line, index) =>
+          index === 0 ? [line] : [<components.hardBreak key={`break-${index}`} />, line],
+        )}
+      </components.block>
+    )
+  })
+  return <>{blocks}</>
+}

--- a/packages/@sanity/tsdown-config/test/fixtures/react-server-library/src/index.ts
+++ b/packages/@sanity/tsdown-config/test/fixtures/react-server-library/src/index.ts
@@ -1,0 +1,1 @@
+export * from './PortableText'

--- a/packages/@sanity/tsdown-config/test/fixtures/react-server-library/tsconfig.dist.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/react-server-library/tsconfig.dist.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["@sanity/tsconfig/strictest", "@sanity/tsconfig/isolated-declarations"],
+  "include": ["./src"],
+  "compilerOptions": {
+    "rootDir": "."
+  }
+}

--- a/packages/@sanity/tsdown-config/test/fixtures/react-server-library/tsdown.config.ts
+++ b/packages/@sanity/tsdown-config/test/fixtures/react-server-library/tsdown.config.ts
@@ -1,0 +1,6 @@
+import {defineConfig} from '@sanity/tsdown-config'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  reactCompiler: {target: '19', reactServer: true},
+})

--- a/packages/@sanity/tsdown-config/test/react-server.test.ts
+++ b/packages/@sanity/tsdown-config/test/react-server.test.ts
@@ -113,14 +113,14 @@ describe('reactCompiler.reactServer option', () => {
     expect(reactServer.publint).toBe(false)
   })
 
-  test('react-server entries sit next to the compiled ones with `.server` inserted', async () => {
+  test('react-server entries sit next to the compiled ones with `.react-server` inserted', async () => {
     const [compiled, reactServer] = await defineDualConfig()
 
-    // tsdown's default extension for the format/package type, with `.server` inserted
-    expect(outExtension(reactServer, 'es', 'module')).toEqual({js: '.server.js'})
-    expect(outExtension(reactServer, 'cjs', 'module')).toEqual({js: '.server.cjs'})
-    expect(outExtension(reactServer, 'es', 'commonjs')).toEqual({js: '.server.mjs'})
-    expect(outExtension(reactServer, 'cjs', 'commonjs')).toEqual({js: '.server.js'})
+    // tsdown's default extension for the format/package type, with `.react-server` inserted
+    expect(outExtension(reactServer, 'es', 'module')).toEqual({js: '.react-server.js'})
+    expect(outExtension(reactServer, 'cjs', 'module')).toEqual({js: '.react-server.cjs'})
+    expect(outExtension(reactServer, 'es', 'commonjs')).toEqual({js: '.react-server.mjs'})
+    expect(outExtension(reactServer, 'cjs', 'commonjs')).toEqual({js: '.react-server.js'})
 
     // The compiled variant keeps tsdown's default naming
     expect(compiled.outExtensions).toBeUndefined()
@@ -137,7 +137,7 @@ describe('reactCompiler.reactServer option', () => {
       customExportsContext({es: ['index.js']}),
     )
     expect(result).toEqual({
-      '.': {'react-server': './dist/index.server.js', 'default': './dist/index.js'},
+      '.': {'react-server': './dist/index.react-server.js', 'default': './dist/index.js'},
       './package.json': './package.json',
     })
     expect(Object.keys(result['.'])).toEqual(['react-server', 'default'])
@@ -160,8 +160,8 @@ describe('reactCompiler.reactServer option', () => {
     expect(result['.']).toEqual({
       'types': './dist/index.d.ts',
       'react-server': {
-        import: './dist/index.server.js',
-        require: './dist/index.server.cjs',
+        import: './dist/index.react-server.js',
+        require: './dist/index.react-server.cjs',
       },
       'import': './dist/index.js',
       'require': './dist/index.cjs',
@@ -192,8 +192,8 @@ describe('reactCompiler.reactServer option', () => {
       customExportsContext({es: ['index.js', 'theme.js']}),
     )
     expect(result).toEqual({
-      '.': {'react-server': './dist/index.server.js', 'default': './dist/index.js'},
-      './theme': {'react-server': './dist/theme.server.js', 'default': './dist/theme.js'},
+      '.': {'react-server': './dist/index.react-server.js', 'default': './dist/index.js'},
+      './theme': {'react-server': './dist/theme.react-server.js', 'default': './dist/theme.js'},
       // The conditional CSS export of `vanillaExtract` names no entry chunks - untouched
       './bundle.css': conditionalCssExport,
       './package.json': './package.json',
@@ -223,7 +223,7 @@ describe('reactCompiler.reactServer option', () => {
       customExportsContext({es: ['index.js']}),
     )
     expect(Object.keys(result['.'])).toEqual(['@sanity/source', 'react-server', 'default'])
-    expect(result['.']).toMatchObject({'react-server': './dist/index.server.js'})
+    expect(result['.']).toMatchObject({'react-server': './dist/index.react-server.js'})
   })
 
   test('composes with a pre-existing `customExports`', async () => {
@@ -236,7 +236,7 @@ describe('reactCompiler.reactServer option', () => {
         customExportsContext({es: ['index.js']}),
       ),
     ).toEqual({
-      '.': {'react-server': './dist/index.server.js', 'default': './dist/index.js'},
+      '.': {'react-server': './dist/index.react-server.js', 'default': './dist/index.js'},
       // The record form applies first, like tsdown itself applies it - and `worker.js` names
       // no entry chunk, so it passes through untouched
       './worker.js': './dist/worker.js',
@@ -251,7 +251,7 @@ describe('reactCompiler.reactServer option', () => {
         customExportsContext({es: ['index.js']}),
       ),
     ).toEqual({
-      '.': {'react-server': './dist/index.server.js', 'default': './dist/index.js'},
+      '.': {'react-server': './dist/index.react-server.js', 'default': './dist/index.js'},
       './worker.js': './dist/worker.js',
     })
   })
@@ -261,7 +261,7 @@ describe('react-server-library', () => {
   test('applies the React Compiler only to the compiled output', async () => {
     const [distIndexJs, distIndexServerJs] = await Promise.all([
       readFile(path.join(fixtureDir, 'dist/index.js'), 'utf-8'),
-      readFile(path.join(fixtureDir, 'dist/index.server.js'), 'utf-8'),
+      readFile(path.join(fixtureDir, 'dist/index.react-server.js'), 'utf-8'),
     ])
 
     // The compiled output is auto-memoized with the memo cache provided by
@@ -286,7 +286,7 @@ describe('react-server-library', () => {
     // `publishConfig.exports` resolves `react-server` to the uncompiled build, everything
     // else to the compiled one
     expect(pkg.publishConfig.exports['.']).toEqual({
-      'react-server': './dist/index.server.js',
+      'react-server': './dist/index.react-server.js',
       'default': './dist/index.js',
     })
     expect(Object.keys(pkg.publishConfig.exports['.'])).toEqual(['react-server', 'default'])
@@ -303,7 +303,7 @@ describe('react-server-library', () => {
     // The compiled variant's declarations serve both entries - TypeScript resolves types
     // through the `default` condition
     await expect(
-      readFile(path.join(fixtureDir, 'dist/index.server.d.ts'), 'utf-8'),
+      readFile(path.join(fixtureDir, 'dist/index.react-server.d.ts'), 'utf-8'),
     ).rejects.toMatchObject({code: 'ENOENT'})
   })
 })

--- a/packages/@sanity/tsdown-config/test/react-server.test.ts
+++ b/packages/@sanity/tsdown-config/test/react-server.test.ts
@@ -1,0 +1,309 @@
+import {readFile} from 'node:fs/promises'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+import type {UserConfig} from 'tsdown'
+import {describe, expect, test} from 'vitest'
+import {defineConfig} from '../src/index.ts'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const fixtureDir = path.resolve(__dirname, 'fixtures/react-server-library')
+
+function getPluginNames(config: UserConfig) {
+  const {plugins} = config
+  if (!Array.isArray(plugins)) return undefined
+  return plugins.map((plugin) =>
+    plugin && typeof plugin === 'object' && 'name' in plugin ? plugin.name : undefined,
+  )
+}
+
+/** Resolves the compiled (`default`) and `react-server` variants of the dual build. */
+async function defineDualConfig(
+  options: Parameters<typeof defineConfig>[0] = {},
+): Promise<[compiled: UserConfig, reactServer: UserConfig]> {
+  const configs = await defineConfig({
+    ...options,
+    reactCompiler: {
+      ...(typeof options?.reactCompiler === 'object' ? options.reactCompiler : {}),
+      reactServer: true,
+    },
+  })
+  expect(configs).toHaveLength(2)
+  const [compiled, reactServer] = configs
+  if (!compiled || !reactServer) {
+    return expect.unreachable('expected the compiled and react-server variants')
+  }
+  return [compiled, reactServer]
+}
+
+type ExportsOptionsObject = Extract<NonNullable<UserConfig['exports']>, object>
+type CustomExportsFunction = Extract<
+  NonNullable<ExportsOptionsObject['customExports']>,
+  (...args: never[]) => unknown
+>
+type CustomExportsContext = Parameters<CustomExportsFunction>[1]
+
+/** Resolves the `customExports` function the config composed into the `exports` option. */
+function getCustomExports(config: UserConfig): CustomExportsFunction {
+  const exportsOption = config.exports
+  if (typeof exportsOption !== 'object' || typeof exportsOption?.customExports !== 'function') {
+    return expect.unreachable('expected `exports.customExports` to be a function')
+  }
+  return exportsOption.customExports as CustomExportsFunction
+}
+
+/** Builds the `customExports` context with entry chunks shaped like the compiled build's. */
+function customExportsContext(
+  entryFileNames: Partial<Record<'es' | 'cjs', string[]>>,
+  isPublish = true,
+): CustomExportsContext {
+  const chunks = Object.fromEntries(
+    Object.entries(entryFileNames).map(([format, fileNames]) => [
+      format,
+      fileNames.map((fileName) => ({type: 'chunk', isEntry: true, fileName, outDir: 'dist'})),
+    ]),
+  )
+  return {
+    pkg: {packageJsonPath: 'package.json'},
+    chunks,
+    isPublish,
+  } as unknown as CustomExportsContext
+}
+
+function outExtension(config: UserConfig, format: 'es' | 'cjs', pkgType?: 'module' | 'commonjs') {
+  const {outExtensions} = config
+  if (typeof outExtensions !== 'function') {
+    return expect.unreachable('expected `outExtensions` to be a function')
+  }
+  return outExtensions({format, pkgType, options: {}} as unknown as Parameters<
+    NonNullable<UserConfig['outExtensions']>
+  >[0])
+}
+
+describe('reactCompiler.reactServer option', () => {
+  test('stays a single build without it', async () => {
+    for (const config of [
+      await defineConfig({reactCompiler: true}),
+      await defineConfig({reactCompiler: {target: '19'}}),
+      await defineConfig({reactCompiler: {target: '19', reactServer: false}}),
+    ]) {
+      expect(Array.isArray(config)).toBe(false)
+      expect(getPluginNames(config)).toEqual(['@rolldown/plugin-babel'])
+      expect(config.exports).not.toHaveProperty('customExports')
+      expect(config.outExtensions).toBeUndefined()
+    }
+  })
+
+  test('resolves the compiled and react-server variants', async () => {
+    const [compiled, reactServer] = await defineDualConfig({reactCompiler: {target: '19'}})
+
+    // The compiled variant is the classic single build: the React Compiler applied, and it
+    // owns `dts`, `exports` generation and `publint`
+    expect(getPluginNames(compiled)).toEqual(['@rolldown/plugin-babel'])
+    expect(compiled.publint).toBe(true)
+    expect(compiled.exports).toMatchObject({enabled: 'local-only'})
+
+    // The react-server variant builds the same source without the compiler, skips d.ts (the
+    // compiled variant's declarations serve both entries), never cleans (the compiled
+    // variant's `clean` covers the run - tsdown cleans once, before either variant emits),
+    // and stays out of `exports` generation and `publint`
+    expect(getPluginNames(reactServer)).toEqual([])
+    expect(reactServer.dts).toBe(false)
+    expect(reactServer.clean).toBe(false)
+    expect(reactServer.exports).toBe(false)
+    expect(reactServer.publint).toBe(false)
+  })
+
+  test('react-server entries sit next to the compiled ones with `.server` inserted', async () => {
+    const [compiled, reactServer] = await defineDualConfig()
+
+    // tsdown's default extension for the format/package type, with `.server` inserted
+    expect(outExtension(reactServer, 'es', 'module')).toEqual({js: '.server.js'})
+    expect(outExtension(reactServer, 'cjs', 'module')).toEqual({js: '.server.cjs'})
+    expect(outExtension(reactServer, 'es', 'commonjs')).toEqual({js: '.server.mjs'})
+    expect(outExtension(reactServer, 'cjs', 'commonjs')).toEqual({js: '.server.js'})
+
+    // The compiled variant keeps tsdown's default naming
+    expect(compiled.outExtensions).toBeUndefined()
+  })
+
+  test('inserts the react-server condition into entry exports', async () => {
+    const [compiled] = await defineDualConfig()
+    const customExports = getCustomExports(compiled)
+
+    // The pure-ESM publish shape: a bare-string entry export becomes a conditional export
+    // with `react-server` resolving before `default`
+    const result = await customExports(
+      {'.': './dist/index.js', './package.json': './package.json'},
+      customExportsContext({es: ['index.js']}),
+    )
+    expect(result).toEqual({
+      '.': {'react-server': './dist/index.server.js', 'default': './dist/index.js'},
+      './package.json': './package.json',
+    })
+    expect(Object.keys(result['.'])).toEqual(['react-server', 'default'])
+  })
+
+  test('nests import/require under react-server for dual-format entries', async () => {
+    const [compiled] = await defineDualConfig()
+    const customExports = getCustomExports(compiled)
+
+    const result = await customExports(
+      {
+        '.': {
+          types: './dist/index.d.ts',
+          import: './dist/index.js',
+          require: './dist/index.cjs',
+        },
+      },
+      customExportsContext({es: ['index.js'], cjs: ['index.cjs']}),
+    )
+    expect(result['.']).toEqual({
+      'types': './dist/index.d.ts',
+      'react-server': {
+        import: './dist/index.server.js',
+        require: './dist/index.server.cjs',
+      },
+      'import': './dist/index.js',
+      'require': './dist/index.cjs',
+    })
+    // Conditions match in order: `types` stays first, `react-server` comes right before the
+    // runtime conditions
+    expect(Object.keys(result['.'])).toEqual(['types', 'react-server', 'import', 'require'])
+  })
+
+  test('covers every entry, and leaves non-entry exports untouched', async () => {
+    const [compiled] = await defineDualConfig()
+    const customExports = getCustomExports(compiled)
+
+    const conditionalCssExport = {
+      types: './dist/bundle-css.d.ts',
+      browser: './dist/bundle.css',
+      style: './dist/bundle.css',
+      node: './dist/bundle-css.js',
+      default: './dist/bundle-css.js',
+    }
+    const result = await customExports(
+      {
+        '.': './dist/index.js',
+        './theme': './dist/theme.js',
+        './bundle.css': conditionalCssExport,
+        './package.json': './package.json',
+      },
+      customExportsContext({es: ['index.js', 'theme.js']}),
+    )
+    expect(result).toEqual({
+      '.': {'react-server': './dist/index.server.js', 'default': './dist/index.js'},
+      './theme': {'react-server': './dist/theme.server.js', 'default': './dist/theme.js'},
+      // The conditional CSS export of `vanillaExtract` names no entry chunks - untouched
+      './bundle.css': conditionalCssExport,
+      './package.json': './package.json',
+    })
+  })
+
+  test('leaves the `devExports` source map untouched', async () => {
+    const [compiled] = await defineDualConfig()
+    const customExports = getCustomExports(compiled)
+
+    // With `devExports: true` the local `exports` map points at source files: source resolves
+    // for every condition in development, which is correct - uncompiled source is exactly
+    // what the `react-server` condition ships
+    const result = await customExports(
+      {'.': './src/index.ts', './package.json': './package.json'},
+      customExportsContext({es: ['index.js']}, false),
+    )
+    expect(result).toEqual({'.': './src/index.ts', './package.json': './package.json'})
+  })
+
+  test('keeps a custom development condition ahead of react-server', async () => {
+    const [compiled] = await defineDualConfig({exports: {devExports: '@sanity/source'}})
+    const customExports = getCustomExports(compiled)
+
+    const result = await customExports(
+      {'.': {'@sanity/source': './src/index.ts', 'default': './dist/index.js'}},
+      customExportsContext({es: ['index.js']}),
+    )
+    expect(Object.keys(result['.'])).toEqual(['@sanity/source', 'react-server', 'default'])
+    expect(result['.']).toMatchObject({'react-server': './dist/index.server.js'})
+  })
+
+  test('composes with a pre-existing `customExports`', async () => {
+    const [withRecord] = await defineDualConfig({
+      exports: {customExports: {'./worker.js': './dist/worker.js'}},
+    })
+    expect(
+      await getCustomExports(withRecord)(
+        {'.': './dist/index.js'},
+        customExportsContext({es: ['index.js']}),
+      ),
+    ).toEqual({
+      '.': {'react-server': './dist/index.server.js', 'default': './dist/index.js'},
+      // The record form applies first, like tsdown itself applies it - and `worker.js` names
+      // no entry chunk, so it passes through untouched
+      './worker.js': './dist/worker.js',
+    })
+
+    const [withFunction] = await defineDualConfig({
+      exports: {customExports: (exports) => ({...exports, './worker.js': './dist/worker.js'})},
+    })
+    expect(
+      await getCustomExports(withFunction)(
+        {'.': './dist/index.js'},
+        customExportsContext({es: ['index.js']}),
+      ),
+    ).toEqual({
+      '.': {'react-server': './dist/index.server.js', 'default': './dist/index.js'},
+      './worker.js': './dist/worker.js',
+    })
+  })
+})
+
+describe('react-server-library', () => {
+  test('applies the React Compiler only to the compiled output', async () => {
+    const [distIndexJs, distIndexServerJs] = await Promise.all([
+      readFile(path.join(fixtureDir, 'dist/index.js'), 'utf-8'),
+      readFile(path.join(fixtureDir, 'dist/index.server.js'), 'utf-8'),
+    ])
+
+    // The compiled output is auto-memoized with the memo cache provided by
+    // `react/compiler-runtime` (the fixture sets `reactCompiler: {target: '19'}`)
+    expect(distIndexJs).toContain('react/compiler-runtime')
+
+    // The react-server output is the same source without the compiler: no
+    // `react/compiler-runtime` (it throws in the `react-server` environment), and - the
+    // source has no manual memoization - no `useMemo`/`useCallback` calls either
+    expect(distIndexServerJs).not.toContain('react/compiler-runtime')
+    expect(distIndexServerJs).not.toContain('useMemo(')
+    expect(distIndexServerJs).not.toContain('useCallback(')
+  })
+
+  test('wires the react-server export condition', async () => {
+    const pkg = JSON.parse(await readFile(path.join(fixtureDir, 'package.json'), 'utf-8'))
+
+    // The local `exports` map keeps pointing at the source (`devExports`), which resolves
+    // for every condition in development
+    expect(pkg.exports['.']).toBe('./src/index.ts')
+
+    // `publishConfig.exports` resolves `react-server` to the uncompiled build, everything
+    // else to the compiled one
+    expect(pkg.publishConfig.exports['.']).toEqual({
+      'react-server': './dist/index.server.js',
+      'default': './dist/index.js',
+    })
+    expect(Object.keys(pkg.publishConfig.exports['.'])).toEqual(['react-server', 'default'])
+
+    // The react-server files never become export subpaths of their own
+    expect(Object.keys(pkg.exports)).toEqual(['.', './package.json'])
+    expect(Object.keys(pkg.publishConfig.exports)).toEqual(['.', './package.json'])
+  })
+
+  test('only the compiled variant emits type declarations', async () => {
+    const distIndexDts = await readFile(path.join(fixtureDir, 'dist/index.d.ts'), 'utf-8')
+    expect(distIndexDts).toContain('PortableText')
+
+    // The compiled variant's declarations serve both entries - TypeScript resolves types
+    // through the `default` condition
+    await expect(
+      readFile(path.join(fixtureDir, 'dist/index.server.d.ts'), 'utf-8'),
+    ).rejects.toMatchObject({code: 'ENOENT'})
+  })
+})

--- a/packages/@sanity/tsdown-config/test/react-server.test.ts
+++ b/packages/@sanity/tsdown-config/test/react-server.test.ts
@@ -149,6 +149,37 @@ describe('reactCompiler.reactServer option', () => {
     expect(Object.keys(result['.'])).toEqual(['types', 'react-server', 'default'])
   })
 
+  test('matches entry exports exactly, never by leaf name', async () => {
+    const [compiled] = await defineDualConfig()
+    const customExports = getCustomExports(compiled)
+
+    // `index.js` and `features/index.js` share a leaf name: export targets are compared as
+    // full `./<outDir>/<fileName>` strings, so the declaration existence check runs against
+    // each entry's own `.d.ts` (only the root entry has one here - no `types` condition is
+    // invented for `./features`), and a non-entry file that merely ends in an entry's
+    // filename passes through untouched
+    const result = await customExports(
+      {
+        '.': './dist/index.js',
+        './features': './dist/features/index.js',
+        './not-an-entry': './dist/vendored/index.js',
+      },
+      customExportsContext({es: ['index.js', 'features/index.js', 'index.d.ts']}),
+    )
+    expect(result).toEqual({
+      '.': {
+        'types': './dist/index.d.ts',
+        'react-server': './dist/index.react-server.js',
+        'default': './dist/index.js',
+      },
+      './features': {
+        'react-server': './dist/features/index.react-server.js',
+        'default': './dist/features/index.js',
+      },
+      './not-an-entry': './dist/vendored/index.js',
+    })
+  })
+
   test('omits the types condition when no declarations are emitted', async () => {
     const [compiled] = await defineDualConfig()
     const customExports = getCustomExports(compiled)

--- a/packages/@sanity/tsdown-config/test/react-server.test.ts
+++ b/packages/@sanity/tsdown-config/test/react-server.test.ts
@@ -131,16 +131,37 @@ describe('reactCompiler.reactServer option', () => {
     const customExports = getCustomExports(compiled)
 
     // The pure-ESM publish shape: a bare-string entry export becomes a conditional export
-    // with `react-server` resolving before `default`
+    // with `types` specified before `react-server` (the `.react-server.` file has no
+    // declaration sibling - the compiled build's declarations serve every resolution mode),
+    // and `react-server` resolving before `default`
     const result = await customExports(
       {'.': './dist/index.js', './package.json': './package.json'},
+      customExportsContext({es: ['index.js', 'index.d.ts']}),
+    )
+    expect(result).toEqual({
+      '.': {
+        'types': './dist/index.d.ts',
+        'react-server': './dist/index.react-server.js',
+        'default': './dist/index.js',
+      },
+      './package.json': './package.json',
+    })
+    expect(Object.keys(result['.'])).toEqual(['types', 'react-server', 'default'])
+  })
+
+  test('omits the types condition when no declarations are emitted', async () => {
+    const [compiled] = await defineDualConfig()
+    const customExports = getCustomExports(compiled)
+
+    // Without declaration chunks (`dts: false` packages) there is no `types` file to point
+    // at, and the entry keeps the plain dual shape
+    const result = await customExports(
+      {'.': './dist/index.js'},
       customExportsContext({es: ['index.js']}),
     )
     expect(result).toEqual({
       '.': {'react-server': './dist/index.react-server.js', 'default': './dist/index.js'},
-      './package.json': './package.json',
     })
-    expect(Object.keys(result['.'])).toEqual(['react-server', 'default'])
   })
 
   test('nests import/require under react-server for dual-format entries', async () => {
@@ -166,9 +187,35 @@ describe('reactCompiler.reactServer option', () => {
       'import': './dist/index.js',
       'require': './dist/index.cjs',
     })
-    // Conditions match in order: `types` stays first, `react-server` comes right before the
-    // runtime conditions
+    // Conditions match in order: an already-present `types` stays first (and is left alone),
+    // `react-server` comes right before the runtime conditions
     expect(Object.keys(result['.'])).toEqual(['types', 'react-server', 'import', 'require'])
+  })
+
+  test('nests format-matched types under react-server for dual-format entries', async () => {
+    const [compiled] = await defineDualConfig()
+    const customExports = getCustomExports(compiled)
+
+    // Without a top-level `types` condition, dual-format entries rely on TypeScript's
+    // adjacent-file lookup (`index.js` ↔ `index.d.ts`, `index.cjs` ↔ `index.d.cts`) - which
+    // cannot work for the declaration-less `.react-server.` files. A single top-level
+    // `types` file can't serve both resolution modes either, so each format nests its own
+    // `types` under the `react-server` condition instead
+    const result = await customExports(
+      {'.': {import: './dist/index.js', require: './dist/index.cjs'}},
+      customExportsContext({
+        es: ['index.js', 'index.d.ts'],
+        cjs: ['index.cjs', 'index.d.cts'],
+      }),
+    )
+    expect(result['.']).toEqual({
+      'react-server': {
+        import: {types: './dist/index.d.ts', default: './dist/index.react-server.js'},
+        require: {types: './dist/index.d.cts', default: './dist/index.react-server.cjs'},
+      },
+      'import': './dist/index.js',
+      'require': './dist/index.cjs',
+    })
   })
 
   test('covers every entry, and leaves non-entry exports untouched', async () => {
@@ -284,12 +331,18 @@ describe('react-server-library', () => {
     expect(pkg.exports['.']).toBe('./src/index.ts')
 
     // `publishConfig.exports` resolves `react-server` to the uncompiled build, everything
-    // else to the compiled one
+    // else to the compiled one - with `types` specified before `react-server`, since the
+    // `.react-server.` file has no declaration sibling for adjacent-file lookup
     expect(pkg.publishConfig.exports['.']).toEqual({
+      'types': './dist/index.d.ts',
       'react-server': './dist/index.react-server.js',
       'default': './dist/index.js',
     })
-    expect(Object.keys(pkg.publishConfig.exports['.'])).toEqual(['react-server', 'default'])
+    expect(Object.keys(pkg.publishConfig.exports['.'])).toEqual([
+      'types',
+      'react-server',
+      'default',
+    ])
 
     // The react-server files never become export subpaths of their own
     expect(Object.keys(pkg.exports)).toEqual(['.', './package.json'])

--- a/packages/@sanity/tsdown-config/test/react-server.test.ts
+++ b/packages/@sanity/tsdown-config/test/react-server.test.ts
@@ -2,8 +2,8 @@ import {readFile} from 'node:fs/promises'
 import path from 'node:path'
 import {fileURLToPath} from 'node:url'
 import type {UserConfig} from 'tsdown'
-import {describe, expect, test} from 'vitest'
-import {defineConfig} from '../src/index.ts'
+import {describe, expect, expectTypeOf, test} from 'vitest'
+import {defineConfig, type ReactCompilerOptions} from '../src/index.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const fixtureDir = path.resolve(__dirname, 'fixtures/react-server-library')
@@ -91,6 +91,31 @@ describe('reactCompiler.reactServer option', () => {
       expect(config.exports).not.toHaveProperty('customExports')
       expect(config.outExtensions).toBeUndefined()
     }
+  })
+
+  test('narrows the return type per overload', async () => {
+    // Literal `reactServer: true` resolves to the two variants
+    const dual = defineConfig({reactCompiler: {target: '19', reactServer: true}})
+    expectTypeOf(dual).toEqualTypeOf<Promise<UserConfig[]>>()
+
+    // Without `reactServer` (or with a literal `false`) the config stays a single build
+    expectTypeOf(defineConfig()).toEqualTypeOf<Promise<UserConfig>>()
+    expectTypeOf(defineConfig({reactCompiler: true})).toEqualTypeOf<Promise<UserConfig>>()
+    const single = defineConfig({reactCompiler: {target: '19'}})
+    expectTypeOf(single).toEqualTypeOf<Promise<UserConfig>>()
+    const explicitlyOff = defineConfig({reactCompiler: {target: '19', reactServer: false}})
+    expectTypeOf(explicitlyOff).toEqualTypeOf<Promise<UserConfig>>()
+
+    // When `reactServer` is widened to `boolean` (e.g. a `ReactCompilerOptions`-typed
+    // variable), TypeScript can't tell which shape resolves - the return type is the union,
+    // so callers have to check `Array.isArray` instead of wrongly assuming a single config
+    const widenedOptions: ReactCompilerOptions = {target: '19', reactServer: true}
+    const widened = defineConfig({reactCompiler: widenedOptions})
+    expectTypeOf(widened).toEqualTypeOf<Promise<UserConfig | UserConfig[]>>()
+
+    // ...and at runtime the widened call indeed resolves to the dual build
+    expect(await widened).toHaveLength(2)
+    await Promise.all([dual, single, explicitlyOff])
   })
 
   test('resolves the compiled and react-server variants', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,7 +310,7 @@ importers:
         version: link:../sanity-css-vanilla-extract-test
       tap:
         specifier: ^21.7.4
-        version: 21.7.4(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+        version: 21.7.4(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -955,6 +955,18 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.8(react@19.2.8)
+
+  packages/@sanity/tsdown-config/test/fixtures/react-server-library:
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
+      react:
+        specifier: ^19.2.7
+        version: 19.2.8
 
   packages/@sanity/tsdown-config/test/fixtures/styled-components-library:
     devDependencies:
@@ -17423,14 +17435,14 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@5.9.3)':
+  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@5.9.3)':
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node14': 14.1.8
       '@tsconfig/node16': 16.1.8
       '@tsconfig/node18': 18.2.6
       '@tsconfig/node20': 20.1.9
-      '@types/node': 24.13.3
+      '@types/node': 26.1.1
       acorn: 8.17.0
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -17441,14 +17453,14 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.46(@swc/helpers@0.5.23)
 
-  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@6.0.3)':
+  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@6.0.3)':
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node14': 14.1.8
       '@tsconfig/node16': 16.1.8
       '@tsconfig/node18': 18.2.6
       '@tsconfig/node20': 20.1.9
-      '@types/node': 24.13.3
+      '@types/node': 26.1.1
       acorn: 8.17.0
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -22287,19 +22299,19 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.162.0': {}
 
-  '@tapjs/after-each@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/after-each@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       function-loop: 4.0.0
 
-  '@tapjs/after@3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/after@3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       is-actual-promise: 1.0.2
 
-  '@tapjs/asserts@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tapjs/asserts@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tapjs/stack': 4.3.3
       is-actual-promise: 1.0.2
       tcompare: 9.3.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -22308,35 +22320,35 @@ snapshots:
       - react
       - react-dom
 
-  '@tapjs/before-each@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/before-each@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       function-loop: 4.0.0
 
-  '@tapjs/before@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/before@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       is-actual-promise: 1.0.2
 
-  '@tapjs/chdir@3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/chdir@3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
-  '@tapjs/config@5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/config@5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/test': 4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/test': 4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       chalk: 5.6.2
       jackspeak: 4.2.3
       polite-json: 5.0.0
       tap-yaml: 4.4.2
       walk-up-path: 4.0.0
 
-  '@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tapjs/processinfo': 3.1.12
       '@tapjs/stack': 4.3.3
-      '@tapjs/test': 4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/test': 4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       async-hook-domain: 4.0.1
       diff: 8.0.4
       is-actual-promise: 1.0.2
@@ -22357,33 +22369,33 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@tapjs/filter@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/filter@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
-  '@tapjs/fixture@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/fixture@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       mkdirp: 3.0.1
       rimraf: 6.1.3
 
-  '@tapjs/intercept@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/intercept@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tapjs/stack': 4.3.3
 
-  '@tapjs/mock@4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/mock@4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tapjs/stack': 4.3.3
       resolve-import: 2.4.0
       walk-up-path: 4.0.0
 
-  '@tapjs/node-serialize@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/node-serialize@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tapjs/error-serdes': 4.3.2
       '@tapjs/stack': 4.3.3
       tap-parser: 18.3.4
@@ -22396,10 +22408,10 @@ snapshots:
       signal-exit: 4.1.0
       uuid: 14.0.1
 
-  '@tapjs/reporter@4.4.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))':
+  '@tapjs/reporter@4.4.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))':
     dependencies:
-      '@tapjs/config': 5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/config': 5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tapjs/stack': 4.3.3
       chalk: 5.6.2
       ink: 5.2.1(@types/react@19.2.17)(react@18.3.1)
@@ -22420,18 +22432,18 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  '@tapjs/run@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tapjs/run@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.1.1)(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@isaacs/which': 7.0.4
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/config': 5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/config': 5.6.4(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tapjs/processinfo': 3.1.12
-      '@tapjs/reporter': 4.4.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))
-      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/test': 4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/reporter': 4.4.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))
+      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/test': 4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       c8: 10.1.3
       chalk: 5.6.2
       chokidar: 4.0.3
@@ -22464,9 +22476,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@tapjs/snapshot@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tapjs/snapshot@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       is-actual-promise: 1.0.2
       tcompare: 9.3.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       trivial-deferred: 2.0.0
@@ -22474,36 +22486,36 @@ snapshots:
       - react
       - react-dom
 
-  '@tapjs/spawn@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/spawn@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   '@tapjs/stack@4.3.3': {}
 
-  '@tapjs/stdin@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/stdin@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
-  '@tapjs/test@4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tapjs/test@4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@5.9.3)
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/after-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/asserts': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/before-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/chdir': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/filter': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/fixture': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/intercept': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/mock': 4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/node-serialize': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/snapshot': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/typescript': 3.5.10(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(typescript@5.9.3)
-      '@tapjs/worker': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@5.9.3)
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/after-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/asserts': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/before-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/chdir': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/filter': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/fixture': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/intercept': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/mock': 4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/node-serialize': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/snapshot': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/typescript': 3.5.10(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.1.1)(typescript@5.9.3)
+      '@tapjs/worker': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       glob: 13.0.6
       jackspeak: 4.2.3
       mkdirp: 3.0.1
@@ -22522,29 +22534,29 @@ snapshots:
       - react
       - react-dom
 
-  '@tapjs/typescript@3.5.10(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(typescript@5.9.3)':
+  '@tapjs/typescript@3.5.10(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.1.1)(typescript@5.9.3)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@5.9.3)
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@5.9.3)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
       - typescript
 
-  '@tapjs/typescript@3.5.10(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(typescript@6.0.3)':
+  '@tapjs/typescript@3.5.10(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.1.1)(typescript@6.0.3)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@6.0.3)
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@6.0.3)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
       - typescript
 
-  '@tapjs/worker@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/worker@4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   '@tsconfig/node14@14.1.8': {}
 
@@ -29970,27 +29982,27 @@ snapshots:
       yaml: 2.9.0
       yaml-types: 0.4.0(yaml@2.9.0)
 
-  tap@21.7.4(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3):
+  tap@21.7.4(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3):
     dependencies:
-      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/after-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/asserts': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/before-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/chdir': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/filter': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/fixture': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/intercept': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/mock': 4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/node-serialize': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/run': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/snapshot': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/test': 4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/typescript': 3.5.10(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(typescript@6.0.3)
-      '@tapjs/worker': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/after': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/after-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/asserts': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/before': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/before-each': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/chdir': 3.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/core': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/filter': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/fixture': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/intercept': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/mock': 4.4.8(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/node-serialize': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/run': 4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.1.1)(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/snapshot': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/spawn': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/stdin': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/test': 4.4.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/typescript': 3.5.10(@swc/core@1.15.46(@swc/helpers@0.5.23))(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.1.1)(typescript@6.0.3)
+      '@tapjs/worker': 4.3.10(@tapjs/core@4.5.8(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       resolve-import: 2.4.0
     transitivePeerDependencies:
       - '@swc/core'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

React Server Components refuse to load React Compiler output — `react/compiler-runtime` throws in the `react-server` environment, and the React team's guidance for libraries that ship compiled code is to [publish two entrypoints](https://github.com/facebook/react/issues/31702): compiled for the client, uncompiled under the `react-server` export condition.

This adds `reactServer: true` to the `reactCompiler` options of `@sanity/tsdown-config` (marked `@alpha`: experimental, not covered by semver, and may change behavior or be removed in a minor version):

```ts
export default defineConfig({
  tsconfig: 'tsconfig.dist.json',
  reactCompiler: {target: '19', reactServer: true},
})
```

Every entry is built twice from the same source, and **the only difference is that React Compiler auto-memoization is applied to the non-`react-server` output** — nothing is stripped from either output. The uncompiled build lands next to the compiled one with an explicit `.react-server` infix (`dist/index.js` ↔ `dist/index.react-server.js`, so the mapping stays obvious with multiple export paths; hashed chunks get the infix too so the variants never collide), only the compiled variant emits `.d.ts`, and when the `exports` feature is enabled every entry export gains a `react-server` condition with `types` specified before it:

```json
".": {
  "types": "./dist/index.d.ts",
  "react-server": "./dist/index.react-server.js",
  "default": "./dist/index.js"
}
```

### Implementation notes

- `defineConfig` returns `Promise<UserConfig[]>` (via an overload — the plain signature is unchanged) only when `reactCompiler.reactServer` is set; tsdown builds both configs in one run, cleans the shared `outDir` once before either variant emits, and runs `exports` generation + `publint` per `package.json` only after every build for it finished, so the `.react-server.` files exist by the time they're validated.
- The `react-server` variant builds with `dts: false`, `exports: false`, `publint: false`, `clean: false`, no babel/compiler plugin, and an `outExtensions` that mirrors tsdown's default extension with `.react-server` inserted.
- The `react-server` conditions are composed into `exports.customExports` (the same composition pattern as `@sanity/vanilla-extract-tsdown-plugin`), matching entry chunk filenames so `devExports` source maps, `./package.json`, and the conditional `./bundle.css` export pass through untouched, and `.react-server.` files never become export subpaths of their own.
- The `.react-server.` files have no declaration siblings for TypeScript's adjacent-file lookup, so a `types` condition pointing at the compiled variant's declarations is specified before `react-server` (only when the declarations exist among the compiled chunks; an already-present `types` is left in place). Dual-format entries instead nest a format-matched `types` under each of the `react-server` condition's `import`/`require` targets, since a single top-level `types` file cannot serve both resolution modes.
- `reactServer` is an option of this config and is never forwarded to `babel-plugin-react-compiler`.

Pair it with deleting manual `useMemo`/`useCallback` calls from the library source (the `@portabletext/react` follow-up): server components stop paying for memoization that cannot pay off (they render exactly once), and client components get the compiler's finer-grained auto-memoization instead.

### Testing

- New `react-server-library` fixture (a `@portabletext/react`-shaped renderer with no manual memoization) builds through the real tsdown pipeline in the vitest global setup: `dist/index.js` contains `react/compiler-runtime`, `dist/index.react-server.js` contains neither the compiler runtime nor any `useMemo(`/`useCallback(` calls, `publishConfig.exports["."]` resolves `types` → `react-server` → `default` in that order, and only the compiled variant emits declarations.
- Unit tests cover the variant configs (plugins, `dts`/`exports`/`publint`/`clean` flags), the `.react-server` extension mapping per format/package type, and the `customExports` composition (pure-ESM strings with and without declarations, dual-format nesting with format-matched `types`, multi-entry, `devExports` source maps, custom dev conditions, pre-existing `customExports`).
- TypeScript resolution proof with `customConditions: ["react-server"]` (`tsc --traceResolution` against the packed tarball): before the `types` condition, TS resolved declarations only via failed-branch fallback (`Failed to resolve under condition 'react-server'` → `default`); after, `Matched 'exports' condition 'types'` resolves `./dist/index.d.ts` directly.
- Runtime demo against the packed tarball (`pnpm pack` applies `publishConfig`, installed into a scratch consumer with `react@19.2.7`): default conditions resolve `dist/index.js` and SSR through `react-dom/server` renders the compiled component; `node --conditions react-server` resolves `dist/index.react-server.js` and RSC-style plain function calls render fine; loading the compiled file under `react-server` conditions crashes with the exact `TypeError: Cannot read properties of undefined (reading 'H')` from facebook/react#31702; and `./dist/*` subpaths are rejected by the exports map. Full transcript: [react-server types condition demo transcript](https://cursor.com/agents/bc-68be269c-d57f-4a3f-bde6-1b12015b7694/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freact_server_types_condition_demo.txt)
- `pnpm vitest run --project @sanity/tsdown-config`: 90/90 passing. Root `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm knip` (the 3 expected unused-catalog warnings, exit 0), and full `pnpm test` (35 files, 404 tests, no type errors) all pass.
- The `pnpm-lock.yaml` diff includes a `@types/node@24.13.3 → 26.1.1` peer re-resolution in the `tap` dependency tree — a fresh `pnpm install` converges on it deterministically once the new fixture importer exists (dev-only, css-playground's `tap`).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68be269c-d57f-4a3f-bde6-1b12015b7694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68be269c-d57f-4a3f-bde6-1b12015b7694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

