### PR TITLE
chore: minimumReleaseAge to pnpm v11 default, exact-version exemptions only

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,68 +19,58 @@ catalog:
 
 minimumReleaseAge: 4320
 
+# Exact-version exemptions for currently locked versions that are younger than the release-age
+# gate. Each entry stops being needed (and can be removed) once the version is older than
+# minimumReleaseAge; new entries are only needed when a dependency bump wants a fresh release.
 minimumReleaseAgeExclude:
-  - '@changesets/*'
-  - '@microsoft/api-extractor'
-  - '@next/*'
-  - '@oxlint/*'
-  - '@oxlint-tsgolint/*'
-  - '@portabletext/*'
-  - '@rollup/*'
-  - '@tanstack/*'
-  - '@sanity/*'
-  - '@types/*'
-  - '@typescript/*'
-  - '@vite/*'
-  - '@vitejs/*'
-  - '@vitest/*'
-  - '@yuku-codegen/*'
-  - '@yuku-parser/*'
-  - csstype
-  - groq
-  - groq-js
-  - next
-  - oxlint
-  - oxlint-tsgolint
-  - react
-  - react-dom
-  - react-is
-  - rollup
-  - sanity
-  - lightningcss
-  - lightningcss-*
-  - vite
-  - vitest
-  - ts-jest
-  - browserslist
-  - baseline-browser-mapping
-  # Dev-only framework deps used exclusively by the css-playground smoke tests. These are not
-  # shipped, so the supply-chain release-age delay does not apply; pin the latest to keep the
-  # cross-framework matrix building against current releases.
-  - '@astrojs/react'
-  - astro
-  # TypeScript 7 (the Go-native compiler) and related toolchain releases that need to be
-  # consumed immediately, including the yuku AST toolchain used by rolldown-plugin-dts
-  # and the oxc types shipped with each rolldown release.
-  - typescript
-  - tsdown
-  - '@tsdown/*'
-  - rolldown
-  - '@rolldown/*'
-  - '@oxc-project/*'
-  - rolldown-plugin-dts
-  - yuku-ast
-  - yuku-parser
-  - yuku-codegen
-  - '@yuku-toolchain/types'
-  - obug
-  # Vanilla Extract plugins and integration packages tracked by the Sanity
-  # vanilla-extract-* packages and their benchmarks; bump immediately so the
-  # comparison suite and plugin peers stay on current releases.
-  - '@vanilla-extract/*'
-  - verkit
-  - publint
-  - '@publint/*'
+  - '@next/env@16.2.11'
+  - '@next/swc-darwin-arm64@16.2.11'
+  - '@next/swc-darwin-x64@16.2.11'
+  - '@next/swc-linux-arm64-gnu@16.2.11'
+  - '@next/swc-linux-arm64-musl@16.2.11'
+  - '@next/swc-linux-x64-gnu@16.2.11'
+  - '@next/swc-linux-x64-musl@16.2.11'
+  - '@next/swc-win32-arm64-msvc@16.2.11'
+  - '@next/swc-win32-x64-msvc@16.2.11'
+  - '@oxlint-tsgolint/darwin-arm64@7.0.2001'
+  - '@oxlint-tsgolint/darwin-x64@7.0.2001'
+  - '@oxlint-tsgolint/linux-arm64@7.0.2001'
+  - '@oxlint-tsgolint/linux-x64@7.0.2001'
+  - '@oxlint-tsgolint/win32-arm64@7.0.2001'
+  - '@oxlint-tsgolint/win32-x64@7.0.2001'
+  - '@portabletext/sanity-bridge@3.2.3'
+  - '@publint/pack@0.1.6'
+  - '@sanity/color@3.0.7'
+  - '@sanity/icons@5.2.1'
+  - '@sanity/logos@2.2.4'
+  - '@sanity/ui@3.4.3'
+  - '@tsdown/css@0.22.13'
+  - '@vitejs/plugin-react@6.0.4'
+  - '@yuku-parser/binding-darwin-arm64@0.8.0'
+  - '@yuku-parser/binding-darwin-x64@0.8.0'
+  - '@yuku-parser/binding-freebsd-x64@0.8.0'
+  - '@yuku-parser/binding-linux-arm-gnu@0.8.0'
+  - '@yuku-parser/binding-linux-arm-musl@0.8.0'
+  - '@yuku-parser/binding-linux-arm64-gnu@0.8.0'
+  - '@yuku-parser/binding-linux-arm64-musl@0.8.0'
+  - '@yuku-parser/binding-linux-x64-gnu@0.8.0'
+  - '@yuku-parser/binding-linux-x64-musl@0.8.0'
+  - '@yuku-parser/binding-win32-arm64@0.8.0'
+  - '@yuku-parser/binding-win32-x64@0.8.0'
+  - '@yuku-toolchain/types@0.8.0'
+  - baseline-browser-mapping@2.11.1
+  - browserslist@4.28.7
+  - next@16.2.11
+  - oxlint-tsgolint@7.0.2001
+  - publint@0.3.22
+  - react@19.2.8
+  - react-dom@19.2.8
+  - react-is@19.2.8
+  - rolldown-plugin-dts@0.27.13
+  - ts-jest@29.4.12
+  - tsdown@0.22.13
+  - yuku-ast@0.8.0
+  - yuku-parser@0.8.0
 
 overrides:
   '@sanity/pkg-utils': workspace:*

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,35 +17,14 @@ catalog:
   typescript: 7.0.2
   vitest: ^4.1.10
 
-minimumReleaseAge: 4320
+# The pnpm v11 default (1 day)
+minimumReleaseAge: 1440
 
-# Exact-version exemptions for currently locked versions that are younger than the release-age
-# gate. Each entry stops being needed (and can be removed) once the version is older than
-# minimumReleaseAge; new entries are only needed when a dependency bump wants a fresh release.
+# Exact-version exemptions for the locked versions that pnpm otherwise rejects against the
+# release-age gate during resolution. Each entry expires naturally (and can be removed) once
+# the version is older than minimumReleaseAge; add new ones only when a dependency bump needs
+# a release fresher than the gate.
 minimumReleaseAgeExclude:
-  - '@next/env@16.2.11'
-  - '@next/swc-darwin-arm64@16.2.11'
-  - '@next/swc-darwin-x64@16.2.11'
-  - '@next/swc-linux-arm64-gnu@16.2.11'
-  - '@next/swc-linux-arm64-musl@16.2.11'
-  - '@next/swc-linux-x64-gnu@16.2.11'
-  - '@next/swc-linux-x64-musl@16.2.11'
-  - '@next/swc-win32-arm64-msvc@16.2.11'
-  - '@next/swc-win32-x64-msvc@16.2.11'
-  - '@oxlint-tsgolint/darwin-arm64@7.0.2001'
-  - '@oxlint-tsgolint/darwin-x64@7.0.2001'
-  - '@oxlint-tsgolint/linux-arm64@7.0.2001'
-  - '@oxlint-tsgolint/linux-x64@7.0.2001'
-  - '@oxlint-tsgolint/win32-arm64@7.0.2001'
-  - '@oxlint-tsgolint/win32-x64@7.0.2001'
-  - '@portabletext/sanity-bridge@3.2.3'
-  - '@publint/pack@0.1.6'
-  - '@sanity/color@3.0.7'
-  - '@sanity/icons@5.2.1'
-  - '@sanity/logos@2.2.4'
-  - '@sanity/ui@3.4.3'
-  - '@tsdown/css@0.22.13'
-  - '@vitejs/plugin-react@6.0.4'
   - '@yuku-parser/binding-darwin-arm64@0.8.0'
   - '@yuku-parser/binding-darwin-x64@0.8.0'
   - '@yuku-parser/binding-freebsd-x64@0.8.0'
@@ -57,20 +36,6 @@ minimumReleaseAgeExclude:
   - '@yuku-parser/binding-linux-x64-musl@0.8.0'
   - '@yuku-parser/binding-win32-arm64@0.8.0'
   - '@yuku-parser/binding-win32-x64@0.8.0'
-  - '@yuku-toolchain/types@0.8.0'
-  - baseline-browser-mapping@2.11.1
-  - browserslist@4.28.7
-  - next@16.2.11
-  - oxlint-tsgolint@7.0.2001
-  - publint@0.3.22
-  - react@19.2.8
-  - react-dom@19.2.8
-  - react-is@19.2.8
-  - rolldown-plugin-dts@0.27.13
-  - ts-jest@29.4.12
-  - tsdown@0.22.13
-  - yuku-ast@0.8.0
-  - yuku-parser@0.8.0
 
 overrides:
   '@sanity/pkg-utils': workspace:*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Lowers `minimumReleaseAge` from `4320` (3 days) to `1440` (1 day) — the default that ships with pnpm v11.
- Rebuilds `minimumReleaseAgeExclude` from scratch: all previous name/wildcard exemptions (e.g. `'@sanity/*'`, `react`, `'@vanilla-extract/*'`) are removed and replaced with exact `name@version` entries covering only what `pnpm install` currently rejects.

## How the list was derived

- With the exclude list emptied, `pnpm install --resolution-only` fails with `ERR_PNPM_NO_MATURE_MATCHING_VERSION` on the first version it must freshly age-check.
- A fix-point loop added back each version pnpm actually rejected and re-ran until resolution passed. Result: exactly the 11 `@yuku-parser/binding-*@0.8.0` platform binaries (published 2026-07-23 10:20 UTC, ~22 h old, exact-pinned as `optionalDependencies` of `yuku-parser@0.8.0`).
- Every entry is therefore provably necessary (added only in response to an actual failure) and the set is sufficient (final run passes cleanly).

## Notes on pnpm semantics observed while testing

- Locked versions that satisfy a range spec are reused from `pnpm-lock.yaml` without an age check; exact-pinned optional deps (platform binaries) and auto-installed peers are freshly age-checked. That's why `yuku-parser@0.8.0`, `yuku-ast@0.8.0`, and `@yuku-toolchain/types@0.8.0` (also &lt; 24 h old, but range-satisfied and locked) need no entries — if that subtree is ever re-resolved before they mature (2026-07-24 ~10:23 UTC), pnpm will name the exact version to add.
- Exact-version entries are self-expiring: once a version is older than `minimumReleaseAge` its entry is a no-op and can be deleted at leisure (the current 11 expire today ~10:22 UTC).
- Future bumps that want a sub-1-day-old release (e.g. Renovate's undelayed `tsdown`/`rolldown`/`rolldown-plugin-dts` updates per `.github/renovate.json`) need their exact versions (plus platform-binary siblings) added here; `name@1.2.3 || 1.2.4` disjunctions are supported for multiple versions.

## Verification (all on the committed config)

- `pnpm install --resolution-only` (forces full re-resolution + release-age verification): exit 0, no age errors.
- `pnpm install` and `pnpm install --frozen-lockfile`: exit 0.
- `pnpm-lock.yaml` untouched; `prettier --check pnpm-workspace.yaml` and `pnpm build` pass.
- Necessity probes: with the list emptied, resolution fails on the first binding (`ERR_PNPM_NO_MATURE_MATCHING_VERSION  Version 0.8.0 (released 22 hours ago) of @yuku-parser/binding-linux-x64-gnu does not meet the minimumReleaseAge constraint`); under the previous 4320 gate the same probe on `react@19.2.8` also failed as expected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-882b2d8c-7591-4b5a-a976-add90442c064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-882b2d8c-7591-4b5a-a976-add90442c064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

