### PR TITLE
fix: skip plain `*.css.js` modules that are not vanilla-extract

### DIFF
--- a/.changeset/skip-plain-css-js-modules.md
+++ b/.changeset/skip-plain-css-js-modules.md
@@ -1,0 +1,11 @@
+---
+'@sanity/vanilla-extract-integration': patch
+'@sanity/vanilla-extract-vite-plugin': patch
+'@sanity/vanilla-extract-rolldown-plugin': patch
+---
+
+Skip plain (non-vanilla-extract) `*.css.js` modules that match `cssFileFilter` by filename only — for example `@bynder/compact-view`'s `Styles.css.js`.
+
+Previously the Vite plugin (and the rolldown/`compile` filescope transform) treated every `*.css.js` as a vanilla-extract module, injecting `@vanilla-extract/css/adapter` / `fileScope`. Under pnpm that import often cannot be resolved from the dependency's nested `node_modules`, so `sanity build` failed with `Cannot find module '@vanilla-extract/css/adapter'`.
+
+The earlier [#3085](https://github.com/sanity-io/pkg-utils/pull/3085) fix kept the compiler alive under `unstable_bundledDev` so those modules no longer hung the dev server; this change stops processing them as vanilla-extract at all when their source does not reference `@vanilla-extract/`.

--- a/benchmarks/vanilla-extract/README.md
+++ b/benchmarks/vanilla-extract/README.md
@@ -79,15 +79,14 @@ Keep this section current: re-run the full suite and update the tables whenever 
 `vanilla-extract` dependencies are bumped or any of the `@sanity/vanilla-extract-*` plugins
 change (see [AGENTS.md](../../AGENTS.md)).
 
-Last run: 2026-07-28 (after bumping `@vanilla-extract/css` to 1.21.2 and
-`@vanilla-extract/vite-plugin` to 5.2.6, and porting the upstream virtual-CSS cache-miss fix
-into `@sanity/vanilla-extract-vite-plugin`), full default suite
-(`pnpm benchmark:vanilla-extract`) on Node.js 24.18.0, Linux x64, Intel Xeon, **4 cores**;
-Rollup 4.62.2, Rolldown 1.2.0 (library builds) / 1.1.5 (inside Vite), Vite 8.1.5,
-Vitest 4.1.10, yuku-parser 0.8.0. Values are mean wall-clock milliseconds from that runner
-and are machine-specific — compare ratios, not absolute numbers. Ratios match the previous
-run within noise: library build 2.9–3.2x, Vite build 1.2–1.5x, HMR ~parity, hook-filter
-1.6–1.9x.
+Last run: 2026-07-28 (after skipping plain non-vanilla-extract `*.css.js` modules in the
+Sanity plugins so `@bynder/compact-view`-style `Styles.css.js` no longer injects
+`@vanilla-extract/css/adapter`), full default suite (`pnpm benchmark:vanilla-extract`) on
+Node.js 24.18.0, Linux x64, Intel Xeon, **4 cores**; Rollup 4.62.3, Rolldown 1.2.0 (library
+builds) / 1.1.5 (inside Vite), Vite 8.1.5, Vitest 4.1.10, yuku-parser 0.8.0. Values are mean
+wall-clock milliseconds from that runner and are machine-specific — compare ratios, not
+absolute numbers. Ratios match the previous run within noise: library build 2.9–3.2x, Vite
+build 1.3–1.5x, HMR ~parity, hook-filter 1.6–1.7x.
 
 ### Core count shifts the build ratios
 
@@ -109,14 +108,14 @@ Sanity on leaf edits, 1.05x official on theme edits, rme up to ±20%); hook-filt
 
 | Variant                  | Rollup + `@vanilla-extract/rollup-plugin` | Rolldown + `@sanity/vanilla-extract-rolldown-plugin` | Relative result     |
 | ------------------------ | ----------------------------------------: | ---------------------------------------------------: | ------------------- |
-| No minify, no target     |                               1,095.64 ms |                                            366.39 ms | Sanity 2.99x faster |
-| Minify                   |                               1,088.82 ms |                                            376.89 ms | Sanity 2.89x faster |
-| Target chrome61          |                               1,087.75 ms |                                            377.69 ms | Sanity 2.88x faster |
-| Minify + target chrome61 |                               1,115.63 ms |                                            375.78 ms | Sanity 2.97x faster |
-| Debug identifiers        |                               1,364.38 ms |                                            425.49 ms | Sanity 3.21x faster |
+| No minify, no target     |                               1,128.01 ms |                                            391.85 ms | Sanity 2.88x faster |
+| Minify                   |                               1,069.06 ms |                                            369.71 ms | Sanity 2.89x faster |
+| Target chrome61          |                               1,072.04 ms |                                            373.92 ms | Sanity 2.87x faster |
+| Minify + target chrome61 |                               1,074.20 ms |                                            372.09 ms | Sanity 2.89x faster |
+| Debug identifiers        |                               1,337.00 ms |                                            417.90 ms | Sanity 3.20x faster |
 
-Debug identifiers cost each pipeline `debug − baseline`: **+268.7 ms** for the official
-babel-based transform, **+59.1 ms** for the Sanity `yuku-parser` pass — the transform runs
+Debug identifiers cost each pipeline `debug − baseline`: **+209.0 ms** for the official
+babel-based transform, **+26.1 ms** for the Sanity `yuku-parser` pass — the transform runs
 once per `.css.ts` module and scales with file size, so the production-shaped modules widen
 the gap the near-empty fixtures used to understate.
 
@@ -124,29 +123,29 @@ the gap the near-empty fixtures used to understate.
 
 | Identifiers | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result     |
 | ----------- | -----------------------------: | ------------------------------------: | ------------------- |
-| Short       |                      927.93 ms |                             750.47 ms | Sanity 1.24x faster |
-| Debug       |                    1,253.39 ms |                             823.45 ms | Sanity 1.52x faster |
+| Short       |                      938.16 ms |                             745.32 ms | Sanity 1.26x faster |
+| Debug       |                    1,252.83 ms |                             839.13 ms | Sanity 1.49x faster |
 
 ### Vite build kitchen sink, 5,000 TS + 500 CSS modules, debug identifiers, css minify + target chrome61 (5 samples each)
 
 | `@vanilla-extract/vite-plugin` | `@sanity/vanilla-extract-vite-plugin` | Relative result     |
 | -----------------------------: | ------------------------------------: | ------------------- |
-|                    4,390.07 ms |                           3,244.98 ms | Sanity 1.35x faster |
+|                    4,345.21 ms |                           3,249.64 ms | Sanity 1.34x faster |
 
 ### Vite dev HMR (10 samples each)
 
 | Scenario                               | Official plugin | Sanity plugin | Relative result       |
 | -------------------------------------- | --------------: | ------------: | --------------------- |
-| Single `.css.ts` leaf edit             |        19.88 ms |      22.84 ms | Official 1.15x faster |
-| Shared theme edit, 100 style importers |       176.71 ms |     180.30 ms | Official 1.02x faster |
+| Single `.css.ts` leaf edit             |        24.32 ms |      23.68 ms | Sanity 1.03x faster   |
+| Shared theme edit, 100 style importers |       158.00 ms |     164.86 ms | Official 1.04x faster |
 
 ### Hook-filter stress, `vite build` with 1 CSS module (3 samples each)
 
 | Unrelated modules | Official plugin | Sanity plugin | Relative result     |
 | ----------------: | --------------: | ------------: | ------------------- |
-|                 0 |       426.49 ms |     244.66 ms | Sanity 1.74x faster |
-|             1,000 |       479.91 ms |     260.09 ms | Sanity 1.85x faster |
-|             5,000 |       644.18 ms |     401.73 ms | Sanity 1.60x faster |
+|                 0 |       408.84 ms |     237.85 ms | Sanity 1.72x faster |
+|             1,000 |       424.52 ms |     252.22 ms | Sanity 1.68x faster |
+|             5,000 |       613.49 ms |     384.92 ms | Sanity 1.59x faster |
 
 The untimed hook diagnostic shows why: the official plugin's unfiltered hooks enter JavaScript
 once per module, while the Sanity plugin's native hook filters reject unrelated ids before the

--- a/integration/vanilla-extract-studio/README.md
+++ b/integration/vanilla-extract-studio/README.md
@@ -33,8 +33,10 @@ Commands, each across the shared option matrix in `test/variants.ts`:
   `@bynder/compact-view`: not built with vanilla-extract, but shipping a plain JS
   `Styles.css.js` whose name matches vanilla-extract's `cssFileFilter`. Processing that
   module used to hang the fork's compiler and crash the dev server, forcing the workaround
-  in [sanity-io/plugins#1553](https://github.com/sanity-io/plugins/pull/1553); the compiled
-  patch must match upstream's byte for byte, no workaround required.
+  in [sanity-io/plugins#1553](https://github.com/sanity-io/plugins/pull/1553). The fork now
+  also skips plain `*.css.js` modules whose source does not reference `@vanilla-extract/`
+  (upstream still re-serializes them); the test asserts matching VE class names / CSS and
+  that the plain CSS-string export survives without a `.vanilla.css` sidecar.
 - **`sanity schema extract`** (`test/schema-extract.test.ts`) — identifier variants. The
   fixture schema embeds the generated class names in a field description, so the extracted
   schema doubles as identifier output; the command also exercises `.css.ts` evaluation inside

--- a/integration/vanilla-extract-studio/test/bundled-dev.test.ts
+++ b/integration/vanilla-extract-studio/test/bundled-dev.test.ts
@@ -21,13 +21,19 @@ import {classNameExpectation} from './variants.ts'
  * whose name matches vanilla-extract's `cssFileFilter`, inside a lazily imported modal. The
  * fixture mirrors it with `plain-css-js-dependency` (a `file:` dependency copied into
  * node_modules) consumed by the `React.lazy`-loaded `PlainCssJsInput`, alongside a real
- * `.css.ts` that also only enters the graph through that chunk. Processing the plain
- * `.css.js` module used to hang the fork's compiler until its module runner's 60s transport
- * timeout and then crash the dev server, which that studio worked around with a resolver
- * plugin; upstream handles it without one, and so must the fork.
+ * `.css.ts` that also only enters the graph through that chunk.
+ *
+ * Two failure modes have shown up for that plain `.css.js`:
+ * 1. Closing the compiler on `buildEnd` under bundled Dev hung `processVanillaFile` until the
+ *    60s transport timeout (fixed by keeping the compiler alive for the httpServer lifetime).
+ * 2. Injecting `@vanilla-extract/css/adapter` into the plain module then failing to resolve it
+ *    under pnpm (`Cannot find module '@vanilla-extract/css/adapter'`). The fork now skips
+ *    modules whose source does not reference `@vanilla-extract/`, so the CSS string passes
+ *    through unchanged; upstream still re-serializes it via `processVanillaFile`.
  */
 interface BundledDevOutput {
   classNames: FixtureClassNames
+  lazyClassNames: Record<string, string>
   lazyPatch: string
 }
 
@@ -74,11 +80,11 @@ async function collectBundledDevOutput(
     expect(lazyPatch).toContain(`.${badge} {`)
     expect(lazyPatch).toContain('rgb(7, 8, 9)')
 
-    // The plain (non-vanilla-extract) `Styles.css.js` of the node_modules dependency was
-    // evaluated by the vanilla-extract compiler without hanging it: its CSS string survives
-    // as a JS export, and produces no CSS of its own
+    // The plain (non-vanilla-extract) `Styles.css.js` of the node_modules dependency survives
+    // as a JS CSS-string export and produces no CSS of its own (no hang, no adapter inject)
     expect(lazyPatch).toContain('.plain-css-js-dependency{color:rgb(201, 202, 203)}')
     expect(lazyPatch).not.toContain('Styles.css.js.vanilla.css')
+    expect(lazyPatch).not.toContain('@vanilla-extract/css/adapter')
 
     // The dev server survived the compile (the regression crashed the whole process)
     const entryAfter = await server.fetchText('/assets/index.js')
@@ -90,6 +96,7 @@ async function collectBundledDevOutput(
         overlay: exports['veStudioOverlay']!,
         button: exports['veStudioButton']!,
       },
+      lazyClassNames: lazyExports,
       lazyPatch,
     }
   } finally {
@@ -98,8 +105,8 @@ async function collectBundledDevOutput(
 }
 
 describe('sanity dev (bundled dev mode)', () => {
-  test('fork output matches the upstream reference, including on-demand chunks with a plain .css.js dependency', async () => {
-    // The upstream plugin is the reference for expected output
+  test('fork matches upstream VE output and survives plain .css.js in on-demand chunks', async () => {
+    // The upstream plugin is the reference for vanilla-extract class names / CSS
     const upstream = await collectBundledDevOutput('upstream')
 
     // Dev servers run in development mode, so plugin-default identifiers resolve to `debug`
@@ -112,6 +119,10 @@ describe('sanity dev (bundled dev mode)', () => {
 
     const fork = await collectBundledDevOutput('fork')
     expect(fork.classNames).toEqual(upstream.classNames)
-    expect(fork.lazyPatch).toBe(upstream.lazyPatch)
+    // Real VE modules in the lazy chunk must match upstream; the plain Styles.css.js region
+    // intentionally diverges (fork leaves the original export alone, upstream re-serializes)
+    expect(fork.lazyClassNames).toEqual(upstream.lazyClassNames)
+    expect(fork.lazyPatch).toContain(`.${fork.lazyClassNames['veStudioLazyBadge']} {`)
+    expect(fork.lazyPatch).toContain('rgb(7, 8, 9)')
   })
 })

--- a/packages/@sanity/vanilla-extract-integration/src/compile.ts
+++ b/packages/@sanity/vanilla-extract-integration/src/compile.ts
@@ -7,7 +7,7 @@
  * The upstream `esbuildOptions` passthrough is intentionally dropped: it leaked the esbuild API
  * into the public surface, and no consumer in this repository ever passed it.
  */
-import {cssFileFilter} from './filters.ts'
+import {cssFileFilter, isVanillaExtractSource} from './filters.ts'
 import {getPackageInfo} from './packageInfo.ts'
 import {transform} from './transform.ts'
 import type {IdentifierOption} from './types.ts'
@@ -52,6 +52,9 @@ export async function compile({
         transform: {
           filter: {id: cssFileFilter},
           handler(code, id) {
+            // Plain `*.css.js` modules (e.g. `@bynder/compact-view`'s `Styles.css.js`) match
+            // the filter by name but are not vanilla-extract — leave them alone
+            if (!isVanillaExtractSource(code)) return null
             const [validId = id] = id.split('?')
             return transform({
               source: code,

--- a/packages/@sanity/vanilla-extract-integration/src/filters.ts
+++ b/packages/@sanity/vanilla-extract-integration/src/filters.ts
@@ -16,3 +16,16 @@ export const cssFileFilter: RegExp = /\.css\.(js|cjs|mjs|jsx|ts|tsx)(\?used)?$/
  * @public
  */
 export const virtualCssFileFilter: RegExp = /\.vanilla\.css\?source=.*$/
+
+/**
+ * True when `source` looks like a vanilla-extract module (imports any `@vanilla-extract/…`
+ * package). {@link cssFileFilter} alone is not enough: packages such as `@bynder/compact-view`
+ * ship plain JS modules named `Styles.css.js` that match the filter but are not
+ * vanilla-extract — processing them injects `@vanilla-extract/css/adapter` / `fileScope` and
+ * then fails under pnpm when those packages cannot be resolved from the dependency's nested
+ * `node_modules`.
+ * @public
+ */
+export function isVanillaExtractSource(source: string): boolean {
+  return source.includes('@vanilla-extract/')
+}

--- a/packages/@sanity/vanilla-extract-integration/src/index.ts
+++ b/packages/@sanity/vanilla-extract-integration/src/index.ts
@@ -9,7 +9,7 @@
  */
 
 export {compile, type CompileOptions} from './compile.ts'
-export {cssFileFilter, virtualCssFileFilter} from './filters.ts'
+export {cssFileFilter, isVanillaExtractSource, virtualCssFileFilter} from './filters.ts'
 export {getSourceFromVirtualCssFile} from './getSourceFromVirtualCssFile.ts'
 export {normalizePath} from './normalizePath.ts'
 export {getPackageInfo, type PackageInfo} from './packageInfo.ts'

--- a/packages/@sanity/vanilla-extract-integration/test/filters.test.ts
+++ b/packages/@sanity/vanilla-extract-integration/test/filters.test.ts
@@ -1,0 +1,37 @@
+import {describe, expect, test} from 'vitest'
+import {cssFileFilter, isVanillaExtractSource} from '../src/filters.ts'
+
+describe('cssFileFilter', () => {
+  test('matches vanilla-extract module extensions', () => {
+    expect(cssFileFilter.test('/app/styles.css.ts')).toBe(true)
+    expect(cssFileFilter.test('/app/styles.css.js')).toBe(true)
+    expect(cssFileFilter.test('/app/styles.css.js?used')).toBe(true)
+    expect(cssFileFilter.test('/app/styles.ts')).toBe(false)
+  })
+})
+
+describe('isVanillaExtractSource', () => {
+  test('detects @vanilla-extract imports', () => {
+    expect(
+      isVanillaExtractSource(`import {style} from '@vanilla-extract/css'\nexport const box = style({})`),
+    ).toBe(true)
+    expect(
+      isVanillaExtractSource(
+        `import {setFileScope} from '@vanilla-extract/css/fileScope'\nsetFileScope('x')`,
+      ),
+    ).toBe(true)
+    expect(
+      isVanillaExtractSource(`const {recipe} = require('@vanilla-extract/recipes')`),
+    ).toBe(true)
+  })
+
+  test('rejects plain Styles.css.js modules that only match by filename', () => {
+    // Mirrors @bynder/compact-view's Styles.css.js — a CSS string export, not VE
+    expect(
+      isVanillaExtractSource(
+        `const e = '.plain-css-js-dependency{color:rgb(201, 202, 203)}'\nexport {e as default}`,
+      ),
+    ).toBe(false)
+    expect(isVanillaExtractSource(`export default ".foo{color:red}"`)).toBe(false)
+  })
+})

--- a/packages/@sanity/vanilla-extract-rolldown-plugin/src/index.ts
+++ b/packages/@sanity/vanilla-extract-rolldown-plugin/src/index.ts
@@ -4,6 +4,7 @@ import {
   cssFileFilter,
   getPackageInfo,
   getSourceFromVirtualCssFile,
+  isVanillaExtractSource,
   processVanillaFile,
   virtualCssFileFilter,
   type IdentifierOption,
@@ -240,6 +241,10 @@ export function vanillaExtractPlugin(options: Options = {}): VanillaExtractPlugi
     transform: {
       filter: {id: cssFileFilter},
       async handler(_code, id) {
+        // Plain `*.css.js` modules (e.g. `@bynder/compact-view`'s `Styles.css.js`) match the
+        // filter by name but are not vanilla-extract — leave them alone
+        if (!isVanillaExtractSource(_code)) return null
+
         const [filePath = id] = id.split('?')
 
         const {source, watchFiles} = await compile({

--- a/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
@@ -15,6 +15,7 @@ import {isAbsolute, join} from 'node:path'
 import {
   cssFileFilter,
   getPackageInfo,
+  isVanillaExtractSource,
   normalizePath,
   serializeVanillaModule,
   transform,
@@ -312,6 +313,9 @@ async function createCompilerServer({
         name: 'sanity-vanilla-extract-transform',
         async transform(code, id) {
           if (!cssFileFilter.test(id)) return null
+          // Plain `*.css.js` modules match the filter by name but are not vanilla-extract —
+          // leave them alone so evaluation does not inject an unresolvable adapter import
+          if (!isVanillaExtractSource(code)) return null
           // Inject the file scope and the adapter binding: the spliced
           // `setAdapter(globalThis[...])` call binds the project's own copy of
           // `@vanilla-extract/css` to the adapter of the compilation in progress

--- a/packages/@sanity/vanilla-extract-vite-plugin/src/index.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/src/index.ts
@@ -5,6 +5,7 @@
  */
 import {
   cssFileFilter,
+  isVanillaExtractSource,
   normalizePath,
   type IdentifierOption,
 } from '@sanity/vanilla-extract-integration'
@@ -327,6 +328,11 @@ export function vanillaExtractPlugin({
         async handler(_code, id, options) {
           const [validId = id] = id.split('?')
           if (!cssFileFilter.test(validId)) return null
+          // Plain `*.css.js` modules (e.g. `@bynder/compact-view`'s `Styles.css.js`) match
+          // the filter by name but are not vanilla-extract. Processing them would inject
+          // `@vanilla-extract/css/adapter` and then fail under pnpm when that package cannot
+          // be resolved from the dependency's nested `node_modules`.
+          if (!isVanillaExtractSource(_code)) return null
 
           // `transform` can run before `buildStart` has finished creating the compiler;
           // `ensureCompiler` is memoized, so this is a no-op once the compiler exists

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/app/src/Styles.css.js
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/app/src/Styles.css.js
@@ -1,0 +1,4 @@
+// Plain CSS-string module — NOT vanilla-extract — whose name matches cssFileFilter
+// (mirrors @bynder/compact-view's Styles.css.js).
+const styles = '.plain-css-js-fixture{color:rgb(201, 202, 203)}'
+export default styles

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/app/src/main.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/app/src/main.ts
@@ -1,4 +1,6 @@
+import plainCss from './Styles.css.js'
 import {button} from './button.css.ts'
 import {box} from './styles.css.ts'
 
 document.body.className = `${box} ${button}`
+document.body.dataset.plainCss = plainCss

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/app/src/main.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/fixtures/app/src/main.ts
@@ -3,4 +3,4 @@ import {button} from './button.css.ts'
 import {box} from './styles.css.ts'
 
 document.body.className = `${box} ${button}`
-document.body.dataset.plainCss = plainCss
+document.body.dataset['plainCss'] = plainCss

--- a/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/test/plugin.test.ts
@@ -107,6 +107,12 @@ describe('vite build', () => {
     if (!entry || entry.type !== 'chunk') expect.unreachable('expected an entry chunk')
     expect(entry.code).toContain('className')
     expect(entry.code).not.toContain('rgb(1, 2, 3)')
+    // Plain Styles.css.js (filename matches cssFileFilter but is not VE) passes through
+    // unchanged — no adapter injection, no .vanilla.css. Regression for the
+    // `@bynder/compact-view` / `Cannot find module '@vanilla-extract/css/adapter'` build failure.
+    expect(entry.code).toContain('.plain-css-js-fixture{color:rgb(201, 202, 203)}')
+    expect(entry.code).not.toContain('@vanilla-extract/css/adapter')
+    expect(entry.code).not.toContain('Styles.css.js.vanilla.css')
 
     // Vite links the CSS from the HTML entry - the extract never leaves its pipeline
     const html = output.find(
@@ -139,6 +145,27 @@ describe('vite dev', () => {
       // The virtual module resolves through Vite's CSS pipeline (served as a JS module in dev)
       const css = await server.transformRequest(virtualImport![1]!)
       expect(css?.code).toContain('rgb(1, 2, 3)')
+    } finally {
+      await server.close()
+    }
+  })
+
+  test('leaves plain Styles.css.js modules unprocessed', async () => {
+    // Filename matches cssFileFilter but the module is not vanilla-extract (same shape as
+    // `@bynder/compact-view`'s Styles.css.js). Must not inject `@vanilla-extract/css/adapter`.
+    const server = await createServer({
+      root: appRoot,
+      configFile: false,
+      logLevel: 'silent',
+      server: {middlewareMode: true},
+      plugins: [vanillaExtractPlugin()],
+    })
+    try {
+      const transformed = await server.transformRequest('/src/Styles.css.js')
+      expect(transformed?.code).toContain('.plain-css-js-fixture{color:rgb(201, 202, 203)}')
+      expect(transformed?.code).not.toContain('@vanilla-extract/css/adapter')
+      expect(transformed?.code).not.toContain('@vanilla-extract/css/fileScope')
+      expect(transformed?.code).not.toContain('.vanilla.css')
     } finally {
       await server.close()
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Downstream `sanity build` can fail when a dependency ships a plain (non-vanilla-extract) module whose name matches `cssFileFilter`, e.g. `@bynder/compact-view`'s `Styles.css.js`:

```
[plugin sanity-vanilla-extract]
…/@bynder/compact-view/Styles.css.js
Error: Cannot find module '@vanilla-extract/css/adapter'
```

### What we fixed before vs now

| Fix | Scope | Symptom |
|-----|--------|---------|
| [#3043](https://github.com/sanity-io/pkg-utils/pull/3043) | rolldown / pkg-utils CSS shim rename (`bundle.css.js` → `bundle-css.js`) | Sanity’s own shims falsely matching the filter |
| [#3085](https://github.com/sanity-io/pkg-utils/pull/3085) | **vite plugin only** | Dev hang / 60s timeout under `unstable_bundledDev` when those modules were processed |
| **This PR** | vite + compiler + rolldown/`compile` | Build/dev failure from injecting `@vanilla-extract/css/adapter` into plain `*.css.js` (unresolvable under pnpm) |

So yes — #3085 did address `@bynder/compact-view` / plain `Styles.css.js`, but only the bundled-dev **hang**. It did **not** stop the Vite plugin from treating those files as vanilla-extract. The rolldown-side rename (#3043) was a different problem (our own `bundle.css.js` shims), not third-party plain `Styles.css.js`.

## Change

Add `isVanillaExtractSource()` (source must mention `@vanilla-extract/`) and skip non-matching modules in:

- `@sanity/vanilla-extract-vite-plugin` transform + internal compiler transform
- `@sanity/vanilla-extract-integration` `compile()` filescope transform
- `@sanity/vanilla-extract-rolldown-plugin` transform

## Tests

- Unit tests for the helper
- Vite build + dev assertions that `Styles.css.js` passes through without adapter / `.vanilla.css` injection
- Integration `bundled-dev` suite updated: still asserts matching VE class names/CSS and plain CSS-string survival; no longer requires byte-identical lazy patches vs upstream (upstream still re-serializes plain `.css.js`)
- Benchmarks re-run; README tables updated

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3ba4835-7cdd-4e55-961d-a43add423f11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3ba4835-7cdd-4e55-961d-a43add423f11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

