### PR TITLE
fix(tsdown-config): default exports generation to always-on

### DIFF
--- a/.changeset/exports-always-on.md
+++ b/.changeset/exports-always-on.md
@@ -1,0 +1,8 @@
+---
+'@sanity/tsdown-config': minor
+'@sanity/pkg-utils': patch
+---
+
+Default `exports` generation to always-on (`true`) instead of `enabled: 'local-only'`.
+
+Gating on `CI` via `'local-only'`/`'ci-only'` surprised environments that set `CI=true` without meaning "don't rewrite package.json" (notably Cursor Cloud). Exports generation now runs the same everywhere; pnpm projects still get `devExports: true` by default. Opt back into a CI condition with `exports: {enabled: 'local-only'}` (or `'ci-only'`) if you need the old gate.

--- a/.changeset/exports-always-on.md
+++ b/.changeset/exports-always-on.md
@@ -3,6 +3,6 @@
 '@sanity/pkg-utils': patch
 ---
 
-Default `exports` generation to always-on (`true`) instead of `enabled: 'local-only'`.
+Default `exports.enabled` to `true` instead of `'local-only'`.
 
-Gating on `CI` via `'local-only'`/`'ci-only'` surprised environments that set `CI=true` without meaning "don't rewrite package.json" (notably Cursor Cloud). Exports generation now runs the same everywhere; pnpm projects still get `devExports: true` by default. Opt back into a CI condition with `exports: {enabled: 'local-only'}` (or `'ci-only'`) if you need the old gate.
+Gating on `CI` via `'local-only'`/`'ci-only'` surprised environments that set `CI=true` without meaning "don't rewrite package.json" (notably Cursor Cloud). The defaults stay object-shaped (`{enabled: true, …}` / `{enabled: true}`), so mergeConfig behavior is unchanged aside from the always-on `enabled` value. Opt back into a CI condition with `exports: {enabled: 'local-only'}` (or `'ci-only'`) if you need the old gate.

--- a/packages/@sanity/pkg-utils/MIGRATE.md
+++ b/packages/@sanity/pkg-utils/MIGRATE.md
@@ -41,9 +41,9 @@ Other behavior changes:
 - **`pkg check` runs [publint](https://publint.dev)** on the packed package (with
   `publishConfig` applied) instead of the esbuild resolution checks. Fix what it reports — it
   lints what consumers actually install.
-- **Local builds keep `exports` in sync**: the map is regenerated from the build (with the
-  `source`-condition development pattern and a `source`-less `publishConfig.exports`); CI uses
-  the committed `package.json` as-is.
+- **Builds keep `exports` in sync**: the map is regenerated from the build (with the
+  `source`-condition development pattern and a `source`-less `publishConfig.exports`), including
+  in CI — so environments that set `CI=true` without meaning "skip package.json" still behave.
 - `tsdown.config.*` files are **never** loaded by `pkg build` — `package.config.ts` is the only
   config source. For customization beyond the config surface, use `tsdown` +
   `@sanity/tsdown-config` directly.

--- a/packages/@sanity/pkg-utils/README.md
+++ b/packages/@sanity/pkg-utils/README.md
@@ -42,9 +42,9 @@ tsdown's programmatic `build()`.
 `pkg build`. For customizations beyond the options below, use `tsdown` +
 `@sanity/tsdown-config` directly instead.
 
-During local builds the `exports` map is regenerated from the build (with `source` conditions for
-development, and a `source`-less `publishConfig.exports` for publishing) and kept in sync; in CI
-the committed `package.json` is used as-is.
+Builds regenerate the `exports` map from the build (with `source` conditions for development, and
+a `source`-less `publishConfig.exports` for publishing) and keep it in sync — including in CI —
+so environments that set `CI=true` without meaning "skip package.json" still behave correctly.
 
 ## Configuration
 

--- a/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
+++ b/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
@@ -114,10 +114,11 @@ export async function resolveTsdownConfig(
   // Exports generation runs on the canonical build only, with `devExports: 'source'` — the
   // hand-written Sanity convention (`source` conditions in `exports`, a `source`-less
   // `publishConfig.exports`) — and the pkg-utils composer reconciling the generated map with
-  // the hand-written one. tsdown's own `enabled: 'local-only'` default applies: the map is
-  // written during local builds and left alone in CI. A types-only build never rewrites
-  // `package.json`, and neither do watch builds (a rewrite would re-trigger the
-  // `package.json` watcher).
+  // the hand-written one. `@sanity/tsdown-config`'s always-on exports default applies: the map
+  // is rewritten on every build (CI included), so environments that set `CI=true` without
+  // meaning "skip package.json" (Cursor Cloud, …) still keep exports in sync. A types-only
+  // build never rewrites `package.json`, and neither do watch builds (a rewrite would
+  // re-trigger the `package.json` watcher).
   const exports: UserConfig['exports'] =
     build.canonical && !ctx.emitDeclarationOnly && !options.watch
       ? {

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -437,8 +437,9 @@ export default defineConfig({
 tsdown's [`exports` option](https://tsdown.dev/options/package-exports) is forwarded with
 different defaults, suited for publishing Sanity libraries:
 
-- `enabled: 'local-only'` - the `exports` map in `package.json` is generated during local builds
-  and skipped in CI, where the committed `package.json` is already up to date, and
+- always on (`true`) - the `exports` map in `package.json` is generated on every build, whether
+  `CI` is set or not. Gating on `'local-only'`/`'ci-only'` surprised environments like Cursor
+  Cloud that set `CI=true` without intending to skip `package.json` rewrites, and
 - `devExports: true` when pnpm is detected - the local `exports` map points at the source files
   (so monorepo siblings and editors resolve them directly), while `publishConfig.exports` receives
   the built files. This default is omitted for other or unknown package managers because they do

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -437,7 +437,7 @@ export default defineConfig({
 tsdown's [`exports` option](https://tsdown.dev/options/package-exports) is forwarded with
 different defaults, suited for publishing Sanity libraries:
 
-- always on (`true`) - the `exports` map in `package.json` is generated on every build, whether
+- `enabled: true` - the `exports` map in `package.json` is generated on every build, whether
   `CI` is set or not. Gating on `'local-only'`/`'ci-only'` surprised environments like Cursor
   Cloud that set `CI=true` without intending to skip `package.json` rewrites, and
 - `devExports: true` when pnpm is detected - the local `exports` map points at the source files

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -154,10 +154,11 @@ export interface PackageOptions extends Pick<
   clean?: UserConfig['clean']
   /**
    * tsdown's `exports` option, with defaults suited for publishing Sanity libraries:
-   * `enabled: 'local-only'` generates the `exports` map during local builds and skips it in CI
-   * (where the committed `package.json` is already up to date). When pnpm is detected,
-   * `devExports: true` also keeps the local `exports` map pointing at source files while
-   * `publishConfig.exports` receives the built files.
+   * exports generation is always on (`true`), so it runs the same whether `CI` is set or not
+   * (GitHub Actions, Cursor Cloud, local shells, …). Relying on `'local-only'`/`'ci-only'`
+   * surprised too many environments that set `CI=true` without meaning "don't rewrite
+   * package.json". When pnpm is detected, `devExports: true` also keeps the local `exports`
+   * map pointing at source files while `publishConfig.exports` receives the built files.
    *
    * Userland values apply with tsdown's `mergeConfig` semantics: an object deep-merges over
    * these defaults (so individual fields can be overridden), while any other value - `false`
@@ -168,8 +169,7 @@ export interface PackageOptions extends Pick<
    * {@link PackageOptions.cwd | `cwd`} and only runs when the default can still apply — it is
    * skipped when the value replaces the defaults (`false`, `true`, a bare CI condition) or
    * sets `devExports` explicitly.
-   * @defaultValue `{enabled: 'local-only', devExports: true}` for pnpm projects;
-   * `{enabled: 'local-only'}` otherwise.
+   * @defaultValue `{devExports: true}` for pnpm projects; `true` otherwise.
    */
   exports?: UserConfig['exports']
   /**
@@ -483,12 +483,11 @@ async function resolvePackageConfig(
     // anything else (`false`, a CI condition) replaces them.
     ;({exports} = mergeConfig(
       {
-        exports: {
-          enabled: 'local-only',
-          // Only opt in by default when pnpm is detected: support for replacing package fields
-          // from `publishConfig` is not reliable across package managers.
-          ...(packageManager?.name === 'pnpm' && {devExports: true}),
-        },
+        // Always on: `'local-only'`/`'ci-only'` surprise environments that set `CI=true`
+        // (Cursor Cloud, etc.) without intending to skip package.json rewrites. Only opt into
+        // `devExports` by default when pnpm is detected — support for replacing package fields
+        // from `publishConfig` is not reliable across package managers.
+        exports: packageManager?.name === 'pnpm' ? {devExports: true} : true,
       },
       {exports: userExports},
     ))

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -154,7 +154,7 @@ export interface PackageOptions extends Pick<
   clean?: UserConfig['clean']
   /**
    * tsdown's `exports` option, with defaults suited for publishing Sanity libraries:
-   * exports generation is always on (`true`), so it runs the same whether `CI` is set or not
+   * `enabled: true` generates the `exports` map on every build, whether `CI` is set or not
    * (GitHub Actions, Cursor Cloud, local shells, …). Relying on `'local-only'`/`'ci-only'`
    * surprised too many environments that set `CI=true` without meaning "don't rewrite
    * package.json". When pnpm is detected, `devExports: true` also keeps the local `exports`
@@ -169,7 +169,8 @@ export interface PackageOptions extends Pick<
    * {@link PackageOptions.cwd | `cwd`} and only runs when the default can still apply — it is
    * skipped when the value replaces the defaults (`false`, `true`, a bare CI condition) or
    * sets `devExports` explicitly.
-   * @defaultValue `{devExports: true}` for pnpm projects; `true` otherwise.
+   * @defaultValue `{enabled: true, devExports: true}` for pnpm projects;
+   * `{enabled: true}` otherwise.
    */
   exports?: UserConfig['exports']
   /**
@@ -483,11 +484,15 @@ async function resolvePackageConfig(
     // anything else (`false`, a CI condition) replaces them.
     ;({exports} = mergeConfig(
       {
-        // Always on: `'local-only'`/`'ci-only'` surprise environments that set `CI=true`
-        // (Cursor Cloud, etc.) without intending to skip package.json rewrites. Only opt into
-        // `devExports` by default when pnpm is detected — support for replacing package fields
-        // from `publishConfig` is not reliable across package managers.
-        exports: packageManager?.name === 'pnpm' ? {devExports: true} : true,
+        exports: {
+          // Always on: `'local-only'`/`'ci-only'` surprise environments that set `CI=true`
+          // (Cursor Cloud, etc.) without intending to skip package.json rewrites. Keep the
+          // object shape so mergeConfig never swaps between a scalar `true` and `{devExports}`.
+          enabled: true,
+          // Only opt in by default when pnpm is detected: support for replacing package fields
+          // from `publishConfig` is not reliable across package managers.
+          ...(packageManager?.name === 'pnpm' && {devExports: true}),
+        },
       },
       {exports: userExports},
     ))

--- a/packages/@sanity/tsdown-config/test/options.test.ts
+++ b/packages/@sanity/tsdown-config/test/options.test.ts
@@ -229,21 +229,19 @@ describe('unexposed options', () => {
 })
 
 describe('exports option', () => {
-  test('defaults to local-only generation with dev exports', async () => {
-    // `enabled: 'local-only'` generates the `exports` map during local builds and skips it in
-    // CI; `devExports: true` keeps the local `exports` map pointing at source files while
-    // `publishConfig.exports` receives the built files
-    expect((await defineConfig()).exports).toEqual({enabled: 'local-only', devExports: true})
+  test('defaults to always-on generation with dev exports', async () => {
+    // Exports generation always runs (no `'local-only'`/`'ci-only'` gate); `devExports: true`
+    // keeps the local `exports` map pointing at source files while `publishConfig.exports`
+    // receives the built files
+    expect((await defineConfig()).exports).toEqual({devExports: true})
   })
 
   test('merges an object over the defaults', async () => {
     expect((await defineConfig({exports: {all: true}})).exports).toEqual({
-      enabled: 'local-only',
       devExports: true,
       all: true,
     })
     expect((await defineConfig({exports: {devExports: 'source'}})).exports).toEqual({
-      enabled: 'local-only',
       devExports: 'source',
     })
   })

--- a/packages/@sanity/tsdown-config/test/options.test.ts
+++ b/packages/@sanity/tsdown-config/test/options.test.ts
@@ -230,18 +230,20 @@ describe('unexposed options', () => {
 
 describe('exports option', () => {
   test('defaults to always-on generation with dev exports', async () => {
-    // Exports generation always runs (no `'local-only'`/`'ci-only'` gate); `devExports: true`
-    // keeps the local `exports` map pointing at source files while `publishConfig.exports`
-    // receives the built files
-    expect((await defineConfig()).exports).toEqual({devExports: true})
+    // `enabled: true` generates the `exports` map on every build (no `'local-only'`/
+    // `'ci-only'` gate); `devExports: true` keeps the local `exports` map pointing at source
+    // files while `publishConfig.exports` receives the built files
+    expect((await defineConfig()).exports).toEqual({enabled: true, devExports: true})
   })
 
   test('merges an object over the defaults', async () => {
     expect((await defineConfig({exports: {all: true}})).exports).toEqual({
+      enabled: true,
       devExports: true,
       all: true,
     })
     expect((await defineConfig({exports: {devExports: 'source'}})).exports).toEqual({
+      enabled: true,
       devExports: 'source',
     })
   })

--- a/packages/@sanity/tsdown-config/test/package-manager.test.ts
+++ b/packages/@sanity/tsdown-config/test/package-manager.test.ts
@@ -15,7 +15,6 @@ describe('devExports default', () => {
     mockedDetect.mockResolvedValue({name: 'pnpm', agent: 'pnpm'})
 
     expect((await defineConfig()).exports).toEqual({
-      enabled: 'local-only',
       devExports: true,
     })
     expect(mockedDetect).toHaveBeenCalledWith({cwd: process.cwd()})
@@ -28,24 +27,20 @@ describe('devExports default', () => {
   ] as const)('is not enabled when $name is detected', async (packageManager) => {
     mockedDetect.mockResolvedValue(packageManager)
 
-    expect((await defineConfig()).exports).toEqual({
-      enabled: 'local-only',
-    })
+    expect((await defineConfig()).exports).toBe(true)
   })
 
   test('is not enabled when no package manager can be detected', async () => {
     mockedDetect.mockResolvedValue(null)
 
-    expect((await defineConfig()).exports).toEqual({
-      enabled: 'local-only',
-    })
+    expect((await defineConfig()).exports).toBe(true)
   })
 
   test('still merges other export options when pnpm is not detected', async () => {
     mockedDetect.mockResolvedValue({name: 'npm', agent: 'npm'})
 
+    // Scalar `true` default is replaced by an object overlay (mergeConfig semantics)
     expect((await defineConfig({exports: {all: true}})).exports).toEqual({
-      enabled: 'local-only',
       all: true,
     })
   })
@@ -54,7 +49,6 @@ describe('devExports default', () => {
     mockedDetect.mockResolvedValue({name: 'npm', agent: 'npm'})
 
     expect((await defineConfig({exports: {devExports: true}})).exports).toEqual({
-      enabled: 'local-only',
       devExports: true,
     })
     // An explicit `devExports` makes the pnpm-gated default unreachable, so the detection
@@ -66,7 +60,6 @@ describe('devExports default', () => {
     mockedDetect.mockResolvedValue({name: 'pnpm', agent: 'pnpm'})
 
     expect((await defineConfig({cwd: '/somewhere/else'})).exports).toEqual({
-      enabled: 'local-only',
       devExports: true,
     })
     expect(mockedDetect).toHaveBeenCalledWith({cwd: '/somewhere/else'})

--- a/packages/@sanity/tsdown-config/test/package-manager.test.ts
+++ b/packages/@sanity/tsdown-config/test/package-manager.test.ts
@@ -15,6 +15,7 @@ describe('devExports default', () => {
     mockedDetect.mockResolvedValue({name: 'pnpm', agent: 'pnpm'})
 
     expect((await defineConfig()).exports).toEqual({
+      enabled: true,
       devExports: true,
     })
     expect(mockedDetect).toHaveBeenCalledWith({cwd: process.cwd()})
@@ -27,20 +28,24 @@ describe('devExports default', () => {
   ] as const)('is not enabled when $name is detected', async (packageManager) => {
     mockedDetect.mockResolvedValue(packageManager)
 
-    expect((await defineConfig()).exports).toBe(true)
+    expect((await defineConfig()).exports).toEqual({
+      enabled: true,
+    })
   })
 
   test('is not enabled when no package manager can be detected', async () => {
     mockedDetect.mockResolvedValue(null)
 
-    expect((await defineConfig()).exports).toBe(true)
+    expect((await defineConfig()).exports).toEqual({
+      enabled: true,
+    })
   })
 
   test('still merges other export options when pnpm is not detected', async () => {
     mockedDetect.mockResolvedValue({name: 'npm', agent: 'npm'})
 
-    // Scalar `true` default is replaced by an object overlay (mergeConfig semantics)
     expect((await defineConfig({exports: {all: true}})).exports).toEqual({
+      enabled: true,
       all: true,
     })
   })
@@ -49,6 +54,7 @@ describe('devExports default', () => {
     mockedDetect.mockResolvedValue({name: 'npm', agent: 'npm'})
 
     expect((await defineConfig({exports: {devExports: true}})).exports).toEqual({
+      enabled: true,
       devExports: true,
     })
     // An explicit `devExports` makes the pnpm-gated default unreachable, so the detection
@@ -60,6 +66,7 @@ describe('devExports default', () => {
     mockedDetect.mockResolvedValue({name: 'pnpm', agent: 'pnpm'})
 
     expect((await defineConfig({cwd: '/somewhere/else'})).exports).toEqual({
+      enabled: true,
       devExports: true,
     })
     expect(mockedDetect).toHaveBeenCalledWith({cwd: '/somewhere/else'})

--- a/packages/@sanity/tsdown-config/test/react-server.test.ts
+++ b/packages/@sanity/tsdown-config/test/react-server.test.ts
@@ -125,7 +125,8 @@ describe('reactCompiler.reactServer option', () => {
     // owns `dts`, `exports` generation and `publint`
     expect(getPluginNames(compiled)).toEqual(['@rolldown/plugin-babel'])
     expect(compiled.publint).toBe(true)
-    expect(compiled.exports).toMatchObject({enabled: 'local-only'})
+    expect(compiled.exports).toMatchObject({devExports: true})
+    expect(compiled.exports).not.toHaveProperty('enabled')
 
     // The react-server variant builds the same source without the compiler, skips d.ts (the
     // compiled variant's declarations serve both entries), never cleans (the compiled

--- a/packages/@sanity/tsdown-config/test/react-server.test.ts
+++ b/packages/@sanity/tsdown-config/test/react-server.test.ts
@@ -125,8 +125,7 @@ describe('reactCompiler.reactServer option', () => {
     // owns `dts`, `exports` generation and `publint`
     expect(getPluginNames(compiled)).toEqual(['@rolldown/plugin-babel'])
     expect(compiled.publint).toBe(true)
-    expect(compiled.exports).toMatchObject({devExports: true})
-    expect(compiled.exports).not.toHaveProperty('enabled')
+    expect(compiled.exports).toMatchObject({enabled: true, devExports: true})
 
     // The react-server variant builds the same source without the compiler, skips d.ts (the
     // compiled variant's declarations serve both entries), never cleans (the compiled

--- a/packages/@sanity/tsdown-config/test/vanilla-extract.test.ts
+++ b/packages/@sanity/tsdown-config/test/vanilla-extract.test.ts
@@ -362,7 +362,7 @@ describe('vanillaExtract option', () => {
       expect.unreachable('expected `exports.customExports` to be a function')
     }
     // The config's own exports settings are preserved
-    expect(exportsOption).toMatchObject({devExports: true})
+    expect(exportsOption).toMatchObject({enabled: true, devExports: true})
 
     const result = await exportsOption.customExports(
       {

--- a/packages/@sanity/tsdown-config/test/vanilla-extract.test.ts
+++ b/packages/@sanity/tsdown-config/test/vanilla-extract.test.ts
@@ -362,7 +362,7 @@ describe('vanillaExtract option', () => {
       expect.unreachable('expected `exports.customExports` to be a function')
     }
     // The config's own exports settings are preserved
-    expect(exportsOption).toMatchObject({enabled: 'local-only', devExports: true})
+    expect(exportsOption).toMatchObject({devExports: true})
 
     const result = await exportsOption.customExports(
       {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`@sanity/tsdown-config` previously defaulted `exports.enabled` to `'local-only'`, so generation ran only when `CI` was unset. That surprised environments that set `CI=true` without meaning "don't rewrite `package.json`" — notably Cursor Cloud.

This flips only `enabled` to `true`, keeping the same object-shaped defaults:

- **pnpm**: `{enabled: true, devExports: true}`
- **other package managers**: `{enabled: true}`

No scalar `exports: true` vs `{devExports: true}` swap — mergeConfig behavior stays as before aside from the always-on `enabled` value. Opt back into a CI condition with `exports: {enabled: 'local-only'}` or `'ci-only'` if you need the old gate. Docs in `@sanity/pkg-utils` / `MIGRATE.md` are updated to match.

## Test plan

- [x] `@sanity/tsdown-config` unit tests for exports / package-manager / react-server / composition (71 passed)
- [x] Confirmed defaults stay object-shaped with `enabled: true`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37bf0182-1506-4e98-8a60-d72e55ec22c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37bf0182-1506-4e98-8a60-d72e55ec22c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

