### PR TITLE
refactor(pkg-utils): drop redundant chalk dependency

### DIFF
--- a/.changeset/lucky-pans-smile.md
+++ b/.changeset/lucky-pans-smile.md
@@ -1,0 +1,5 @@
+---
+'@sanity/pkg-utils': patch
+---
+
+drop chalk in favor of node's built-in `util.styleText`

--- a/packages/@sanity/pkg-utils/package.json
+++ b/packages/@sanity/pkg-utils/package.json
@@ -66,7 +66,6 @@
     "browserslist": "^4.28.7",
     "browserslist-to-esbuild": "2.1.1",
     "cac": "^7.0.0",
-    "chalk": "^6.0.0",
     "chokidar": "^5.0.0",
     "empathic": "^2.0.1",
     "find-config": "^1.0.0",

--- a/packages/@sanity/pkg-utils/src/cli/handleError.ts
+++ b/packages/@sanity/pkg-utils/src/cli/handleError.ts
@@ -1,8 +1,8 @@
-import chalk from 'chalk'
+import {styleText} from 'node:util'
 
 export function handleError(err: unknown): void {
   if (err instanceof Error) {
-    console.error(chalk.red('error'), err.stack)
+    console.error(styleText('red', 'error', {stream: process.stderr}), err.stack)
   } else {
     console.error(err)
   }

--- a/packages/@sanity/pkg-utils/src/node/core/pkg/loadPkgWithReporting.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/pkg/loadPkgWithReporting.ts
@@ -1,5 +1,5 @@
+import {styleText} from 'node:util'
 import {ZodError, type PackageJSON} from '@sanity/parse-package-json'
-import chalk from 'chalk'
 import type {Logger} from '../../logger.ts'
 import type {StrictOptions} from '../../strict.ts'
 import {checkDependencyPlacement} from './dependencyPlacement.ts'
@@ -419,8 +419,8 @@ export async function loadPkgWithReporting(options: {
           logger.error(
             [
               `\`${formatPath(issue.path)}\` `,
-              `in \`./package.json\` must be of type ${chalk.magenta(issue.expected)} `,
-              `(received ${chalk.magenta(issue.received)})`,
+              `in \`./package.json\` must be of type ${styleText('magenta', issue.expected)} `,
+              `(received ${styleText('magenta', issue.received)})`,
             ].join(''),
           )
           continue

--- a/packages/@sanity/pkg-utils/src/node/logger.ts
+++ b/packages/@sanity/pkg-utils/src/node/logger.ts
@@ -1,5 +1,5 @@
 // oxlint-disable no-console
-import chalk from 'chalk'
+import {styleText} from 'node:util'
 
 /** @alpha */
 export interface Logger {
@@ -17,16 +17,16 @@ export function createLogger(quiet = false): Logger {
       if (!quiet) console.log(...args)
     },
     info: (...args) => {
-      if (!quiet) console.log(chalk.blue('[info]'), ...args)
+      if (!quiet) console.log(styleText('blue', '[info]'), ...args)
     },
     warn: (...args) => {
-      console.log(chalk.yellow('[warning]'), ...args)
+      console.log(styleText('yellow', '[warning]'), ...args)
     },
     error: (...args) => {
-      console.log(chalk.red('[error]'), ...args)
+      console.log(styleText('red', '[error]'), ...args)
     },
     success: (...args) => {
-      if (!quiet) console.log(chalk.green('[success]'), ...args)
+      if (!quiet) console.log(styleText('green', '[success]'), ...args)
     },
   }
 }

--- a/packages/@sanity/pkg-utils/src/node/printPackageTree.ts
+++ b/packages/@sanity/pkg-utils/src/node/printPackageTree.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import chalk from 'chalk'
+import {styleText} from 'node:util'
 import treeify from 'treeify'
 import type {PkgExport} from './core/config/types.ts'
 import type {BuildContext} from './core/contexts/buildContext.ts'
@@ -19,17 +19,17 @@ export function printPackageTree(ctx: BuildContext): void {
 
   if (!exports) return
 
-  logger.log(`${chalk.blue(pkg.name)}@${chalk.green(pkg.version)}`)
+  logger.log(`${styleText('blue', pkg.name)}@${styleText('green', pkg.version)}`)
 
   const tree: Record<string, unknown> = {}
 
   if (pkg.type) {
-    tree['type'] = chalk.yellow(pkg.type)
+    tree['type'] = styleText('yellow', pkg.type)
   }
 
   if (pkg.bin) {
     tree['bin'] = Object.fromEntries(
-      Object.entries(pkg.bin).map(([name, file]) => [chalk.cyan(name), fileInfo(file)]),
+      Object.entries(pkg.bin).map(([name, file]) => [styleText('cyan', name), fileInfo(file)]),
     )
   }
 
@@ -37,10 +37,10 @@ export function printPackageTree(ctx: BuildContext): void {
     const info = getFileInfo(cwd, file)
 
     if (!info.size) {
-      return `${chalk.gray(file)} ${chalk.red('does not exist')}`
+      return `${styleText('gray', file)} ${styleText('red', 'does not exist')}`
     }
 
-    return `${chalk.yellow(file)} ${chalk.gray(info.size)}`
+    return `${styleText('yellow', file)} ${styleText('gray', info.size)}`
   }
 
   tree['exports'] = Object.fromEntries(
@@ -87,7 +87,7 @@ export function printPackageTree(ctx: BuildContext): void {
           delete exp.import
         }
 
-        return [chalk.cyan(path.join(pkg.name, exportPath)), exp]
+        return [styleText('cyan', path.join(pkg.name, exportPath)), exp]
       }),
   )
 

--- a/packages/@sanity/pkg-utils/src/node/spinner.ts
+++ b/packages/@sanity/pkg-utils/src/node/spinner.ts
@@ -1,5 +1,5 @@
 // oxlint-disable no-console
-import chalk from 'chalk'
+import {styleText} from 'node:util'
 
 export function createSpinner(
   msg: string,
@@ -12,10 +12,14 @@ export function createSpinner(
   return {
     complete: () => {
       if (!quiet)
-        console.log(`${chalk.green('[success]')} ${chalk.gray(`${Date.now() - startTime}ms`)}`)
+        console.log(
+          `${styleText('green', '[success]')} ${styleText('gray', `${Date.now() - startTime}ms`)}`,
+        )
     },
     error: () => {
-      console.log(`${chalk.red('[error]')} ${chalk.gray(`${Date.now() - startTime}ms`)}`)
+      console.log(
+        `${styleText('red', '[error]')} ${styleText('gray', `${Date.now() - startTime}ms`)}`,
+      )
     },
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -727,9 +727,6 @@ importers:
       cac:
         specifier: ^7.0.0
         version: 7.0.0
-      chalk:
-        specifier: ^6.0.0
-        version: 6.0.0
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
@@ -8399,10 +8396,6 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-
-  chalk@6.0.0:
-    resolution: {integrity: sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==}
-    engines: {node: '>=22'}
 
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -23119,8 +23112,6 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
-
-  chalk@6.0.0: {}
 
   char-regex@1.0.2: {}
 


### PR DESCRIPTION
pkg-utils already requires node versions where `util.styleText` is stable, so we can drop the dependency entirely, which follows the [recommendation of the e18e working group](https://replacements.fyi/chalk).