### PR TITLE
fix(test): resolve bundled-dev wsToken from /bundledDevClient.mjs

### DIFF
--- a/integration/vanilla-extract-studio/test/helpers.ts
+++ b/integration/vanilla-extract-studio/test/helpers.ts
@@ -265,8 +265,9 @@ function extractWsToken(code: string): string | undefined {
  * `/@vite/lazy?id=<module id>&clientId=<id>`, compiling the chunk on first request. The
  * `clientId` must belong to a registered client, so this helper first announces one over the
  * HMR WebSocket (`vite:module-loaded`, like the Rolldown browser runtime on startup) using
- * the `wsToken` embedded in the served entry — or, when Vite/Rolldown splits the runtime,
- * in the sibling `rolldown-runtime-*.js` chunk the entry imports.
+ * the `wsToken` embedded in the HMR client. Vite has moved that token between the served
+ * entry, a sibling `rolldown-runtime-*.js` chunk, and (as of vite ≥8.2.1) the standalone
+ * `/bundledDevClient.mjs` script loaded from the HTML.
  */
 export async function compileLazyChunk(
   server: DevServerHandle,
@@ -284,7 +285,19 @@ export async function compileLazyChunk(
     }
   }
   if (!wsToken) {
-    throw new Error('No wsToken found in the served entry chunk (or its rolldown-runtime sibling)')
+    // vite ≥8.2.1 serves the HMR client as its own `/bundledDevClient.mjs` module (linked
+    // from the HTML), keeping `wsToken` out of both the entry and the rolldown-runtime chunk.
+    try {
+      const bundledDevClient = await server.fetchText('/bundledDevClient.mjs')
+      wsToken = extractWsToken(bundledDevClient)
+    } catch {
+      // Older Vite layouts don't serve this standalone client module.
+    }
+  }
+  if (!wsToken) {
+    throw new Error(
+      'No wsToken found in the served entry, its rolldown-runtime sibling, or /bundledDevClient.mjs',
+    )
   }
 
   const clientId = `integration-test-${Math.random().toString(36).slice(2)}`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the failing `Sanity Studio integration tests` job on `main` after the lockfile maintenance bump (#3270).

Vite `8.2.1` moved the HMR `wsToken` out of the bundled entry / `rolldown-runtime-*.js` sibling and into the standalone `/bundledDevClient.mjs` script loaded from the HTML. The `compileLazyChunk` helper still only looked in the entry and runtime chunk, so `test/bundled-dev.test.ts` failed with:

```
No wsToken found in the served entry chunk (or its rolldown-runtime sibling)
```

## Change

- Teach `compileLazyChunk` to fall back to `/bundledDevClient.mjs` when the token is missing from the older locations.
- Keep the fetch soft-failing so older Vite layouts that don't serve that module still get the existing clear error.

## Test plan

- [x] `pnpm exec vitest run test/bundled-dev.test.ts` in `integration/vanilla-extract-studio`
- [x] `pnpm integration:test` (13/13 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfca964c-2573-40a8-b6ba-aded23e072e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfca964c-2573-40a8-b6ba-aded23e072e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

