### PR TITLE
chore(deps): bump @sanity/ui to ^4.0.1

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -48,12 +48,6 @@
     {
       "matchPackageNames": ["@typescript/native-preview"],
       "followTag": "beta"
-    },
-    {
-      "description": "The vanilla-extract playground exercises the `@sanity/ui` static channel (`@sanity/ui/css`), which is published under the `static` dist-tag and is not the same line as `latest`",
-      "matchFileNames": ["playground/sanity-plugin-with-vanilla-extract/package.json"],
-      "matchPackageNames": ["@sanity/ui"],
-      "followTag": "static"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -48,6 +48,12 @@
     {
       "matchPackageNames": ["@typescript/native-preview"],
       "followTag": "beta"
+    },
+    {
+      "description": "The vanilla-extract playground exercises the `@sanity/ui` static channel (`@sanity/ui/css`), which is published under the `static` dist-tag and is not the same line as `latest`",
+      "matchFileNames": ["playground/sanity-plugin-with-vanilla-extract/package.json"],
+      "matchPackageNames": ["@sanity/ui"],
+      "followTag": "static"
     }
   ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -14,6 +14,7 @@
   },
   "rules": {
     "import/no-cycle": "error",
+    "import/no-unassigned-import": ["error", {"allow": ["**/*.css"]}],
     "oxc/no-barrel-file": "error",
     "eslint/no-console": ["warn", {"allow": ["warn", "error"]}],
     "react/react-in-jsx-scope": "off",

--- a/packages/@sanity/pkg-utils/test/__snapshots__/cli.test.ts.snap
+++ b/packages/@sanity/pkg-utils/test/__snapshots__/cli.test.ts.snap
@@ -719,11 +719,11 @@ export { ColorInput, colorInput };
 
 exports[`cli > should build \`sanity-plugin-with-vanilla-extract\` package > ./dist/ColorInput-[hash].js 1`] = `
 "import { c } from "react/compiler-runtime";
-import { Root, Stack, Text } from "@sanity/ui";
+import { Stack, Text } from "@sanity/ui";
 import { jsx, jsxs } from "react/jsx-runtime";
 var input = "_1n31tph0";
 function ColorInput(props) {
-	let $ = c(12), t0 = props.schemaType.options?.colorspace ?? "limited-srgb", t1 = props.schemaType.options?.alpha ? "true" : void 0, t2;
+	let $ = c(10), t0 = props.schemaType.options?.colorspace ?? "limited-srgb", t1 = props.schemaType.options?.alpha ? "true" : void 0, t2;
 	$[0] !== props.elementProps || $[1] !== t0 || $[2] !== t1 ? (t2 = /* @__PURE__ */ jsx("input", {
 		...props.elementProps,
 		type: "color",
@@ -732,38 +732,31 @@ function ColorInput(props) {
 		alpha: t1
 	}), $[0] = props.elementProps, $[1] = t0, $[2] = t1, $[3] = t2) : t2 = $[3];
 	let t3;
-	$[4] === props.value ? t3 = $[5] : (t3 = /* @__PURE__ */ jsx(Text, {
+	$[4] !== props.elementProps.id || $[5] !== props.value ? (t3 = /* @__PURE__ */ jsx(Text, {
+		as: "output",
 		muted: !0,
 		size: 0,
-		children: props.value
-	}), $[4] = props.value, $[5] = t3);
-	let t4;
-	$[6] !== props.elementProps.id || $[7] !== t3 ? (t4 = /* @__PURE__ */ jsx("output", {
 		htmlFor: props.elementProps.id,
-		children: t3
-	}), $[6] = props.elementProps.id, $[7] = t3, $[8] = t4) : t4 = $[8];
-	let t5;
-	return $[9] !== t2 || $[10] !== t4 ? (t5 = /* @__PURE__ */ jsx(Root, {
-		as: "div",
-		overflow: "visible",
-		children: /* @__PURE__ */ jsxs(Stack, {
-			gap: 2,
-			children: [t2, t4]
-		})
-	}), $[9] = t2, $[10] = t4, $[11] = t5) : t5 = $[11], t5;
+		children: props.value
+	}), $[4] = props.elementProps.id, $[5] = props.value, $[6] = t3) : t3 = $[6];
+	let t4;
+	return $[7] !== t2 || $[8] !== t3 ? (t4 = /* @__PURE__ */ jsxs(Stack, {
+		gap: 2,
+		children: [t2, t3]
+	}), $[7] = t2, $[8] = t3, $[9] = t4) : t4 = $[9], t4;
 }
 export { ColorInput as default };
 
-//# sourceMappingURL=ColorInput-rhEnzAiP.js.map"
+//# sourceMappingURL=ColorInput-C7Xco6IZ.js.map"
 `;
 
 exports[`cli > should build \`sanity-plugin-with-vanilla-extract\` package > ./dist/bundle.css 1`] = `
-"._1n31tph0{cursor:pointer;box-sizing:border-box;background:var(--ui-4cxy8h24v);appearance:none;border:0 solid #0000;border-radius:2px;width:8ch;height:1.6rem;margin:0;padding:0;overflow:clip}._1n31tph0:hover{box-shadow:0 0 0 2px var(--ui-4cxy8h26u)}._1n31tph0::-webkit-color-swatch-wrapper{padding:0}._1n31tph0::-webkit-color-swatch{box-shadow:inset 0 0 0 1px var(--ui-4cxy8h25y);border:0 solid #0000;border-radius:2px;padding:0}._1n31tph0::-moz-color-swatch{box-shadow:inset 0 0 0 1px var(--ui-4cxy8h25y);border:0 solid #0000;border-radius:2px;padding:0}@supports (color:rgb(from white r g b / 20%)){._1n31tph0::-webkit-color-swatch{box-shadow:inset 0 0 0 1px rgb(from var(--ui-4cxy8h25y) r g b / 20%)}._1n31tph0::-moz-color-swatch{box-shadow:inset 0 0 0 1px rgb(from var(--ui-4cxy8h25y) r g b / 20%)}}
+"._1n31tph0{cursor:pointer;box-sizing:border-box;background:var(--card-border-color);appearance:none;border:0 solid #0000;border-radius:2px;width:8ch;height:1.6rem;margin:0;padding:0;overflow:clip}._1n31tph0:hover{box-shadow:0 0 0 2px var(--card-focus-ring-color)}._1n31tph0::-webkit-color-swatch-wrapper{padding:0}._1n31tph0::-webkit-color-swatch{box-shadow:inset 0 0 0 1px var(--card-fg-color);border:0 solid #0000;border-radius:2px;padding:0}._1n31tph0::-moz-color-swatch{box-shadow:inset 0 0 0 1px var(--card-fg-color);border:0 solid #0000;border-radius:2px;padding:0}@supports (color:rgb(from white r g b / 20%)){._1n31tph0::-webkit-color-swatch{box-shadow:inset 0 0 0 1px rgb(from var(--card-fg-color) r g b / 20%)}._1n31tph0::-moz-color-swatch{box-shadow:inset 0 0 0 1px rgb(from var(--card-fg-color) r g b / 20%)}}
 "
 `;
 
 exports[`cli > should build \`sanity-plugin-with-vanilla-extract\` package > ./dist/index.d.ts 1`] = `
-"import "@sanity/ui/css/index.css";
+"import "@sanity/ui/styles.css";
 import { Plugin, StringDefinition, StringInputProps, StringSchemaType } from "sanity";
 interface ColorOptions {
   alpha?: boolean;
@@ -796,11 +789,11 @@ export { type ColorDefinition, ColorInput, colorInput };
 
 exports[`cli > should build \`sanity-plugin-with-vanilla-extract\` package > ./dist/index.js 1`] = `
 "import "sanity-plugin-with-vanilla-extract/bundle.css";
-import "@sanity/ui/css/index.css";
+import "@sanity/ui/styles.css";
 import { definePlugin, defineType } from "sanity";
 import { lazy } from "react";
 /** @public */
-const ColorInput = lazy(() => import("./ColorInput-rhEnzAiP.js")), colorType = defineType({
+const ColorInput = lazy(() => import("./ColorInput-C7Xco6IZ.js")), colorType = defineType({
 	name: "color",
 	type: "string",
 	title: "Color",

--- a/packages/@sanity/pkg-utils/test/__snapshots__/cli.test.ts.snap
+++ b/packages/@sanity/pkg-utils/test/__snapshots__/cli.test.ts.snap
@@ -638,7 +638,7 @@ import { styled } from "styled-components";
 import { jsx, jsxs } from "react/jsx-runtime";
 const CustomTextInput = styled.input.attrs({ type: "color" }).withConfig({
 	displayName: "CustomTextInput",
-	componentId: "sc-ijy29k-0"
+	componentId: "sc-3mv8r8-0"
 })\`cursor:pointer;box-sizing:border-box;background:var(--card-border-color);border:0 solid transparent;border-radius:2px;padding:0;appearance:none;margin:0;height:1.6rem;width:8ch;&:hover{box-shadow:0 0 0 2px \${({ theme }) => theme.sanity.color.card.hovered.border};}&::-webkit-color-swatch-wrapper{padding:0;}&::-webkit-color-swatch{padding:0;border:0 solid transparent;border-radius:2px;box-shadow:inset 0 0 0 1px \${({ theme }) => theme.sanity.color.card.enabled.fg};@supports (color:rgb(from white r g b / 20%)){box-shadow:inset 0 0 0 1px rgb(from \${({ theme }) => theme.sanity.color.card.enabled.fg} r g b / 20%);}}&::-moz-color-swatch{padding:0;border:0 solid transparent;border-radius:2px;box-shadow:inset 0 0 0 1px \${({ theme }) => theme.sanity.color.card.enabled.fg};@supports (color:rgb(from white r g b / 20%)){box-shadow:inset 0 0 0 1px rgb(from \${({ theme }) => theme.sanity.color.card.enabled.fg} r g b / 20%);}}\`;
 function ColorInput(props) {
 	let $ = c(10), t0 = props.schemaType.options?.colorspace ?? "limited-srgb", t1 = props.schemaType.options?.alpha ? "true" : void 0, t2;
@@ -657,17 +657,18 @@ function ColorInput(props) {
 	}), $[4] = props.elementProps.id, $[5] = props.value, $[6] = t3) : t3 = $[6];
 	let t4;
 	return $[7] !== t2 || $[8] !== t3 ? (t4 = /* @__PURE__ */ jsxs(Stack, {
-		space: 2,
+		gap: 2,
 		children: [t2, t3]
 	}), $[7] = t2, $[8] = t3, $[9] = t4) : t4 = $[9], t4;
 }
 export { ColorInput as default };
 
-//# sourceMappingURL=ColorInput-3kj391ks.js.map"
+//# sourceMappingURL=ColorInput-jwKTnvie.js.map"
 `;
 
 exports[`cli > should build \`sanity-plugin-with-styled-components\` package > ./dist/index.d.ts 1`] = `
-"import { Plugin, StringDefinition, StringInputProps, StringSchemaType } from "sanity";
+"import "@sanity/ui/styles.css";
+import { Plugin, StringDefinition, StringInputProps, StringSchemaType } from "sanity";
 interface ColorOptions {
   alpha?: boolean;
   colorspace?: 'limited-srgb' | 'display-p3';
@@ -698,10 +699,11 @@ export { type ColorDefinition, ColorInput, colorInput };
 `;
 
 exports[`cli > should build \`sanity-plugin-with-styled-components\` package > ./dist/index.js 1`] = `
-"import { definePlugin, defineType } from "sanity";
+"import "@sanity/ui/styles.css";
+import { definePlugin, defineType } from "sanity";
 import { lazy } from "react";
 /** @public */
-const ColorInput = lazy(() => import("./ColorInput-3kj391ks.js")), colorType = defineType({
+const ColorInput = lazy(() => import("./ColorInput-jwKTnvie.js")), colorType = defineType({
 	name: "color",
 	type: "string",
 	title: "Color",

--- a/packages/@sanity/pkg-utils/test/cli.test.ts
+++ b/packages/@sanity/pkg-utils/test/cli.test.ts
@@ -664,7 +664,7 @@ describe.skipIf(process.platform === 'win32')('cli', () => {
     expect(distChunksColorInput).not.toContain('border:')
     expect(distBundleCss).toContain('border:')
     // The CSS side effectful imports should remain
-    expect(distIndexJs).toContain(`import "@sanity/ui/css/index.css"`)
+    expect(distIndexJs).toContain(`import "@sanity/ui/styles.css"`)
     // `vanillaExtract` compat mode injects the self-referential bundle.css import automatically
     expect(distIndexJs).toContain(`import "sanity-plugin-with-vanilla-extract/bundle.css"`)
     // …emits a no-op JS shim for CSS-unaware runtimes (named `bundle-css.js`, not

--- a/playground/css-import/src/index.ts
+++ b/playground/css-import/src/index.ts
@@ -1,4 +1,3 @@
-// oxlint-disable-next-line no-unassigned-import
 import './button.css'
 
 /**

--- a/playground/sanity-plugin-with-styled-components/package.json
+++ b/playground/sanity-plugin-with-styled-components/package.json
@@ -26,7 +26,7 @@
   },
   "browserslist": "extends @sanity/browserslist-config",
   "dependencies": {
-    "@sanity/ui": "^3.5.2",
+    "@sanity/ui": "^4.0.1",
     "react-compiler-runtime": "^1.0.0"
   },
   "devDependencies": {

--- a/playground/sanity-plugin-with-styled-components/src/ColorInput.tsx
+++ b/playground/sanity-plugin-with-styled-components/src/ColorInput.tsx
@@ -49,7 +49,7 @@ const CustomTextInput = styled.input.attrs({type: 'color'})`
 
 export default function ColorInput(props: ColorInputProps): React.JSX.Element {
   return (
-    <Stack space={2}>
+    <Stack gap={2}>
       <CustomTextInput
         {...props.elementProps}
         // @ts-expect-error - these are valid in Safari 18.4 and later

--- a/playground/sanity-plugin-with-styled-components/src/index.ts
+++ b/playground/sanity-plugin-with-styled-components/src/index.ts
@@ -1,3 +1,5 @@
+// oxlint-disable-next-line no-unassigned-import
+import '@sanity/ui/styles.css'
 import {definePlugin, type Plugin} from 'sanity'
 import {colorType} from './schema'
 

--- a/playground/sanity-plugin-with-styled-components/src/index.ts
+++ b/playground/sanity-plugin-with-styled-components/src/index.ts
@@ -1,4 +1,3 @@
-// oxlint-disable-next-line no-unassigned-import
 import '@sanity/ui/styles.css'
 import {definePlugin, type Plugin} from 'sanity'
 import {colorType} from './schema'

--- a/playground/sanity-plugin-with-vanilla-extract/package.json
+++ b/playground/sanity-plugin-with-vanilla-extract/package.json
@@ -33,7 +33,7 @@
   },
   "browserslist": "extends @sanity/browserslist-config",
   "dependencies": {
-    "@sanity/ui": "4.0.0-static.46"
+    "@sanity/ui": "4.0.1"
   },
   "devDependencies": {
     "@types/react": "^19.2.18",

--- a/playground/sanity-plugin-with-vanilla-extract/package.json
+++ b/playground/sanity-plugin-with-vanilla-extract/package.json
@@ -33,7 +33,7 @@
   },
   "browserslist": "extends @sanity/browserslist-config",
   "dependencies": {
-    "@sanity/ui": "4.0.1"
+    "@sanity/ui": "^4.0.1"
   },
   "devDependencies": {
     "@types/react": "^19.2.18",

--- a/playground/sanity-plugin-with-vanilla-extract/src/ColorInput.tsx
+++ b/playground/sanity-plugin-with-vanilla-extract/src/ColorInput.tsx
@@ -1,25 +1,21 @@
-import {Root, Stack, Text} from '@sanity/ui'
+import {Stack, Text} from '@sanity/ui'
 import {input} from './styles.css'
 import type {ColorInputProps} from './types'
 
 export default function ColorInput(props: ColorInputProps): React.JSX.Element {
   return (
-    <Root as="div" overflow="visible">
-      <Stack gap={2}>
-        <input
-          {...props.elementProps}
-          type="color"
-          className={input}
-          // @ts-expect-error - these are valid in Safari 18.4 and later
-          colorspace={props.schemaType.options?.colorspace ?? 'limited-srgb'}
-          alpha={props.schemaType.options?.alpha ? 'true' : undefined}
-        />
-        <output htmlFor={props.elementProps.id}>
-          <Text muted size={0}>
-            {props.value}
-          </Text>
-        </output>
-      </Stack>
-    </Root>
+    <Stack gap={2}>
+      <input
+        {...props.elementProps}
+        type="color"
+        className={input}
+        // @ts-expect-error - these are valid in Safari 18.4 and later
+        colorspace={props.schemaType.options?.colorspace ?? 'limited-srgb'}
+        alpha={props.schemaType.options?.alpha ? 'true' : undefined}
+      />
+      <Text as="output" muted size={0} htmlFor={props.elementProps.id}>
+        {props.value}
+      </Text>
+    </Stack>
   )
 }

--- a/playground/sanity-plugin-with-vanilla-extract/src/index.ts
+++ b/playground/sanity-plugin-with-vanilla-extract/src/index.ts
@@ -1,5 +1,5 @@
 // oxlint-disable-next-line no-unassigned-import
-import '@sanity/ui/css/index.css'
+import '@sanity/ui/styles.css'
 import {definePlugin, type Plugin} from 'sanity'
 import {colorType} from './schema'
 

--- a/playground/sanity-plugin-with-vanilla-extract/src/index.ts
+++ b/playground/sanity-plugin-with-vanilla-extract/src/index.ts
@@ -1,4 +1,3 @@
-// oxlint-disable-next-line no-unassigned-import
 import '@sanity/ui/styles.css'
 import {definePlugin, type Plugin} from 'sanity'
 import {colorType} from './schema'

--- a/playground/sanity-plugin-with-vanilla-extract/src/styles.css.ts
+++ b/playground/sanity-plugin-with-vanilla-extract/src/styles.css.ts
@@ -1,10 +1,9 @@
-import {vars} from '@sanity/ui/css'
 import {style} from '@vanilla-extract/css'
 
 export const input = style({
   'cursor': 'pointer',
   'boxSizing': 'border-box',
-  'background': vars.color.border,
+  'background': 'var(--card-border-color)',
   'border': '0 solid transparent',
   'borderRadius': '2px',
   'padding': '0',
@@ -15,7 +14,7 @@ export const input = style({
   'width': '8ch',
 
   ':hover': {
-    boxShadow: `0 0 0 2px ${vars.color.tinted.default.border[3]}`,
+    boxShadow: '0 0 0 2px var(--card-focus-ring-color)',
   },
 
   'selectors': {
@@ -26,10 +25,10 @@ export const input = style({
       'padding': '0',
       'border': '0 solid transparent',
       'borderRadius': '2px',
-      'boxShadow': `inset 0 0 0 1px ${vars.color.fg}`,
+      'boxShadow': 'inset 0 0 0 1px var(--card-fg-color)',
       '@supports': {
         '(color: rgb(from white r g b / 20%))': {
-          boxShadow: `inset 0 0 0 1px rgb(from ${vars.color.fg} r g b / 20%)`,
+          boxShadow: 'inset 0 0 0 1px rgb(from var(--card-fg-color) r g b / 20%)',
         },
       },
     },
@@ -37,10 +36,10 @@ export const input = style({
       'padding': '0',
       'border': '0 solid transparent',
       'borderRadius': '2px',
-      'boxShadow': `inset 0 0 0 1px ${vars.color.fg}`,
+      'boxShadow': 'inset 0 0 0 1px var(--card-fg-color)',
       '@supports': {
         '(color: rgb(from white r g b / 20%))': {
-          boxShadow: `inset 0 0 0 1px rgb(from ${vars.color.fg} r g b / 20%)`,
+          boxShadow: 'inset 0 0 0 1px rgb(from var(--card-fg-color) r g b / 20%)',
         },
       },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,7 +310,7 @@ importers:
         version: link:../sanity-css-vanilla-extract-test
       tap:
         specifier: ^21.7.5
-        version: 21.7.5(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+        version: 21.7.5(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1276,8 +1276,8 @@ importers:
   playground/sanity-plugin-with-styled-components:
     dependencies:
       '@sanity/ui':
-        specifier: ^3.5.2
-        version: 3.5.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+        specifier: ^4.0.1
+        version: 4.0.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       react-compiler-runtime:
         specifier: ^1.0.0
         version: 1.0.0(react@19.2.8)
@@ -6361,6 +6361,14 @@ packages:
       react: ^19.2
       react-dom: ^19.2
       react-is: ^19.2
+
+  '@sanity/ui@4.0.1':
+    resolution: {integrity: sha512-OjsUCrI75fqhRHFljHUVQbddaDfVj3z1IJhbNImeZFguYyWEUTtf5N4j7S1mR9B9rbeZ0mx9QRyVg8YfriIaRA==}
+    engines: {node: '>=22.12'}
+    peerDependencies:
+      react: ^19.2
+      react-dom: ^19.2
+      styled-components: ^6.1
 
   '@sanity/util@6.9.1':
     resolution: {integrity: sha512-MYyqbWPPcUebA+GRStZqCYSMfi8PghWCO07SurL9CqpjHf0YVOfmRbY8mY9X9Quqyo5TlnDOkEAFpSuOSeXC+g==}
@@ -16595,14 +16603,14 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@5.9.3)':
+  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(typescript@5.9.3)':
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node14': 14.1.8
       '@tsconfig/node16': 16.1.8
       '@tsconfig/node18': 18.2.6
       '@tsconfig/node20': 20.1.9
-      '@types/node': 24.13.3
+      '@types/node': 26.2.0
       acorn: 8.18.0
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -16613,14 +16621,14 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.47(@swc/helpers@0.5.23)
 
-  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@6.0.3)':
+  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(typescript@6.0.3)':
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node14': 14.1.8
       '@tsconfig/node16': 16.1.8
       '@tsconfig/node18': 18.2.6
       '@tsconfig/node20': 20.1.9
-      '@types/node': 24.13.3
+      '@types/node': 26.2.0
       acorn: 8.18.0
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -20654,6 +20662,20 @@ snapshots:
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
 
+  '@sanity/ui@4.0.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@sanity/color': 3.0.8
+      '@sanity/icons': 5.2.1(react@19.2.8)
+      csstype: 3.2.3
+      motion: 13.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-is: 19.2.8
+      react-refractor: 4.0.0(react@19.2.8)
+      styled-components: 6.5.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      use-effect-event: 2.0.3(react@19.2.8)
+
   '@sanity/util@6.9.1(@types/react@19.2.18)':
     dependencies:
       '@date-fns/tz': 1.5.0
@@ -21207,19 +21229,19 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.162.0': {}
 
-  '@tapjs/after-each@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/after-each@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       function-loop: 4.0.0
 
-  '@tapjs/after@3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/after@3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       is-actual-promise: 1.0.2
 
-  '@tapjs/asserts@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tapjs/asserts@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tapjs/stack': 4.3.3
       is-actual-promise: 1.0.2
       tcompare: 9.3.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -21228,35 +21250,35 @@ snapshots:
       - react
       - react-dom
 
-  '@tapjs/before-each@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/before-each@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       function-loop: 4.0.0
 
-  '@tapjs/before@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/before@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       is-actual-promise: 1.0.2
 
-  '@tapjs/chdir@3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/chdir@3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
-  '@tapjs/config@5.6.5(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/config@5.6.5(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/test': 4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/test': 4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       chalk: 5.6.2
       jackspeak: 4.2.3
       polite-json: 5.0.0
       tap-yaml: 4.4.2
       walk-up-path: 4.0.0
 
-  '@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tapjs/processinfo': 3.1.12
       '@tapjs/stack': 4.3.3
-      '@tapjs/test': 4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/test': 4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       async-hook-domain: 4.0.1
       diff: 8.0.4
       is-actual-promise: 1.0.2
@@ -21277,33 +21299,33 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@tapjs/filter@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/filter@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
-  '@tapjs/fixture@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/fixture@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       mkdirp: 3.0.1
       rimraf: 6.1.3
 
-  '@tapjs/intercept@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/intercept@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/after': 3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/after': 3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tapjs/stack': 4.3.3
 
-  '@tapjs/mock@4.4.9(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/mock@4.4.9(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/after': 3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/after': 3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tapjs/stack': 4.3.3
       resolve-import: 2.4.0
       walk-up-path: 4.0.0
 
-  '@tapjs/node-serialize@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/node-serialize@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tapjs/error-serdes': 4.3.2
       '@tapjs/stack': 4.3.3
       tap-parser: 18.3.4
@@ -21316,10 +21338,10 @@ snapshots:
       signal-exit: 4.1.0
       uuid: 14.0.1
 
-  '@tapjs/reporter@4.4.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))':
+  '@tapjs/reporter@4.4.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))':
     dependencies:
-      '@tapjs/config': 5.6.5(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/config': 5.6.5(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tapjs/stack': 4.3.3
       chalk: 5.6.2
       ink: 5.2.1(@types/react@19.2.18)(react@18.3.1)
@@ -21340,18 +21362,18 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  '@tapjs/run@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tapjs/run@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.2.0)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@isaacs/which': 7.0.4
-      '@tapjs/after': 3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/before': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/config': 5.6.5(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/after': 3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/before': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/config': 5.6.5(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tapjs/processinfo': 3.1.12
-      '@tapjs/reporter': 4.4.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))
-      '@tapjs/spawn': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/stdin': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/test': 4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/reporter': 4.4.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tapjs/test@4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))
+      '@tapjs/spawn': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/stdin': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/test': 4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       c8: 12.0.0
       chalk: 5.6.2
       chokidar: 4.0.3
@@ -21384,9 +21406,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@tapjs/snapshot@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tapjs/snapshot@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       is-actual-promise: 1.0.2
       tcompare: 9.3.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       trivial-deferred: 2.0.0
@@ -21394,36 +21416,36 @@ snapshots:
       - react
       - react-dom
 
-  '@tapjs/spawn@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/spawn@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   '@tapjs/stack@4.3.3': {}
 
-  '@tapjs/stdin@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/stdin@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
-  '@tapjs/test@4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tapjs/test@4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@5.9.3)
-      '@tapjs/after': 3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/after-each': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/asserts': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/before': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/before-each': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/chdir': 3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/filter': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/fixture': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/intercept': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/mock': 4.4.9(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/node-serialize': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/snapshot': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/spawn': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/stdin': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/typescript': 3.5.11(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(typescript@5.9.3)
-      '@tapjs/worker': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(typescript@5.9.3)
+      '@tapjs/after': 3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/after-each': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/asserts': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/before': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/before-each': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/chdir': 3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/filter': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/fixture': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/intercept': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/mock': 4.4.9(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/node-serialize': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/snapshot': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/spawn': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/stdin': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/typescript': 3.5.11(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.2.0)(typescript@5.9.3)
+      '@tapjs/worker': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       glob: 13.0.6
       jackspeak: 4.2.3
       mkdirp: 3.0.1
@@ -21442,29 +21464,29 @@ snapshots:
       - react
       - react-dom
 
-  '@tapjs/typescript@3.5.11(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(typescript@5.9.3)':
+  '@tapjs/typescript@3.5.11(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.2.0)(typescript@5.9.3)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@5.9.3)
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(typescript@5.9.3)
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
       - typescript
 
-  '@tapjs/typescript@3.5.11(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(typescript@6.0.3)':
+  '@tapjs/typescript@3.5.11(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.2.0)(typescript@6.0.3)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(typescript@6.0.3)
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(typescript@6.0.3)
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
       - typescript
 
-  '@tapjs/worker@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@tapjs/worker@4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   '@tsconfig/node14@14.1.8': {}
 
@@ -28802,27 +28824,27 @@ snapshots:
       yaml: 2.9.0
       yaml-types: 0.4.0(yaml@2.9.0)
 
-  tap@21.7.5(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3):
+  tap@21.7.5(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3):
     dependencies:
-      '@tapjs/after': 3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/after-each': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/asserts': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/before': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/before-each': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/chdir': 3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/filter': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/fixture': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/intercept': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/mock': 4.4.9(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/node-serialize': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/run': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/snapshot': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/spawn': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/stdin': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@tapjs/test': 4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tapjs/typescript': 3.5.11(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@24.13.3)(typescript@6.0.3)
-      '@tapjs/worker': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/after': 3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/after-each': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/asserts': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/before': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/before-each': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/chdir': 3.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/core': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/filter': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/fixture': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/intercept': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/mock': 4.4.9(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/node-serialize': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/run': 4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.2.0)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/snapshot': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/spawn': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/stdin': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@tapjs/test': 4.4.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tapjs/typescript': 3.5.11(@swc/core@1.15.47(@swc/helpers@0.5.23))(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/node@26.2.0)(typescript@6.0.3)
+      '@tapjs/worker': 4.3.11(@tapjs/core@4.5.9(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       resolve-import: 2.4.0
     transitivePeerDependencies:
       - '@swc/core'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1310,8 +1310,8 @@ importers:
   playground/sanity-plugin-with-vanilla-extract:
     dependencies:
       '@sanity/ui':
-        specifier: 4.0.0-static.46
-        version: 4.0.0-static.46(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8(react@19.2.8))(react-is@19.2.8)(react@19.2.8)
+        specifier: 4.0.1
+        version: 4.0.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
     devDependencies:
       '@types/react':
         specifier: ^19.2.18
@@ -6354,14 +6354,6 @@ packages:
       react-dom: ^18 || >=19.0.0-0
       styled-components: ^5.2 || ^6
 
-  '@sanity/ui@4.0.0-static.46':
-    resolution: {integrity: sha512-WfgA6HpXPM7X3GOceb8i8MLNkwkRe4rSQ7/Pc33YER/icAjAqPLo9pcLv5a4t96Sxjt2r5W4zmYLjzxco/+KDA==}
-    engines: {node: '>=20.19 <22 || >=22.12'}
-    peerDependencies:
-      react: ^19.2
-      react-dom: ^19.2
-      react-is: ^19.2
-
   '@sanity/ui@4.0.1':
     resolution: {integrity: sha512-OjsUCrI75fqhRHFljHUVQbddaDfVj3z1IJhbNImeZFguYyWEUTtf5N4j7S1mR9B9rbeZ0mx9QRyVg8YfriIaRA==}
     engines: {node: '>=22.12'}
@@ -7500,9 +7492,6 @@ packages:
 
   '@vanilla-extract/css@1.21.2':
     resolution: {integrity: sha512-ehF/tmv2MxQwOJB1DicALUqnjZTnmY9Y7J2ccKB578JzZpYeL6sLAUqbaXo1taw1Erp0qBq0I4Kejs0uU/pBfg==}
-
-  '@vanilla-extract/dynamic@2.1.5':
-    resolution: {integrity: sha512-QGIFGb1qyXQkbzx6X6i3+3LMc/iv/ZMBttMBL+Wm/DetQd36KsKsFg5CtH3qy+1hCA/5w93mEIIAiL4fkM8ycw==}
 
   '@vanilla-extract/integration@8.0.10':
     resolution: {integrity: sha512-01IB5gbrgTe8IIrtfRXXTmACl5D8Enzqp2cKbCWaMKXmnoilXXVCPbJoA96q88PXkNDXsXepCxUugMvEmL3c7A==}
@@ -20646,22 +20635,6 @@ snapshots:
       styled-components: 6.5.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       use-effect-event: 2.0.3(react@19.2.8)
 
-  '@sanity/ui@4.0.0-static.46(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8(react@19.2.8))(react-is@19.2.8)(react@19.2.8)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@juggle/resize-observer': 3.4.0
-      '@sanity/color': 3.0.8
-      '@sanity/icons': 3.8.0(react@19.2.8)
-      '@vanilla-extract/dynamic': 2.1.5
-      csstype: 3.2.3
-      motion: 12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-is: 19.2.8
-      react-refractor: 4.0.0(react@19.2.8)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-
   '@sanity/ui@4.0.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
       '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -22030,10 +22003,6 @@ snapshots:
       picocolors: 1.1.1
     transitivePeerDependencies:
       - babel-plugin-macros
-
-  '@vanilla-extract/dynamic@2.1.5':
-    dependencies:
-      '@vanilla-extract/private': 1.0.9
 
   '@vanilla-extract/integration@8.0.10':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1310,7 +1310,7 @@ importers:
   playground/sanity-plugin-with-vanilla-extract:
     dependencies:
       '@sanity/ui':
-        specifier: 4.0.1
+        specifier: ^4.0.1
         version: 4.0.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
     devDependencies:
       '@types/react':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,7 @@ minimumReleaseAge: 1440
 # a release fresher than the gate.
 minimumReleaseAgeExclude:
   - '@tsdown/css@0.22.14'
+  - '@sanity/ui@4.0.1'
   - '@sanity/diff@6.9.1'
   - '@sanity/mutator@6.9.1'
   - '@sanity/schema@6.9.1'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Supersedes #3275 (Renovate could not refresh the lockfile because `@sanity/ui@4.0.1` is newer than the workspace `minimumReleaseAge`).

## Changes
- Bump `playground/sanity-plugin-with-styled-components` from `@sanity/ui@^3.5.2` → `^4.0.1`
- Bump `playground/sanity-plugin-with-vanilla-extract` from `4.0.0-static.46` → `4.0.1`
- Apply the v3→v4 migration: `Stack` `space` → `gap`, import `@sanity/ui/styles.css`, drop the retired `@sanity/ui/css` / `Root` surface in the vanilla-extract fixture (use card CSS variables instead)
- Age-exclude `@sanity/ui@4.0.1` in `pnpm-workspace.yaml` so `pnpm install` can resolve the fresh release
- Allow side-effect CSS imports in oxlint (`import/no-unassigned-import` with `allow: ["**/*.css"]`) and drop the redundant suppressions
- Update CLI build snapshots for both playgrounds

## Verification
- `pnpm --filter sanity-plugin-with-styled-components build` + `typecheck`
- `pnpm --filter sanity-plugin-with-vanilla-extract build` + `typecheck`
- `vitest` CLI tests for both playgrounds
- `pnpm lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-065a9418-2b16-44ac-b8c9-4e31ae4914e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-065a9418-2b16-44ac-b8c9-4e31ae4914e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

