### PR TITLE
fix: preserve namespace re-export release tags

### DIFF
--- a/.changeset/preserve-namespace-release-tags.md
+++ b/.changeset/preserve-namespace-release-tags.md
@@ -2,4 +2,4 @@
 '@sanity/tsdown-config': patch
 ---
 
-Preserve an explicit TSDoc release tag on `export * as namespace` declarations when bundling types, so API Extractor no longer reports the generated `<module>_d_exports` namespace as untagged.
+Preserve an explicit TSDoc release tag on namespace re-exports when bundling types, so API Extractor no longer reports the generated `<module>_d_exports` namespace as untagged.

--- a/.changeset/preserve-namespace-release-tags.md
+++ b/.changeset/preserve-namespace-release-tags.md
@@ -1,0 +1,5 @@
+---
+'@sanity/tsdown-config': patch
+---
+
+Preserve an explicit TSDoc release tag on `export * as namespace` declarations when bundling types, so API Extractor no longer reports the generated `<module>_d_exports` namespace as untagged.

--- a/packages/@sanity/tsdown-config/package.json
+++ b/packages/@sanity/tsdown-config/package.json
@@ -53,6 +53,7 @@
     "browserslist": "^4.28.8",
     "jsonc-parser": "^3.3.1",
     "lightningcss": "catalog:",
+    "magic-string": "^1.1.0",
     "package-manager-detector": "^1.8.0",
     "publint": "^0.3.23"
   },

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -429,12 +429,12 @@ async function resolvePackageConfig(
   const report = {gzip: false} as const satisfies UserConfig['report']
   const format = options.format ?? 'esm'
   // rolldown-plugin-dts synthesizes `declare namespace <name>_d_exports` for namespace
-  // re-exports after the source comments have already been lost. This output plugin runs after
-  // that synthesis and restores an explicitly authored release tag on the generated namespace.
-  // It lives in `inputOptions.plugins` so tsdown also applies it to the separate CJS declaration
-  // pass, where top-level user plugins are intentionally skipped.
+  // re-exports after its transform has stripped the source comments. This companion plugin
+  // captures the comments first and restores an explicitly authored release tag after rendering.
+  // It is only installed for builds that run TSDoc validation, and lives in `inputOptions.plugins`
+  // so tsdown also applies it to the separate CJS declaration pass.
   const namespaceReleaseTags =
-    dts === false
+    dts === false || tsdoc === false
       ? undefined
       : (await import('./namespaceReleaseTagPlugin.ts')).namespaceReleaseTagPlugin()
   // When `platform` is `'neutral'`, restore the conventional `module`/`main` fallback that
@@ -443,7 +443,6 @@ async function resolvePackageConfig(
     // https://github.com/rolldown/rolldown/blob/main/packages/rolldown/src/options/docs/preserve-entry-signatures.md#strict
     preserveEntrySignatures: 'strict',
     experimental: {attachDebugInfo: 'none'},
-    ...(namespaceReleaseTags && {plugins: [namespaceReleaseTags]}),
     ...(platform === 'neutral' && {
       resolve: {mainFields: ['module', 'main']},
     }),
@@ -470,6 +469,7 @@ async function resolvePackageConfig(
         },
       },
     }),
+    ...(namespaceReleaseTags && {plugins: [namespaceReleaseTags]}),
   } satisfies UserConfig['inputOptions']
 
   // `neverBundle` is concatenated (not `mergeConfig`'d) so per-package externals add to the

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -428,12 +428,22 @@ async function resolvePackageConfig(
   const tsdoc = isReactServer ? false : (options.tsdoc ?? false)
   const report = {gzip: false} as const satisfies UserConfig['report']
   const format = options.format ?? 'esm'
+  // rolldown-plugin-dts synthesizes `declare namespace <name>_d_exports` for namespace
+  // re-exports after the source comments have already been lost. This output plugin runs after
+  // that synthesis and restores an explicitly authored release tag on the generated namespace.
+  // It lives in `inputOptions.plugins` so tsdown also applies it to the separate CJS declaration
+  // pass, where top-level user plugins are intentionally skipped.
+  const namespaceReleaseTags =
+    dts === false
+      ? undefined
+      : (await import('./namespaceReleaseTagPlugin.ts')).namespaceReleaseTagPlugin()
   // When `platform` is `'neutral'`, restore the conventional `module`/`main` fallback that
   // rolldown's strict neutral defaults drop - needed for inlined deps without an `exports` map.
   const inputOptions = {
     // https://github.com/rolldown/rolldown/blob/main/packages/rolldown/src/options/docs/preserve-entry-signatures.md#strict
     preserveEntrySignatures: 'strict',
     experimental: {attachDebugInfo: 'none'},
+    ...(namespaceReleaseTags && {plugins: [namespaceReleaseTags]}),
     ...(platform === 'neutral' && {
       resolve: {mainFields: ['module', 'main']},
     }),

--- a/packages/@sanity/tsdown-config/src/namespaceReleaseTagPlugin.ts
+++ b/packages/@sanity/tsdown-config/src/namespaceReleaseTagPlugin.ts
@@ -4,7 +4,7 @@ import type ts from '@typescript/typescript6'
 import type {Rolldown} from 'tsdown'
 
 const RE_DTS_FILE = /\.d\.(ts|mts|cts)$/
-const RE_NAMESPACE_EXPORT = /\bexport\s*\*\s*as\s+/
+const RE_NAMESPACE_REEXPORT = /\b(?:export\s+(?:type\s+)?\*\s*as|import\s+(?:type\s+)?\*\s*as)\s+/
 const RE_RELEASE_TAG = /@(alpha|beta|internal|public)\b/
 const RELEASE_TAGS = new Set(['alpha', 'beta', 'internal', 'public'])
 
@@ -18,9 +18,10 @@ interface EntrySource {
 
 /**
  * Restores release tags on the namespace declarations that rolldown-plugin-dts synthesizes for
- * `export * as name` declarations. The declaration plugin currently drops the source statement's
- * comments before its `patchTsNamespace` pass, leaving API Extractor to report an unfixable
- * `ae-missing-release-tag` error against the generated `<module>_d_exports` identifier.
+ * `export * as name` and `import * as name; export {name}` declarations. The declaration plugin
+ * currently drops the source statement's comments before its `patchTsNamespace` pass, leaving API
+ * Extractor to report an unfixable `ae-missing-release-tag` error against the generated
+ * `<module>_d_exports` identifier.
  *
  * @internal
  */
@@ -47,7 +48,7 @@ export function namespaceReleaseTagPlugin(): Rolldown.Plugin {
         const sourceText = await readFile(sourcePath, 'utf8').catch(() => undefined)
         if (
           sourceText === undefined ||
-          !RE_NAMESPACE_EXPORT.test(sourceText) ||
+          !RE_NAMESPACE_REEXPORT.test(sourceText) ||
           !RE_RELEASE_TAG.test(sourceText)
         ) {
           return undefined
@@ -139,17 +140,36 @@ function namespaceReleaseTagInsertions(
     true,
   )
   const tagsByExportName = new Map<string, ReleaseTag>()
+  const namespaceImports = new Map<string, ReleaseTag | undefined>()
 
   for (const statement of sourceFile.statements) {
-    if (
-      !typescript.isExportDeclaration(statement) ||
-      !statement.exportClause ||
-      !typescript.isNamespaceExport(statement.exportClause)
-    ) {
+    const namedBindings =
+      typescript.isImportDeclaration(statement) && statement.importClause?.namedBindings
+    if (!namedBindings || !typescript.isNamespaceImport(namedBindings)) continue
+    namespaceImports.set(namedBindings.name.text, getReleaseTag(typescript, statement))
+  }
+
+  for (const statement of sourceFile.statements) {
+    if (!typescript.isExportDeclaration(statement) || !statement.exportClause) continue
+
+    if (typescript.isNamespaceExport(statement.exportClause)) {
+      const releaseTag = getReleaseTag(typescript, statement)
+      if (releaseTag) tagsByExportName.set(statement.exportClause.name.text, releaseTag)
       continue
     }
-    const releaseTag = getReleaseTag(typescript, statement)
-    if (releaseTag) tagsByExportName.set(statement.exportClause.name.text, releaseTag)
+
+    if (statement.moduleSpecifier || !typescript.isNamedExports(statement.exportClause)) continue
+    const exportReleaseTag = getReleaseTag(typescript, statement)
+    for (const specifier of statement.exportClause.elements) {
+      const localName = specifier.propertyName?.text ?? specifier.name.text
+      if (!namespaceImports.has(localName)) continue
+      const importReleaseTag = namespaceImports.get(localName)
+      const releaseTag =
+        exportReleaseTag && importReleaseTag && exportReleaseTag !== importReleaseTag
+          ? undefined
+          : (exportReleaseTag ?? importReleaseTag)
+      if (releaseTag) tagsByExportName.set(specifier.name.text, releaseTag)
+    }
   }
   if (tagsByExportName.size === 0) return []
 

--- a/packages/@sanity/tsdown-config/src/namespaceReleaseTagPlugin.ts
+++ b/packages/@sanity/tsdown-config/src/namespaceReleaseTagPlugin.ts
@@ -1,0 +1,237 @@
+import {readFile} from 'node:fs/promises'
+import path from 'node:path'
+import type ts from '@typescript/typescript6'
+import type {Rolldown} from 'tsdown'
+
+const RE_DTS_FILE = /\.d\.(ts|mts|cts)$/
+const RE_NAMESPACE_EXPORT = /\bexport\s*\*\s*as\s+/
+const RE_RELEASE_TAG = /@(alpha|beta|internal|public)\b/
+const RELEASE_TAGS = new Set(['alpha', 'beta', 'internal', 'public'])
+
+type ReleaseTag = 'alpha' | 'beta' | 'internal' | 'public'
+
+interface EntrySource {
+  name?: string
+  sourcePath: string
+  declarationPath: string
+}
+
+/**
+ * Restores release tags on the namespace declarations that rolldown-plugin-dts synthesizes for
+ * `export * as name` declarations. The declaration plugin currently drops the source statement's
+ * comments before its `patchTsNamespace` pass, leaving API Extractor to report an unfixable
+ * `ae-missing-release-tag` error against the generated `<module>_d_exports` identifier.
+ *
+ * @internal
+ */
+export function namespaceReleaseTagPlugin(): Rolldown.Plugin {
+  let entrySources: EntrySource[] = []
+
+  return {
+    name: 'sanity-namespace-release-tags',
+
+    buildStart({cwd, input}) {
+      entrySources = Array.isArray(input)
+        ? input.map((sourcePath) => entrySource(cwd, sourcePath))
+        : Object.entries(input).map(([name, sourcePath]) => entrySource(cwd, sourcePath, name))
+    },
+
+    renderChunk: {
+      order: 'post',
+      async handler(code, chunk) {
+        if (!chunk.isEntry || !RE_DTS_FILE.test(chunk.fileName)) return undefined
+
+        const sourcePath = sourcePathForChunk(chunk, entrySources)
+        if (!sourcePath) return undefined
+
+        const sourceText = await readFile(sourcePath, 'utf8').catch(() => undefined)
+        if (
+          sourceText === undefined ||
+          !RE_NAMESPACE_EXPORT.test(sourceText) ||
+          !RE_RELEASE_TAG.test(sourceText)
+        ) {
+          return undefined
+        }
+        const {default: typescript} = await import('@typescript/typescript6')
+        const insertions = namespaceReleaseTagInsertions(
+          typescript,
+          sourcePath,
+          sourceText,
+          chunk.fileName,
+          code,
+        )
+        if (insertions.length === 0) return undefined
+
+        // Rolldown's native `meta.magicString` still represents the chunk from before an earlier
+        // renderChunk hook returned replacement code. rolldown-plugin-dts does exactly that, so
+        // create a map-producing editor over the current declaration text instead.
+        const {default: MagicString} = await import('magic-string')
+        const magicString = new MagicString(code)
+        for (const {position, tag} of insertions) {
+          magicString.prependLeft(position, `/** @${tag} */ `)
+        }
+        return {
+          code: magicString.toString(),
+          map: magicString.generateMap({hires: 'boundary', includeContent: true}),
+        }
+      },
+    },
+  }
+}
+
+function entrySource(cwd: string, sourcePath: string, name?: string): EntrySource {
+  const absolutePath = path.resolve(cwd, sourcePath)
+  return {
+    name,
+    sourcePath: absolutePath,
+    declarationPath: sourceToDeclarationPath(absolutePath),
+  }
+}
+
+function sourceToDeclarationPath(sourcePath: string): string {
+  if (RE_DTS_FILE.test(sourcePath)) return sourcePath
+  if (sourcePath.endsWith('.mts') || sourcePath.endsWith('.mjs')) {
+    return sourcePath.replace(/\.(mts|mjs)$/, '.d.mts')
+  }
+  if (sourcePath.endsWith('.cts') || sourcePath.endsWith('.cjs')) {
+    return sourcePath.replace(/\.(cts|cjs)$/, '.d.cts')
+  }
+  return sourcePath.replace(/\.(tsx?|jsx?)$/, '.d.ts')
+}
+
+function sourcePathForChunk(
+  chunk: Pick<Rolldown.RenderedChunk, 'facadeModuleId' | 'name'>,
+  entries: EntrySource[],
+): string | undefined {
+  const facadeModuleId = chunk.facadeModuleId && path.normalize(chunk.facadeModuleId)
+  if (facadeModuleId) {
+    const exact = entries.find(
+      ({declarationPath, sourcePath}) =>
+        path.normalize(declarationPath) === facadeModuleId ||
+        sourceStem(path.normalize(sourcePath)) === declarationStem(facadeModuleId),
+    )
+    if (exact) return exact.sourcePath
+  }
+
+  const entryName = chunk.name.endsWith('.d') ? chunk.name.slice(0, -2) : chunk.name
+  return entries.find(({name}) => name === entryName)?.sourcePath
+}
+
+function sourceStem(sourcePath: string): string {
+  return sourcePath.replace(/\.d\.[mc]?ts$/, '').replace(/\.(?:[mc]?[jt]sx?)$/, '')
+}
+
+function declarationStem(declarationPath: string): string {
+  return declarationPath.replace(/\.d\.[mc]?ts$/, '')
+}
+
+function namespaceReleaseTagInsertions(
+  typescript: typeof ts,
+  sourcePath: string,
+  sourceText: string,
+  declarationPath: string,
+  declarationText: string,
+): Array<{position: number; tag: ReleaseTag}> {
+  const sourceFile = typescript.createSourceFile(
+    sourcePath,
+    sourceText,
+    typescript.ScriptTarget.Latest,
+    true,
+  )
+  const tagsByExportName = new Map<string, ReleaseTag>()
+
+  for (const statement of sourceFile.statements) {
+    if (
+      !typescript.isExportDeclaration(statement) ||
+      !statement.exportClause ||
+      !typescript.isNamespaceExport(statement.exportClause)
+    ) {
+      continue
+    }
+    const releaseTag = getReleaseTag(typescript, statement)
+    if (releaseTag) tagsByExportName.set(statement.exportClause.name.text, releaseTag)
+  }
+  if (tagsByExportName.size === 0) return []
+
+  const declarationFile = typescript.createSourceFile(
+    declarationPath,
+    declarationText,
+    typescript.ScriptTarget.Latest,
+    true,
+  )
+  const namespaces = new Map<string, ts.ModuleDeclaration>()
+  for (const statement of declarationFile.statements) {
+    if (isSyntheticNamespace(typescript, statement)) {
+      namespaces.set(statement.name.text, statement)
+    }
+  }
+
+  const tagsByPosition = new Map<number, ReleaseTag>()
+  const conflictingPositions = new Set<number>()
+  for (const statement of declarationFile.statements) {
+    if (
+      !typescript.isExportDeclaration(statement) ||
+      statement.moduleSpecifier ||
+      !statement.exportClause ||
+      !typescript.isNamedExports(statement.exportClause)
+    ) {
+      continue
+    }
+
+    for (const specifier of statement.exportClause.elements) {
+      if (!specifier.propertyName) continue
+      const releaseTag = tagsByExportName.get(specifier.name.text)
+      const namespace = namespaces.get(specifier.propertyName.text)
+      if (!releaseTag || !namespace || getReleaseTag(typescript, namespace)) continue
+
+      const position = namespace.getStart(declarationFile)
+      const previousTag = tagsByPosition.get(position)
+      if (previousTag && previousTag !== releaseTag) {
+        conflictingPositions.add(position)
+      } else {
+        tagsByPosition.set(position, releaseTag)
+      }
+    }
+  }
+
+  return [...tagsByPosition]
+    .filter(([position]) => !conflictingPositions.has(position))
+    .map(([position, tag]) => ({position, tag}))
+    .toSorted((a, b) => b.position - a.position)
+}
+
+function isSyntheticNamespace(
+  typescript: typeof ts,
+  statement: ts.Statement,
+): statement is ts.ModuleDeclaration & {name: ts.Identifier; body: ts.ModuleBlock} {
+  if (
+    !typescript.isModuleDeclaration(statement) ||
+    !typescript.isIdentifier(statement.name) ||
+    !statement.name.text.endsWith('_exports') ||
+    !statement.modifiers?.some(({kind}) => kind === typescript.SyntaxKind.DeclareKeyword) ||
+    !statement.body ||
+    !typescript.isModuleBlock(statement.body) ||
+    statement.body.statements.length !== 1
+  ) {
+    return false
+  }
+
+  const [namespaceExport] = statement.body.statements
+  return (
+    !!namespaceExport &&
+    typescript.isExportDeclaration(namespaceExport) &&
+    !namespaceExport.moduleSpecifier &&
+    !!namespaceExport.exportClause &&
+    typescript.isNamedExports(namespaceExport.exportClause)
+  )
+}
+
+function getReleaseTag(typescript: typeof ts, node: ts.Node): ReleaseTag | undefined {
+  const tags = new Set(
+    typescript
+      .getJSDocTags(node)
+      .map(({tagName}) => tagName.text)
+      .filter((tag): tag is ReleaseTag => RELEASE_TAGS.has(tag)),
+  )
+  return tags.size === 1 ? tags.values().next().value : undefined
+}

--- a/packages/@sanity/tsdown-config/src/namespaceReleaseTagPlugin.ts
+++ b/packages/@sanity/tsdown-config/src/namespaceReleaseTagPlugin.ts
@@ -1,64 +1,134 @@
-import {readFile} from 'node:fs/promises'
-import path from 'node:path'
 import type ts from '@typescript/typescript6'
 import type {Rolldown} from 'tsdown'
 
-const RE_DTS_FILE = /\.d\.(ts|mts|cts)$/
+const RE_DTS_FILE = /\.d\.(?:ts|mts|cts)$/
+const RE_SYNTHETIC_NAMESPACE = /\bdeclare\s+namespace\s+\S+_exports\b/
 const RE_NAMESPACE_REEXPORT = /\b(?:export\s+(?:type\s+)?\*\s*as|import\s+(?:type\s+)?\*\s*as)\s+/
-const RE_RELEASE_TAG = /@(alpha|beta|internal|public)\b/
+const NAMESPACE_ALIAS_META = 'sanityNamespaceReleaseTags'
 const RELEASE_TAGS = new Set(['alpha', 'beta', 'internal', 'public'])
 
 type ReleaseTag = 'alpha' | 'beta' | 'internal' | 'public'
 
-interface EntrySource {
-  name?: string
-  sourcePath: string
-  declarationPath: string
+interface NamespaceAlias {
+  exportName: string
+  releaseTag: ReleaseTag | undefined
+  targetId: string
 }
+
+interface UnresolvedNamespaceAlias {
+  exportName: string
+  moduleSpecifier: string
+  releaseTag: ReleaseTag | undefined
+}
+
+type AliasesByTarget = Map<string, NamespaceAlias[]>
+type AliasesByDeclaration = Map<string, AliasesByTarget>
 
 /**
  * Restores release tags on the namespace declarations that rolldown-plugin-dts synthesizes for
- * `export * as name` and `import * as name; export {name}` declarations. The declaration plugin
- * currently drops the source statement's comments before its `patchTsNamespace` pass, leaving API
- * Extractor to report an unfixable `ae-missing-release-tag` error against the generated
- * `<module>_d_exports` identifier.
+ * `export * as name` and `import * as name; export {name}` declarations. A pre-transform sees
+ * each emitted declaration module while its source comments are still present and records only
+ * namespace aliases; the post-render hook matches those aliases to the generated wrappers.
  *
  * @internal
  */
 export function namespaceReleaseTagPlugin(): Rolldown.Plugin {
-  let entrySources: EntrySource[] = []
+  // `mergeConfig` deliberately reuses input plugin objects, including when tsdown starts its ESM
+  // and CJS declaration passes concurrently. Direct hook invocations (and Rollup-compatible
+  // hosts that preserve their context object) stay partitioned by context here. Rolldown creates
+  // a fresh JavaScript context wrapper for each hook call, so transform metadata is also stored
+  // on its build-local ModuleInfo below and recovered through the current render context.
+  const aliasesByContext = new WeakMap<Rolldown.PluginContext, AliasesByDeclaration>()
+  // Module IDs are only an index into build-local ModuleInfo metadata; no alias data lives here,
+  // so concurrent builds with identical IDs cannot overwrite one another.
+  const declarationIds = new Set<string>()
 
   return {
     name: 'sanity-namespace-release-tags',
 
-    buildStart({cwd, input}) {
-      entrySources = Array.isArray(input)
-        ? input.map((sourcePath) => entrySource(cwd, sourcePath))
-        : Object.entries(input).map(([name, sourcePath]) => entrySource(cwd, sourcePath, name))
+    transform: {
+      order: 'pre',
+      filter: {id: RE_DTS_FILE},
+      async handler(code, id) {
+        const declarationId = normalizeModuleId(id)
+
+        // Every ordinary declaration module stops here: no parser import, resolution, or graph read.
+        if (!RE_NAMESPACE_REEXPORT.test(code)) {
+          aliasesByContext.get(this)?.delete(declarationId)
+          return declarationIds.has(declarationId)
+            ? {meta: {[NAMESPACE_ALIAS_META]: undefined}}
+            : undefined
+        }
+
+        const {default: typescript} = await import('@typescript/typescript6')
+        const unresolvedAliases = collectNamespaceAliases(typescript, id, code)
+        const targetIds = new Map<string, Promise<string | undefined>>()
+        const resolveTarget = (moduleSpecifier: string): Promise<string | undefined> => {
+          let targetId = targetIds.get(moduleSpecifier)
+          if (!targetId) {
+            targetId = this.resolve(moduleSpecifier, id).then((resolved) =>
+              resolved && !resolved.external ? normalizeModuleId(resolved.id) : undefined,
+            )
+            targetIds.set(moduleSpecifier, targetId)
+          }
+          return targetId
+        }
+
+        const aliasesByTarget: AliasesByTarget = new Map()
+        for (const alias of unresolvedAliases) {
+          const targetId = await resolveTarget(alias.moduleSpecifier)
+          if (!targetId) continue
+          const resolvedAlias: NamespaceAlias = {
+            exportName: alias.exportName,
+            releaseTag: alias.releaseTag,
+            targetId,
+          }
+          const aliases = aliasesByTarget.get(targetId)
+          if (aliases) aliases.push(resolvedAlias)
+          else aliasesByTarget.set(targetId, [resolvedAlias])
+        }
+
+        declarationIds.add(declarationId)
+        const contextAliases = aliasesForContext(aliasesByContext, this)
+        if (aliasesByTarget.size === 0) {
+          contextAliases.delete(declarationId)
+        } else {
+          contextAliases.set(declarationId, aliasesByTarget)
+        }
+        return {
+          meta: {
+            [NAMESPACE_ALIAS_META]: aliasesByTarget.size === 0 ? undefined : aliasesByTarget,
+          },
+        }
+      },
+    },
+
+    watchChange(id) {
+      // Authored dtsInput modules have their real declaration identity here. Generated declaration
+      // modules are refreshed by their next transform, which atomically replaces this entry.
+      aliasesByContext.get(this)?.delete(normalizeModuleId(id))
     },
 
     renderChunk: {
       order: 'post',
-      async handler(code, chunk) {
-        if (!chunk.isEntry || !RE_DTS_FILE.test(chunk.fileName)) return undefined
-
-        const sourcePath = sourcePathForChunk(chunk, entrySources)
-        if (!sourcePath) return undefined
-
-        const sourceText = await readFile(sourcePath, 'utf8').catch(() => undefined)
-        if (
-          sourceText === undefined ||
-          !RE_NAMESPACE_REEXPORT.test(sourceText) ||
-          !RE_RELEASE_TAG.test(sourceText)
-        ) {
+      async handler(code, chunk, _outputOptions, meta) {
+        if (!RE_DTS_FILE.test(chunk.fileName) || !RE_SYNTHETIC_NAMESPACE.test(code)) {
           return undefined
         }
-        const {default: typescript} = await import('@typescript/typescript6')
+
+        const moduleRenderedExports = renderedExportsByModule(chunk, meta.chunks)
+        const aliases = activeNamespaceAliases(
+          this,
+          aliasesByContext,
+          declarationIds,
+          moduleRenderedExports,
+        )
+        if (aliases.length === 0) return undefined
+
         const insertions = namespaceReleaseTagInsertions(
-          typescript,
-          sourcePath,
-          sourceText,
-          chunk.fileName,
+          aliases,
+          new Set(Object.keys(chunk.modules).map(normalizeModuleId)),
+          moduleRenderedExports,
           code,
         )
         if (insertions.length === 0) return undefined
@@ -80,81 +150,63 @@ export function namespaceReleaseTagPlugin(): Rolldown.Plugin {
   }
 }
 
-function entrySource(cwd: string, sourcePath: string, name?: string): EntrySource {
-  const absolutePath = path.resolve(cwd, sourcePath)
-  return {
-    name,
-    sourcePath: absolutePath,
-    declarationPath: sourceToDeclarationPath(absolutePath),
-  }
+function aliasesForContext(
+  aliasesByContext: WeakMap<Rolldown.PluginContext, AliasesByDeclaration>,
+  context: Rolldown.PluginContext,
+): AliasesByDeclaration {
+  const existing = aliasesByContext.get(context)
+  if (existing) return existing
+  const aliases = new Map<string, AliasesByTarget>()
+  aliasesByContext.set(context, aliases)
+  return aliases
 }
 
-function sourceToDeclarationPath(sourcePath: string): string {
-  if (RE_DTS_FILE.test(sourcePath)) return sourcePath
-  if (sourcePath.endsWith('.mts') || sourcePath.endsWith('.mjs')) {
-    return sourcePath.replace(/\.(mts|mjs)$/, '.d.mts')
-  }
-  if (sourcePath.endsWith('.cts') || sourcePath.endsWith('.cjs')) {
-    return sourcePath.replace(/\.(cts|cjs)$/, '.d.cts')
-  }
-  return sourcePath.replace(/\.(tsx?|jsx?)$/, '.d.ts')
-}
-
-function sourcePathForChunk(
-  chunk: Pick<Rolldown.RenderedChunk, 'facadeModuleId' | 'name'>,
-  entries: EntrySource[],
-): string | undefined {
-  const facadeModuleId = chunk.facadeModuleId && path.normalize(chunk.facadeModuleId)
-  if (facadeModuleId) {
-    const exact = entries.find(
-      ({declarationPath, sourcePath}) =>
-        path.normalize(declarationPath) === facadeModuleId ||
-        sourceStem(path.normalize(sourcePath)) === declarationStem(facadeModuleId),
-    )
-    if (exact) return exact.sourcePath
-  }
-
-  const entryName = chunk.name.endsWith('.d') ? chunk.name.slice(0, -2) : chunk.name
-  return entries.find(({name}) => name === entryName)?.sourcePath
-}
-
-function sourceStem(sourcePath: string): string {
-  return sourcePath.replace(/\.d\.[mc]?ts$/, '').replace(/\.(?:[mc]?[jt]sx?)$/, '')
-}
-
-function declarationStem(declarationPath: string): string {
-  return declarationPath.replace(/\.d\.[mc]?ts$/, '')
-}
-
-function namespaceReleaseTagInsertions(
+function collectNamespaceAliases(
   typescript: typeof ts,
-  sourcePath: string,
-  sourceText: string,
   declarationPath: string,
   declarationText: string,
-): Array<{position: number; tag: ReleaseTag}> {
+): UnresolvedNamespaceAlias[] {
   const sourceFile = typescript.createSourceFile(
-    sourcePath,
-    sourceText,
+    declarationPath,
+    declarationText,
     typescript.ScriptTarget.Latest,
     true,
   )
-  const tagsByExportName = new Map<string, ReleaseTag>()
-  const namespaceImports = new Map<string, ReleaseTag | undefined>()
+  const namespaceImports = new Map<
+    string,
+    {moduleSpecifier: string; releaseTag: ReleaseTag | undefined}
+  >()
+  const aliases: UnresolvedNamespaceAlias[] = []
 
   for (const statement of sourceFile.statements) {
     const namedBindings =
       typescript.isImportDeclaration(statement) && statement.importClause?.namedBindings
-    if (!namedBindings || !typescript.isNamespaceImport(namedBindings)) continue
-    namespaceImports.set(namedBindings.name.text, getReleaseTag(typescript, statement))
+    if (
+      !namedBindings ||
+      !typescript.isNamespaceImport(namedBindings) ||
+      !typescript.isStringLiteral(statement.moduleSpecifier)
+    ) {
+      continue
+    }
+    namespaceImports.set(namedBindings.name.text, {
+      moduleSpecifier: statement.moduleSpecifier.text,
+      releaseTag: getReleaseTag(typescript, statement),
+    })
   }
 
   for (const statement of sourceFile.statements) {
     if (!typescript.isExportDeclaration(statement) || !statement.exportClause) continue
 
-    if (typescript.isNamespaceExport(statement.exportClause)) {
-      const releaseTag = getReleaseTag(typescript, statement)
-      if (releaseTag) tagsByExportName.set(statement.exportClause.name.text, releaseTag)
+    if (
+      typescript.isNamespaceExport(statement.exportClause) &&
+      statement.moduleSpecifier &&
+      typescript.isStringLiteral(statement.moduleSpecifier)
+    ) {
+      aliases.push({
+        exportName: statement.exportClause.name.text,
+        moduleSpecifier: statement.moduleSpecifier.text,
+        releaseTag: getReleaseTag(typescript, statement),
+      })
       continue
     }
 
@@ -162,88 +214,245 @@ function namespaceReleaseTagInsertions(
     const exportReleaseTag = getReleaseTag(typescript, statement)
     for (const specifier of statement.exportClause.elements) {
       const localName = specifier.propertyName?.text ?? specifier.name.text
-      if (!namespaceImports.has(localName)) continue
-      const importReleaseTag = namespaceImports.get(localName)
-      const releaseTag =
-        exportReleaseTag && importReleaseTag && exportReleaseTag !== importReleaseTag
-          ? undefined
-          : (exportReleaseTag ?? importReleaseTag)
-      if (releaseTag) tagsByExportName.set(specifier.name.text, releaseTag)
-    }
-  }
-  if (tagsByExportName.size === 0) return []
-
-  const declarationFile = typescript.createSourceFile(
-    declarationPath,
-    declarationText,
-    typescript.ScriptTarget.Latest,
-    true,
-  )
-  const namespaces = new Map<string, ts.ModuleDeclaration>()
-  for (const statement of declarationFile.statements) {
-    if (isSyntheticNamespace(typescript, statement)) {
-      namespaces.set(statement.name.text, statement)
+      const namespaceImport = namespaceImports.get(localName)
+      if (!namespaceImport) continue
+      const importReleaseTag = namespaceImport.releaseTag
+      aliases.push({
+        exportName: specifier.name.text,
+        moduleSpecifier: namespaceImport.moduleSpecifier,
+        releaseTag:
+          exportReleaseTag && importReleaseTag && exportReleaseTag !== importReleaseTag
+            ? undefined
+            : (exportReleaseTag ?? importReleaseTag),
+      })
     }
   }
 
-  const tagsByPosition = new Map<number, ReleaseTag>()
-  const conflictingPositions = new Set<number>()
-  for (const statement of declarationFile.statements) {
-    if (
-      !typescript.isExportDeclaration(statement) ||
-      statement.moduleSpecifier ||
-      !statement.exportClause ||
-      !typescript.isNamedExports(statement.exportClause)
-    ) {
-      continue
-    }
+  return aliases
+}
 
-    for (const specifier of statement.exportClause.elements) {
-      if (!specifier.propertyName) continue
-      const releaseTag = tagsByExportName.get(specifier.name.text)
-      const namespace = namespaces.get(specifier.propertyName.text)
-      if (!releaseTag || !namespace || getReleaseTag(typescript, namespace)) continue
-
-      const position = namespace.getStart(declarationFile)
-      const previousTag = tagsByPosition.get(position)
-      if (previousTag && previousTag !== releaseTag) {
-        conflictingPositions.add(position)
-      } else {
-        tagsByPosition.set(position, releaseTag)
+function activeNamespaceAliases(
+  context: Rolldown.PluginContext,
+  aliasesByContext: WeakMap<Rolldown.PluginContext, AliasesByDeclaration>,
+  declarationIds: Set<string>,
+  moduleRenderedExports: Map<string, Set<string>>,
+): NamespaceAlias[] {
+  let aliasesByDeclaration = aliasesByContext.get(context)
+  if (!aliasesByDeclaration) {
+    aliasesByDeclaration = new Map()
+    for (const declarationId of declarationIds) {
+      const moduleInfo = context.getModuleInfo(declarationId)
+      if (!moduleInfo) continue
+      const aliasesByTarget = moduleInfo.meta[NAMESPACE_ALIAS_META]
+      if (aliasesByTarget instanceof Map) {
+        aliasesByDeclaration.set(declarationId, aliasesByTarget as AliasesByTarget)
       }
     }
   }
 
-  return [...tagsByPosition]
-    .filter(([position]) => !conflictingPositions.has(position))
-    .map(([position, tag]) => ({position, tag}))
-    .toSorted((a, b) => b.position - a.position)
-}
+  const allRenderedExports = new Set<string>()
+  for (const exportNames of moduleRenderedExports.values()) {
+    for (const exportName of exportNames) allRenderedExports.add(exportName)
+  }
+  const aliases: NamespaceAlias[] = []
 
-function isSyntheticNamespace(
-  typescript: typeof ts,
-  statement: ts.Statement,
-): statement is ts.ModuleDeclaration & {name: ts.Identifier; body: ts.ModuleBlock} {
-  if (
-    !typescript.isModuleDeclaration(statement) ||
-    !typescript.isIdentifier(statement.name) ||
-    !statement.name.text.endsWith('_exports') ||
-    !statement.modifiers?.some(({kind}) => kind === typescript.SyntaxKind.DeclareKeyword) ||
-    !statement.body ||
-    !typescript.isModuleBlock(statement.body) ||
-    statement.body.statements.length !== 1
-  ) {
-    return false
+  for (const [declarationId, aliasesByTarget] of aliasesByDeclaration) {
+    // Prefer this declaration module's own output metadata. A transitive declaration barrel can
+    // be collapsed out of the final chunks; in that case names rendered by any declaration module
+    // still identify ordinary (non-renamed) aliases. If none of the authored names remain, retain
+    // the aliases as structural candidates: a later barrel may have renamed every one of them.
+    const renderedExports = moduleRenderedExports.get(declarationId) ?? allRenderedExports
+    const declarationAliases = [...aliasesByTarget.values()].flat()
+    const hasRenderedAuthoredName = declarationAliases.some(({exportName}) =>
+      renderedExports.has(exportName),
+    )
+    if (renderedExports.size === 0) continue
+    for (const targetAliases of aliasesByTarget.values()) {
+      aliases.push(
+        ...(hasRenderedAuthoredName
+          ? targetAliases.filter(({exportName}) => renderedExports.has(exportName))
+          : targetAliases),
+      )
+    }
   }
 
-  const [namespaceExport] = statement.body.statements
-  return (
-    !!namespaceExport &&
-    typescript.isExportDeclaration(namespaceExport) &&
-    !namespaceExport.moduleSpecifier &&
-    !!namespaceExport.exportClause &&
-    typescript.isNamedExports(namespaceExport.exportClause)
+  return aliases
+}
+
+function renderedExportsByModule(
+  chunk: Pick<Rolldown.RenderedChunk, 'modules'>,
+  chunks: Record<string, Rolldown.RenderedChunk>,
+): Map<string, Set<string>> {
+  const renderedExports = new Map<string, Set<string>>()
+  const addChunk = ({modules}: Pick<Rolldown.RenderedChunk, 'modules'>): void => {
+    for (const [id, renderedModule] of Object.entries(modules)) {
+      const normalizedId = normalizeModuleId(id)
+      if (!RE_DTS_FILE.test(normalizedId)) continue
+      const exportNames = renderedExports.get(normalizedId)
+      if (exportNames) {
+        for (const exportName of renderedModule.renderedExports) exportNames.add(exportName)
+      } else {
+        renderedExports.set(normalizedId, new Set(renderedModule.renderedExports))
+      }
+    }
+  }
+  for (const renderedChunk of Object.values(chunks)) addChunk(renderedChunk)
+  // Rolldown's `meta.chunks` may omit the chunk whose hook is currently running.
+  addChunk(chunk)
+  return renderedExports
+}
+
+function namespaceReleaseTagInsertions(
+  aliases: NamespaceAlias[],
+  chunkModuleIds: Set<string>,
+  moduleRenderedExports: Map<string, Set<string>>,
+  declarationText: string,
+): Array<{position: number; tag: ReleaseTag}> {
+  const namespaces = new Map<
+    string,
+    {
+      aliases: NamespaceAlias[]
+      exportedMembers: Set<string>
+      hasReleaseTag: boolean
+      position: number
+      targetIds: Set<string>
+    }
+  >()
+
+  for (const match of declarationText.matchAll(/\bdeclare\s+namespace\s+([^\s{]+_exports)\s*\{/g)) {
+    const name = match[1]
+    if (!name) continue
+    const position = match.index
+    const openingBrace = position + match[0].lastIndexOf('{')
+    const closingBrace = matchingClosingBrace(declarationText, openingBrace)
+    if (closingBrace === undefined) continue
+    const prefix = declarationText.slice(0, position)
+    const jsDocStart = prefix.lastIndexOf('/**')
+    const precedingJsDoc =
+      jsDocStart === -1 ? undefined : prefix.slice(jsDocStart).match(/^\/\*\*[\s\S]*?\*\/\s*$/)?.[0]
+    namespaces.set(name, {
+      aliases: [],
+      exportedMembers: renderedExportNames(declarationText.slice(openingBrace + 1, closingBrace)),
+      hasReleaseTag: !!precedingJsDoc && /@(alpha|beta|internal|public)\b/.test(precedingJsDoc),
+      position,
+      targetIds: new Set(),
+    })
+  }
+
+  const aliasesByExportName = new Map<string, NamespaceAlias[]>()
+  for (const alias of aliases) {
+    const namedAliases = aliasesByExportName.get(alias.exportName)
+    if (namedAliases) namedAliases.push(alias)
+    else aliasesByExportName.set(alias.exportName, [alias])
+  }
+  // The rendered export specifiers identify which authored aliases survived tree-shaking.
+  for (const match of declarationText.matchAll(/\bexport\s+(?:type\s+)?\{([^}]*)\}\s*;/g)) {
+    for (const renderedSpecifier of (match[1] ?? '').split(',')) {
+      const [localName, exportName = localName] = renderedSpecifier
+        .trim()
+        .replace(/^type\s+/, '')
+        .split(/\s+as\s+/)
+      if (!localName || !exportName) continue
+      const namespace = namespaces.get(localName)
+      if (!namespace) continue
+      for (const alias of aliasesByExportName.get(exportName) ?? []) {
+        if (!chunkModuleIds.has(alias.targetId)) continue
+        namespace.aliases.push(alias)
+        namespace.targetIds.add(alias.targetId)
+      }
+    }
+  }
+
+  // A shared declaration chunk can export wrappers under generated inter-chunk aliases, while
+  // transitive barrels can rename every authored alias. Match each unresolved wrapper's complete
+  // exported-member set to the target modules' tree-shaken rendered exports. Both ends must be
+  // unique; an ambiguous structural match never invents a release tag.
+  const claimedTargets = new Set<string>()
+  for (const namespace of namespaces.values()) {
+    if (namespace.targetIds.size === 1) {
+      const [targetId] = namespace.targetIds
+      if (targetId) claimedTargets.add(targetId)
+    }
+  }
+  const aliasesByTarget = new Map<string, NamespaceAlias[]>()
+  for (const alias of aliases) {
+    if (claimedTargets.has(alias.targetId)) continue
+    const targetAliases = aliasesByTarget.get(alias.targetId)
+    if (targetAliases) targetAliases.push(alias)
+    else aliasesByTarget.set(alias.targetId, [alias])
+  }
+  const unresolvedNamespaces = [...namespaces.values()].filter(
+    (namespace) => namespace.aliases.length === 0,
   )
+  const structuralMatches = unresolvedNamespaces.map((namespace) => ({
+    namespace,
+    targetIds: [...aliasesByTarget.keys()].filter((targetId) => {
+      const targetExports = moduleRenderedExports.get(targetId)
+      return (
+        targetExports !== undefined && equalStringSets(namespace.exportedMembers, targetExports)
+      )
+    }),
+  }))
+  const targetMatchCounts = new Map<string, number>()
+  for (const {targetIds} of structuralMatches) {
+    for (const targetId of targetIds) {
+      targetMatchCounts.set(targetId, (targetMatchCounts.get(targetId) ?? 0) + 1)
+    }
+  }
+  for (const {namespace, targetIds} of structuralMatches) {
+    const [targetId] = targetIds
+    if (targetIds.length === 1 && targetId && targetMatchCounts.get(targetId) === 1) {
+      const targetAliases = aliasesByTarget.get(targetId)
+      if (!targetAliases) continue
+      namespace.targetIds.add(targetId)
+      namespace.aliases.push(...targetAliases)
+    }
+  }
+
+  const insertions: Array<{position: number; tag: ReleaseTag}> = []
+  for (const {
+    aliases: referencedAliases,
+    hasReleaseTag,
+    position,
+    targetIds,
+  } of namespaces.values()) {
+    if (targetIds.size !== 1 || referencedAliases.length === 0 || hasReleaseTag) {
+      continue
+    }
+    const tags = new Set(referencedAliases.map(({releaseTag}) => releaseTag))
+    if (tags.size !== 1 || tags.has(undefined)) continue
+    const [tag] = tags
+    if (tag) insertions.push({position, tag})
+  }
+
+  return insertions.toSorted((a, b) => b.position - a.position)
+}
+
+function matchingClosingBrace(text: string, openingBrace: number): number | undefined {
+  let depth = 0
+  for (let index = openingBrace; index < text.length; index++) {
+    const character = text[index]
+    if (character === '{') depth++
+    else if (character === '}' && --depth === 0) return index
+  }
+  return undefined
+}
+
+function renderedExportNames(namespaceBody: string): Set<string> {
+  const exportNames = new Set<string>()
+  for (const match of namespaceBody.matchAll(/\bexport\s+(?:type\s+)?\{([^}]*)\}\s*;/g)) {
+    for (const renderedSpecifier of (match[1] ?? '').split(',')) {
+      const normalizedSpecifier = renderedSpecifier.trim().replace(/^type\s+/, '')
+      if (!normalizedSpecifier) continue
+      const [localName, exportName = localName] = normalizedSpecifier.split(/\s+as\s+/)
+      if (exportName) exportNames.add(exportName)
+    }
+  }
+  return exportNames
+}
+
+function equalStringSets(left: Set<string>, right: Set<string>): boolean {
+  return left.size > 0 && left.size === right.size && [...left].every((value) => right.has(value))
 }
 
 function getReleaseTag(typescript: typeof ts, node: ts.Node): ReleaseTag | undefined {
@@ -254,4 +463,8 @@ function getReleaseTag(typescript: typeof ts, node: ts.Node): ReleaseTag | undef
       .filter((tag): tag is ReleaseTag => RELEASE_TAGS.has(tag)),
   )
   return tags.size === 1 ? tags.values().next().value : undefined
+}
+
+function normalizeModuleId(id: string): string {
+  return id.replace(/[?#].*$/, '')
 }

--- a/packages/@sanity/tsdown-config/test/composition.test.ts
+++ b/packages/@sanity/tsdown-config/test/composition.test.ts
@@ -28,6 +28,18 @@ describe('programmatic composition via mergeConfig', () => {
     expect(composed.plugins).toEqual([marker])
   })
 
+  test('keeps TSDoc repair when a host adds an input plugin', async () => {
+    const composed = mergeConfig(await defineConfig({dts: true, tsdoc: true}), {
+      inputOptions: {plugins: [marker]},
+    })
+    const {inputOptions} = composed
+    if (!inputOptions || typeof inputOptions === 'function') throw new Error('expected an object')
+    expect(inputOptions.plugins).toEqual([
+      expect.objectContaining({name: 'sanity-namespace-release-tags'}),
+      marker,
+    ])
+  })
+
   test('deep-merges plain objects over the defaults', async () => {
     const composed = mergeConfig(await defineConfig(), {minify: {mangle: true}})
     expect(composed.minify).toEqual({

--- a/packages/@sanity/tsdown-config/test/namespace-release-tag.test.ts
+++ b/packages/@sanity/tsdown-config/test/namespace-release-tag.test.ts
@@ -37,12 +37,37 @@ describe('namespace re-export release tags', () => {
     },
   )
 
-  test(
-    'does not invent a tag for an untagged namespace re-export',
-    {timeout: 120_000},
-    async () => {
+  test('preserves a tag on imported namespace re-exports', {timeout: 120_000}, async () => {
+    const cases = [
+      {
+        tag: 'beta',
+        index: `/** @beta */\nimport * as inner from './inner'\nexport {inner}\n`,
+      },
+      {
+        tag: 'public',
+        index: `import * as inner from './inner'\n/** @public */\nexport {inner}\n`,
+      },
+    ] as const
+
+    for (const {index, tag} of cases) {
       const fixtureDir = await createFixture({
-        index: `export * as inner from './inner'\n`,
+        index,
+        inner: `/** @${tag} */\nexport function hello(): string {\n  return 'hello'\n}\n`,
+      })
+      await runBuild(fixtureDir)
+      expect(await readFile(path.join(fixtureDir, 'dist/index.d.ts'), 'utf8')).toContain(
+        `/** @${tag} */ declare namespace inner_d_exports`,
+      )
+    }
+  })
+
+  test('does not invent a tag for untagged namespace re-exports', {timeout: 120_000}, async () => {
+    for (const index of [
+      `export * as inner from './inner'\n`,
+      `import * as inner from './inner'\nexport {inner}\n`,
+    ]) {
+      const fixtureDir = await createFixture({
+        index,
         inner: `/** @alpha */\nexport function hello(): string {\n  return 'hello'\n}\n`,
       })
 
@@ -52,8 +77,8 @@ describe('namespace re-export release tags', () => {
       expect(await readFile(path.join(fixtureDir, 'dist/index.d.ts'), 'utf8')).toMatch(
         /^declare namespace inner_d_exports/,
       )
-    },
-  )
+    }
+  })
 
   test('ordinary untagged API still fails', {timeout: 120_000}, async () => {
     const fixtureDir = await createFixture({

--- a/packages/@sanity/tsdown-config/test/namespace-release-tag.test.ts
+++ b/packages/@sanity/tsdown-config/test/namespace-release-tag.test.ts
@@ -1,0 +1,121 @@
+import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import path from 'node:path'
+import {build, mergeConfig, type UserConfig} from 'tsdown'
+import {afterAll, describe, expect, test} from 'vitest'
+import {defineConfig} from '../src/index.ts'
+
+const fixtureDirs: string[] = []
+
+afterAll(async () => {
+  await Promise.all(fixtureDirs.map((fixtureDir) => rm(fixtureDir, {force: true, recursive: true})))
+})
+
+describe('namespace re-export release tags', () => {
+  test(
+    'preserves an explicit tag on the generated ESM and CJS namespaces',
+    {timeout: 120_000},
+    async () => {
+      const fixtureDir = await createFixture({
+        index: `/** @alpha */\nexport * as inner from './inner'\n`,
+        inner: `/** @alpha */\nexport function hello(): string {\n  return 'hello'\n}\n`,
+      })
+
+      await runBuild(fixtureDir, ['esm', 'cjs'])
+
+      for (const declarationFile of ['index.d.ts', 'index.d.cts']) {
+        const declaration = await readFile(path.join(fixtureDir, 'dist', declarationFile), 'utf8')
+        expect(declaration).toContain('/** @alpha */ declare namespace inner_d_exports')
+        expect(declaration).toContain('/** @alpha */\ndeclare function hello(): string')
+
+        const sourceMap: {mappings: string; sources: string[]} = JSON.parse(
+          await readFile(path.join(fixtureDir, 'dist', `${declarationFile}.map`), 'utf8'),
+        )
+        expect(sourceMap.sources).toContain('../src/inner.ts')
+        expect(sourceMap.mappings).not.toBe('')
+      }
+    },
+  )
+
+  test(
+    'does not invent a tag for an untagged namespace re-export',
+    {timeout: 120_000},
+    async () => {
+      const fixtureDir = await createFixture({
+        index: `export * as inner from './inner'\n`,
+        inner: `/** @alpha */\nexport function hello(): string {\n  return 'hello'\n}\n`,
+      })
+
+      await expect(runBuild(fixtureDir)).rejects.toThrow(
+        'TSDoc/release-tag check failed with 1 error',
+      )
+      expect(await readFile(path.join(fixtureDir, 'dist/index.d.ts'), 'utf8')).toMatch(
+        /^declare namespace inner_d_exports/,
+      )
+    },
+  )
+
+  test('ordinary untagged API still fails', {timeout: 120_000}, async () => {
+    const fixtureDir = await createFixture({
+      index: `export function untagged(): string {\n  return 'untagged'\n}\n`,
+    })
+
+    await expect(runBuild(fixtureDir)).rejects.toThrow(
+      'TSDoc/release-tag check failed with 1 error',
+    )
+  })
+})
+
+async function createFixture(files: {index: string; inner?: string}): Promise<string> {
+  const fixtureDir = await mkdtemp(path.join(tmpdir(), 'tsdown-namespace-release-tag-'))
+  fixtureDirs.push(fixtureDir)
+  await mkdir(path.join(fixtureDir, 'src'))
+  await Promise.all([
+    writeFile(
+      path.join(fixtureDir, 'package.json'),
+      `${JSON.stringify({
+        name: '@fixtures/namespace-release-tag',
+        version: '0.0.0-development',
+        private: true,
+        type: 'module',
+      })}\n`,
+    ),
+    writeFile(
+      path.join(fixtureDir, 'tsconfig.json'),
+      `${JSON.stringify({
+        compilerOptions: {
+          declaration: true,
+          module: 'Preserve',
+          moduleResolution: 'Bundler',
+          strict: true,
+          target: 'ES2022',
+        },
+        include: ['src'],
+      })}\n`,
+    ),
+    writeFile(path.join(fixtureDir, 'src/index.ts'), files.index),
+    ...(files.inner === undefined
+      ? []
+      : [writeFile(path.join(fixtureDir, 'src/inner.ts'), files.inner)]),
+  ])
+  return fixtureDir
+}
+
+async function runBuild(cwd: string, format: UserConfig['format'] = 'esm'): Promise<unknown> {
+  return build(
+    mergeConfig(
+      await defineConfig({
+        clean: true,
+        cwd,
+        dts: {newContext: true, sourcemap: true},
+        entry: './src/index.ts',
+        exports: false,
+        format,
+        outDir: 'dist',
+        sourcemap: false,
+        tsdoc: {rules: {'ae-missing-release-tag': 'error'}},
+      }),
+      {logLevel: 'silent', publint: false},
+    ),
+  )
+}

--- a/packages/@sanity/tsdown-config/test/namespace-release-tag.test.ts
+++ b/packages/@sanity/tsdown-config/test/namespace-release-tag.test.ts
@@ -1,9 +1,10 @@
-import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises'
+import {mkdir, mkdtemp, readdir, readFile, rm, writeFile} from 'node:fs/promises'
 import {tmpdir} from 'node:os'
 import path from 'node:path'
-import {build, mergeConfig, type UserConfig} from 'tsdown'
+import {build, mergeConfig, type Rolldown, type UserConfig} from 'tsdown'
 import {afterAll, describe, expect, test} from 'vitest'
 import {defineConfig} from '../src/index.ts'
+import {namespaceReleaseTagPlugin} from '../src/namespaceReleaseTagPlugin.ts'
 
 const fixtureDirs: string[] = []
 
@@ -61,6 +62,24 @@ describe('namespace re-export release tags', () => {
     }
   })
 
+  test(
+    'does not invent a tag when namespace import and export tags conflict',
+    {timeout: 120_000},
+    async () => {
+      const fixtureDir = await createFixture({
+        index: `/** @alpha */\nimport * as inner from './inner'\n/** @beta */\nexport {inner}\n`,
+        inner: `/** @alpha */\nexport function hello(): string {\n  return 'hello'\n}\n`,
+      })
+
+      await expect(runBuild(fixtureDir)).rejects.toThrow(
+        'TSDoc/release-tag check failed with 1 error',
+      )
+      expect(await readFile(path.join(fixtureDir, 'dist/index.d.ts'), 'utf8')).toMatch(
+        /^declare namespace inner_d_exports/,
+      )
+    },
+  )
+
   test('does not invent a tag for untagged namespace re-exports', {timeout: 120_000}, async () => {
     for (const index of [
       `export * as inner from './inner'\n`,
@@ -89,9 +108,531 @@ describe('namespace re-export release tags', () => {
       'TSDoc/release-tag check failed with 1 error',
     )
   })
+
+  test.each([
+    {
+      name: 'an untagged alias',
+      aliases:
+        `/** @alpha */\nexport * as tagged from './inner'\n` +
+        `export * as untagged from './inner'\n`,
+    },
+    {
+      name: 'differently tagged aliases',
+      aliases:
+        `/** @alpha */\nexport * as alpha from './inner'\n` +
+        `/** @beta */\nexport * as beta from './inner'\n`,
+    },
+  ])(
+    'does not tag a shared namespace wrapper when the module also has $name',
+    {timeout: 120_000},
+    async ({aliases}) => {
+      const fixtureDir = await createFixture({
+        index: aliases,
+        inner: `/** @alpha */\nexport function hello(): string {\n  return 'hello'\n}\n`,
+      })
+
+      await expect(runBuild(fixtureDir)).rejects.toThrow(
+        'TSDoc/release-tag check failed with 1 error',
+      )
+      expect(await readFile(path.join(fixtureDir, 'dist/index.d.ts'), 'utf8')).toMatch(
+        /^declare namespace inner_d_exports/,
+      )
+    },
+  )
+
+  test(
+    'ignores a tree-shaken conflicting alias when only the tagged alias is re-exported',
+    {timeout: 120_000},
+    async () => {
+      const fixtureDir = await createFixture({
+        index: `export {tagged} from './barrel'\n`,
+        barrel:
+          `/** @alpha */\nexport * as tagged from './inner'\n` +
+          `export * as untagged from './inner'\n`,
+        inner: `/** @alpha */\nexport function hello(): string {\n  return 'hello'\n}\n`,
+      })
+
+      await runBuild(fixtureDir)
+      expect(await readFile(path.join(fixtureDir, 'dist/index.d.ts'), 'utf8')).toContain(
+        '/** @alpha */ declare namespace inner_d_exports',
+      )
+    },
+  )
+
+  test(
+    'finds a tagged namespace re-export through a transitive barrel',
+    {timeout: 120_000},
+    async () => {
+      const fixtureDir = await createFixture({
+        index: `export * from './barrel'\n`,
+        barrel: `/** @beta */\nexport * as inner from './inner'\n`,
+        inner: `/** @beta */\nexport function hello(): string {\n  return 'hello'\n}\n`,
+      })
+
+      await runBuild(fixtureDir)
+      expect(await readFile(path.join(fixtureDir, 'dist/index.d.ts'), 'utf8')).toContain(
+        '/** @beta */ declare namespace inner_d_exports',
+      )
+    },
+  )
+
+  test('preserves multiple type-only namespace release tags', {timeout: 120_000}, async () => {
+    const fixtureDir = await createFixture({
+      index:
+        `/** @public */\nexport type * as first from './first'\n` +
+        `/** @public */\nexport type * as second from './second'\n`,
+      first: `/** @public */\nexport interface First {value: string}\n`,
+      second: `/** @public */\nexport interface Second {value: number}\n`,
+    })
+
+    await runBuild(fixtureDir)
+    const declaration = await readFile(path.join(fixtureDir, 'dist/index.d.ts'), 'utf8')
+    expect(declaration).toContain('/** @public */ declare namespace first_d_exports')
+    expect(declaration).toContain('/** @public */ declare namespace second_d_exports')
+  })
+
+  test('combines multiple type-only member exports for structural matching', async () => {
+    const sourceId = '/fixture/namespaces.d.mts'
+    const firstId = '/fixture/first.d.mts'
+    const secondId = '/fixture/second.d.mts'
+    const plugin = namespaceReleaseTagPlugin()
+    const transform = objectHook(plugin, 'transform')
+    const renderChunk = objectHook(plugin, 'renderChunk')
+    const context = metadataPluginContextForTargets(sourceId, {
+      './first': firstId,
+      './second': secondId,
+    })
+    const sharedChunk = {
+      fileName: 'shared.d.mts',
+      moduleIds: [firstId, secondId],
+      modules: {
+        [firstId]: {renderedExports: ['First', 'FirstOptions']},
+        [secondId]: {renderedExports: ['Second', 'SecondOptions']},
+      },
+    } as unknown as Rolldown.RenderedChunk
+    const entryChunk = {
+      fileName: 'index.d.mts',
+      moduleIds: [sourceId],
+      modules: {
+        [sourceId]: {renderedExports: ['renamedFirst', 'renamedSecond']},
+      },
+    } as unknown as Rolldown.RenderedChunk
+    const declaration =
+      `declare namespace first_d_exports {\n` +
+      `  export type { First };\n` +
+      `  export type { FirstOptions };\n` +
+      `}\n` +
+      `declare namespace second_d_exports {\n` +
+      `  export type { Second };\n` +
+      `  export type { SecondOptions };\n` +
+      `}\n` +
+      `export type { first_d_exports as n, second_d_exports as t };\n`
+
+    await transform.handler.call(
+      context,
+      `/** @alpha */\nexport type * as first from './first';\n` +
+        `/** @beta */\nexport type * as second from './second';\n`,
+      sourceId,
+      {} as never,
+    )
+    const rendered = renderedCode(
+      await renderChunk.handler.call(
+        context,
+        declaration,
+        sharedChunk,
+        {} as never,
+        {
+          chunks: {
+            [entryChunk.fileName]: entryChunk,
+            [sharedChunk.fileName]: sharedChunk,
+          },
+        } as never,
+      ),
+    )
+
+    expect(rendered).toContain('/** @alpha */ declare namespace first_d_exports')
+    expect(rendered).toContain('/** @beta */ declare namespace second_d_exports')
+  })
+
+  test(
+    'processes a synthesized namespace in a shared declaration chunk',
+    {timeout: 120_000},
+    async () => {
+      const fixtureDir = await createFixture({
+        a: `export * from './barrel'\n`,
+        b: `export * from './barrel'\n`,
+        barrel: `/** @internal */\nexport * as inner from './inner'\n`,
+        inner: `/** @internal */\nexport function hello(): string {\n  return 'hello'\n}\n`,
+      })
+
+      await runBuild(fixtureDir, 'esm', {a: './src/a.ts', b: './src/b.ts'})
+
+      const declarationFiles = (await readdir(path.join(fixtureDir, 'dist'))).filter((fileName) =>
+        fileName.endsWith('.d.ts'),
+      )
+      const declarations = await Promise.all(
+        declarationFiles.map(async (fileName) => ({
+          contents: await readFile(path.join(fixtureDir, 'dist', fileName), 'utf8'),
+          fileName,
+        })),
+      )
+      const sharedDeclaration = declarations.find(({contents}) =>
+        contents.includes('declare namespace inner_d_exports'),
+      )
+      expect(sharedDeclaration).toBeDefined()
+      if (!sharedDeclaration) throw new Error('Expected a shared namespace declaration chunk')
+      expect(sharedDeclaration.contents).toContain(
+        '/** @internal */ declare namespace inner_d_exports',
+      )
+
+      const sourceMap: {mappings: string; sources: string[]} = JSON.parse(
+        await readFile(path.join(fixtureDir, 'dist', `${sharedDeclaration.fileName}.map`), 'utf8'),
+      )
+      expect(sourceMap.sources).toContain('../src/inner.ts')
+      expect(sourceMap.mappings).not.toBe('')
+    },
+  )
+
+  test(
+    'ignores a tree-shaken conflicting alias for a shared wrapper',
+    {timeout: 120_000},
+    async () => {
+      const fixtureDir = await createFixture({
+        a: `export {tagged} from './barrel'\n`,
+        b: `export {tagged} from './barrel'\n`,
+        barrel:
+          `/** @internal */\nexport * as tagged from './inner'\n` +
+          `export * as untagged from './inner'\n`,
+        inner: `/** @internal */\nexport function hello(): string {\n  return 'hello'\n}\n`,
+      })
+
+      await runBuild(fixtureDir, 'esm', {a: './src/a.ts', b: './src/b.ts'})
+      const declarations = await Promise.all(
+        (await readdir(path.join(fixtureDir, 'dist')))
+          .filter((fileName) => fileName.endsWith('.d.ts'))
+          .map(async (fileName) => readFile(path.join(fixtureDir, 'dist', fileName), 'utf8')),
+      )
+      expect(
+        declarations.find((declaration) =>
+          declaration.includes('declare namespace inner_d_exports'),
+        ),
+      ).toContain('/** @internal */ declare namespace inner_d_exports')
+    },
+  )
+
+  test(
+    'matches two shared type-only wrappers through transitive renamed barrels',
+    {timeout: 120_000},
+    async () => {
+      const fixtureDir = await createFixture({
+        a: `export type {renamedFirst, renamedSecond} from './barrel'\n`,
+        b: `export type {renamedFirst, renamedSecond} from './barrel'\n`,
+        barrel: `export type {first as renamedFirst, second as renamedSecond} from './namespaces'\n`,
+        namespaces:
+          `/** @alpha */\nexport type * as first from './first'\n` +
+          `/** @beta */\nexport type * as second from './second'\n`,
+        first:
+          `/** @alpha */\nexport interface First {value: string}\n` +
+          `/** @alpha */\nexport interface FirstOptions {optional?: boolean}\n`,
+        second:
+          `/** @beta */\nexport interface Second {value: number}\n` +
+          `/** @beta */\nexport interface SecondOptions {optional?: boolean}\n`,
+      })
+
+      await runBuild(fixtureDir, 'esm', {a: './src/a.ts', b: './src/b.ts'})
+      const declarations = await Promise.all(
+        (await readdir(path.join(fixtureDir, 'dist')))
+          .filter((fileName) => fileName.endsWith('.d.ts'))
+          .map(async (fileName) => readFile(path.join(fixtureDir, 'dist', fileName), 'utf8')),
+      )
+      const sharedDeclaration = declarations.find(
+        (declaration) =>
+          declaration.includes('declare namespace first_d_exports') &&
+          declaration.includes('declare namespace second_d_exports'),
+      )
+      expect(sharedDeclaration).toContain('/** @alpha */ declare namespace first_d_exports')
+      expect(sharedDeclaration).toContain('/** @beta */ declare namespace second_d_exports')
+    },
+  )
+
+  test(
+    'reads an authored declaration entry instead of its TypeScript sibling with dtsInput',
+    {timeout: 120_000},
+    async () => {
+      const fixtureDir = await createFixture({
+        'index.d.ts': `/** @alpha */\nexport * as inner from './inner'\n`,
+        'index.ts': `/** @beta */\nexport * as inner from './inner'\n`,
+        'inner.d.ts': `/** @alpha */\nexport declare function hello(): string\n`,
+        'inner.ts': `/** @beta */\nexport function hello(): string {\n  return 'hello'\n}\n`,
+      })
+
+      await runBuild(fixtureDir, 'esm', './src/index.d.ts', {
+        dts: {dtsInput: true, newContext: true, sourcemap: true},
+      })
+      const declaration = await readFile(path.join(fixtureDir, 'dist/index.d.ts'), 'utf8')
+      expect(declaration).toContain('/** @alpha */ declare namespace inner_d_exports')
+      expect(declaration).not.toContain('/** @beta */ declare namespace inner_d_exports')
+    },
+  )
+
+  test('supports a non-ASCII namespace alias', {timeout: 120_000}, async () => {
+    const fixtureDir = await createFixture({
+      index: `/** @public */\nexport * as 日本語 from './日本語'\n`,
+      日本語: `/** @public */\nexport function hello(): string {\n  return 'hello'\n}\n`,
+    })
+
+    await runBuild(fixtureDir)
+    expect(await readFile(path.join(fixtureDir, 'dist/index.d.ts'), 'utf8')).toContain(
+      '/** @public */ declare namespace 日本語_d_exports',
+    )
+  })
+
+  test('supports extensionless entry paths', {timeout: 120_000}, async () => {
+    const fixtureDir = await createFixture({
+      index: `/** @public */\nexport * as inner from './inner'\n`,
+      inner: `/** @public */\nexport function hello(): string {\n  return 'hello'\n}\n`,
+    })
+
+    await runBuild(fixtureDir, 'esm', './src/index')
+    expect(await readFile(path.join(fixtureDir, 'dist/index.d.ts'), 'utf8')).toContain(
+      '/** @public */ declare namespace inner_d_exports',
+    )
+  })
+
+  test('replaces and deletes declaration metadata across watch updates', async () => {
+    const sourceId = '/fixture/index.d.cts'
+    const targetId = '/fixture/inner.d.cts'
+    const plugin = namespaceReleaseTagPlugin()
+    const transform = objectHook(plugin, 'transform')
+    const renderChunk = objectHook(plugin, 'renderChunk')
+    const context = metadataPluginContext(sourceId, targetId)
+    const chunk = metadataChunk('index.d.cts', sourceId, targetId)
+
+    await transform.handler.call(
+      context,
+      `/** @alpha */\nexport * as inner from './inner';\n`,
+      sourceId,
+      {} as never,
+    )
+    expect(
+      renderedCode(
+        await renderChunk.handler.call(
+          context,
+          renderedNamespace,
+          chunk,
+          {} as never,
+          renderMetadata(chunk),
+        ),
+      ),
+    ).toContain('/** @alpha */ declare namespace inner_d_exports')
+    await expect(
+      renderChunk.handler.call(
+        context,
+        `/** @alpha */ ${renderedNamespace}`,
+        chunk,
+        {} as never,
+        renderMetadata(chunk),
+      ),
+    ).resolves.toBeUndefined()
+
+    await transform.handler.call(
+      context,
+      `/** @beta */\nexport * as inner from './inner';\n`,
+      sourceId,
+      {} as never,
+    )
+    expect(
+      renderedCode(
+        await renderChunk.handler.call(
+          context,
+          renderedNamespace,
+          chunk,
+          {} as never,
+          renderMetadata(chunk),
+        ),
+      ),
+    ).toContain('/** @beta */ declare namespace inner_d_exports')
+
+    await transform.handler.call(
+      context,
+      `/** @public */\nexport interface Ordinary {}\n`,
+      sourceId,
+      {} as never,
+    )
+    await expect(
+      renderChunk.handler.call(
+        context,
+        renderedNamespace,
+        chunk,
+        {} as never,
+        renderMetadata(chunk),
+      ),
+    ).resolves.toBeUndefined()
+
+    await transform.handler.call(
+      context,
+      `/** @internal */\nexport * as inner from './inner';\n`,
+      sourceId,
+      {} as never,
+    )
+    const watchChange = plugin.watchChange
+    expect(watchChange).toBeTypeOf('function')
+    if (typeof watchChange !== 'function') return
+    await watchChange.call(context, sourceId, {event: 'delete'})
+    await expect(
+      renderChunk.handler.call(
+        context,
+        renderedNamespace,
+        chunk,
+        {} as never,
+        renderMetadata(chunk),
+      ),
+    ).resolves.toBeUndefined()
+  })
+
+  test('isolates one plugin instance by concurrent declaration contexts', async () => {
+    const sourceId = '/fixture/index.d.mts'
+    const targetId = '/fixture/inner.d.mts'
+    const chunk = metadataChunk('index.d.mts', sourceId, targetId)
+    const plugin = namespaceReleaseTagPlugin()
+    const transform = objectHook(plugin, 'transform')
+    const renderChunk = objectHook(plugin, 'renderChunk')
+    const alphaContext = metadataPluginContext(sourceId, targetId)
+    const betaContext = metadataPluginContext(sourceId, targetId)
+
+    await Promise.all([
+      transform.handler.call(
+        alphaContext,
+        `/** @alpha */\nexport * as inner from './inner';\n`,
+        sourceId,
+        {} as never,
+      ),
+      transform.handler.call(
+        betaContext,
+        `/** @beta */\nexport * as inner from './inner';\n`,
+        sourceId,
+        {} as never,
+      ),
+    ])
+    const [alphaResult, betaResult] = await Promise.all([
+      renderChunk.handler.call(
+        alphaContext,
+        renderedNamespace,
+        chunk,
+        {} as never,
+        renderMetadata(chunk),
+      ),
+      renderChunk.handler.call(
+        betaContext,
+        renderedNamespace,
+        chunk,
+        {} as never,
+        renderMetadata(chunk),
+      ),
+    ])
+
+    expect(renderedCode(alphaResult)).toContain('/** @alpha */ declare namespace inner_d_exports')
+    expect(renderedCode(betaResult)).toContain('/** @beta */ declare namespace inner_d_exports')
+  })
+
+  test('returns before parser, resolution, or module inspection for ordinary declarations', async () => {
+    const plugin = namespaceReleaseTagPlugin()
+    const transform = objectHook(plugin, 'transform')
+    const renderChunk = objectHook(plugin, 'renderChunk')
+    const inaccessibleContext = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error('plugin context should not be inspected')
+        },
+      },
+    ) as never
+
+    await expect(
+      transform.handler.call(
+        inaccessibleContext,
+        `/** @public */\nexport declare function hello(): string;\n`,
+        '/fixture/index.d.ts',
+        {} as never,
+      ),
+    ).resolves.toBeUndefined()
+
+    const ordinaryChunk = {
+      fileName: 'index.d.ts',
+      get moduleIds(): never {
+        throw new Error('moduleIds should not be read')
+      },
+    }
+    await expect(
+      renderChunk.handler.call(
+        inaccessibleContext,
+        `/** @public */\ndeclare function hello(): string;\nexport {hello};\n`,
+        ordinaryChunk as never,
+        {} as never,
+        {} as never,
+      ),
+    ).resolves.toBeUndefined()
+  })
 })
 
-async function createFixture(files: {index: string; inner?: string}): Promise<string> {
+const renderedNamespace =
+  `declare namespace inner_d_exports {\n  export { hello };\n}\n` +
+  `/** @public */\ndeclare function hello(): string;\n` +
+  `export { inner_d_exports as inner };\n`
+
+function objectHook<Name extends 'transform' | 'renderChunk'>(
+  plugin: Rolldown.Plugin,
+  name: Name,
+): Extract<NonNullable<Rolldown.Plugin[Name]>, {handler: unknown}> {
+  const hook = plugin[name]
+  if (!hook || typeof hook === 'function') throw new Error(`Expected an object ${name} hook`)
+  return hook as Extract<NonNullable<Rolldown.Plugin[Name]>, {handler: unknown}>
+}
+
+function metadataPluginContext(sourceId: string, targetId: string): never {
+  return metadataPluginContextForTargets(sourceId, {'./inner': targetId})
+}
+
+function metadataPluginContextForTargets(sourceId: string, targets: Record<string, string>): never {
+  const targetIds = new Set(Object.values(targets))
+  return {
+    async resolve(moduleSpecifier: string) {
+      const id = targets[moduleSpecifier]
+      return id ? {external: false, id} : null
+    },
+    getModuleInfo(id: string) {
+      return id === sourceId || targetIds.has(id) ? ({id, meta: {}} as never) : null
+    },
+  } as never
+}
+
+function metadataChunk(
+  fileName: string,
+  sourceId: string,
+  targetId: string,
+): Rolldown.RenderedChunk {
+  return {
+    facadeModuleId: sourceId,
+    fileName,
+    isEntry: true,
+    moduleIds: [sourceId, targetId],
+    modules: {
+      [sourceId]: {renderedExports: ['inner']},
+      [targetId]: {renderedExports: ['hello']},
+    },
+  } as Rolldown.RenderedChunk
+}
+
+function renderMetadata(chunk: Rolldown.RenderedChunk): never {
+  return {chunks: {[chunk.fileName]: chunk}} as never
+}
+
+function renderedCode(result: unknown): string | undefined {
+  if (!result || typeof result !== 'object' || !('code' in result)) return undefined
+  return typeof result.code === 'string' ? result.code : undefined
+}
+
+async function createFixture(files: Record<string, string>): Promise<string> {
   const fixtureDir = await mkdtemp(path.join(tmpdir(), 'tsdown-namespace-release-tag-'))
   fixtureDirs.push(fixtureDir)
   await mkdir(path.join(fixtureDir, 'src'))
@@ -118,28 +659,34 @@ async function createFixture(files: {index: string; inner?: string}): Promise<st
         include: ['src'],
       })}\n`,
     ),
-    writeFile(path.join(fixtureDir, 'src/index.ts'), files.index),
-    ...(files.inner === undefined
-      ? []
-      : [writeFile(path.join(fixtureDir, 'src/inner.ts'), files.inner)]),
+    ...Object.entries(files).map(([name, contents]) => {
+      const fileName = /\.[cm]?[jt]sx?$/.test(name) ? name : `${name}.ts`
+      return writeFile(path.join(fixtureDir, 'src', fileName), contents)
+    }),
   ])
   return fixtureDir
 }
 
-async function runBuild(cwd: string, format: UserConfig['format'] = 'esm'): Promise<unknown> {
+async function runBuild(
+  cwd: string,
+  format: UserConfig['format'] = 'esm',
+  entry: UserConfig['entry'] = './src/index.ts',
+  overrides: UserConfig = {},
+): Promise<unknown> {
   return build(
     mergeConfig(
       await defineConfig({
         clean: true,
         cwd,
         dts: {newContext: true, sourcemap: true},
-        entry: './src/index.ts',
+        entry,
         exports: false,
         format,
         outDir: 'dist',
         sourcemap: false,
         tsdoc: {rules: {'ae-missing-release-tag': 'error'}},
       }),
+      overrides,
       {logLevel: 'silent', publint: false},
     ),
   )

--- a/packages/@sanity/tsdown-config/test/options.test.ts
+++ b/packages/@sanity/tsdown-config/test/options.test.ts
@@ -41,7 +41,26 @@ describe('tsdoc option', () => {
       expect.objectContaining({checkTsdoc: expect.any(Function)}),
     )
   })
+
+  test('registers namespace release-tag repair only for declaration builds with TSDoc', async () => {
+    expect(inputPlugins(await defineConfig({dts: true, tsdoc: false}))).toBeUndefined()
+    expect(inputPlugins(await defineConfig({dts: false, tsdoc: true}))).toBeUndefined()
+
+    for (const config of [
+      await defineConfig({dts: true, tsdoc: true}),
+      // An omitted dts option lets tsdown enable declarations from package.json.
+      await defineConfig({tsdoc: true}),
+    ]) {
+      expect(inputPlugins(config)).toEqual([
+        expect.objectContaining({name: 'sanity-namespace-release-tags'}),
+      ])
+    }
+  })
 })
+
+function inputPlugins(config: UserConfig) {
+  return typeof config.inputOptions === 'function' ? undefined : config.inputOptions?.plugins
+}
 
 describe('define option', () => {
   test('is undefined by default', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -856,6 +856,9 @@ importers:
       lightningcss:
         specifier: 'catalog:'
         version: 1.33.0
+      magic-string:
+        specifier: ^1.1.0
+        version: 1.1.0
       package-manager-detector:
         specifier: ^1.8.0
         version: 1.8.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- capture authored release-tag metadata before `rolldown-plugin-dts` strips declaration comments, then restore it on synthesized namespace wrappers
- install the companion plugin only for declaration builds with TSDoc validation; ordinary declaration modules exit before parser loading, resolution, or graph inspection
- preserve tree-shaking, shared chunks, renamed/type-only exports, ESM/CJS, dtsInput, watch updates, and sourcemaps without suppressing API Extractor diagnostics
- merge the latest `main`

Fixes #3281.

## Testing
- `pnpm --dir packages/@sanity/tsdown-config exec vitest run test/namespace-release-tag.test.ts test/options.test.ts test/composition.test.ts` (69 passed)
- `pnpm --filter @sanity/tsdown-config test` (151 passed)
- `NODE_OPTIONS=--max_old_space_size=8192 pnpm test` (504 passed, 15 skipped)
- `NODE_OPTIONS=--max_old_space_size=8192 pnpm build`
- `pnpm lint`
- `NODE_OPTIONS=--max_old_space_size=8192 pnpm typecheck`
- `pnpm knip` (passes with the 3 existing unused-catalog warnings)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-630710d5-a817-43e9-885d-a7c3dac60dfb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-630710d5-a817-43e9-885d-a7c3dac60dfb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

