### PR TITLE
fix(pkg-utils): accept condensed runtime conditions in publishConfig.exports

### DIFF
--- a/.changeset/condensed-publish-runtime-conditions.md
+++ b/.changeset/condensed-publish-runtime-conditions.md
@@ -1,0 +1,13 @@
+---
+'@sanity/parse-package-json': patch
+'@sanity/pkg-utils': patch
+---
+
+Accept a runtime condition condensed to a plain string in `publishConfig.exports`
+(`"node": "./dist/index.node.js"` resolves identically to
+`"node": {"default": "./dist/index.node.js"}`), which is what is left of a `{source, default}`
+condition once `source` is stripped for publishing. Validating an export subpath now also picks the
+expected shape from the subpath itself, so a malformed entry is reported against the condition that
+is wrong instead of as `A conditional CSS export must resolve to at least one ".css" file`, and a
+`package.json` validation error that carries its own message is printed as a message rather than as
+a raw issue object.

--- a/packages/@sanity/parse-package-json/src/parsePackage.ts
+++ b/packages/@sanity/parse-package-json/src/parsePackage.ts
@@ -45,15 +45,113 @@ const exportEntrySchema = z
  * file in bundler/browser environments, while resolving to a no-op JS shim in runtimes (like Node)
  * that cannot import `.css` files directly.
  *
- * It is intentionally a flat map of condition name -> relative path string. To distinguish it from a
- * regular export entry (and to avoid silently accepting malformed objects), at least one of the
- * resolved targets must be a `.css` file.
+ * It is intentionally a flat map of condition name -> relative path string. Only `.css` subpaths
+ * are validated against it (see {@link exportSchemaFor}), and at least one of the resolved targets
+ * must be a `.css` file - otherwise `import "<pkg>/bundle.css"` resolves to something that isn't a
+ * stylesheet in every environment.
  */
 const cssExportConditionsSchema = z
   .record(z.string(), z.string())
   .refine((data) => Object.values(data).some((value) => value.endsWith('.css')), {
-    message: 'A conditional CSS export must resolve to at least one ".css" file',
+    message: 'A conditional export for a ".css" subpath must resolve to at least one ".css" file',
   })
+
+/**
+ * A `svelte` entry is not built by the pipeline, so the rest of its conditions are the author's to
+ * keep: it is validated, then passed through as authored.
+ */
+const svelteExportSchema = z
+  .object({
+    types: z.optional(z.string()),
+    svelte: z.string(),
+    default: z.optional(z.string()),
+  })
+  .passthrough()
+
+/**
+ * A subpath that ships a file as-is instead of building it, declared as a plain string. Every
+ * other subpath is a build entry, which needs its conditions (and its `source`) spelled out.
+ */
+const passthroughExportSchema = z.custom<`./${string}.json` | `./${string}.css`>(
+  (val) => typeof val === 'string' && /^\.\/.*\.(json|css)$/.test(val),
+  {
+    message:
+      'A string export target must be a ".json" or ".css" file that ships as-is. Other subpaths are build entries and must declare their conditions, including "source"',
+  },
+)
+
+/**
+ * A runtime condition (`browser`, `node`) nests the module-format conditions of that runtime, but
+ * may be condensed to a plain string when there is only one target left to resolve to - the
+ * resolver treats `"node": "./dist/index.node.js"` and `"node": {"default": "./dist/index.node.js"}`
+ * identically.
+ */
+const publishRuntimeConditionSchema = z.union([z.string(), z.record(z.string(), z.string())], {
+  errorMap: () => ({
+    message: 'A runtime condition must be a path string, or a map of condition name -> path string',
+  }),
+})
+
+const publishExportEntrySchema = z.object({
+  types: z.optional(z.string()),
+  browser: z.optional(publishRuntimeConditionSchema),
+  node: z.optional(publishRuntimeConditionSchema),
+  import: z.optional(z.string()),
+  require: z.optional(z.string()),
+  default: z.optional(z.string()),
+  svelte: z.optional(z.string()),
+})
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+/**
+ * The schema an export subpath is validated against. The subpath decides which shape is expected:
+ * a `.css` subpath carries a flat condition -> path map, everything else is a regular export entry.
+ * Dispatching up front - instead of trying every shape and reporting whichever error looks closest -
+ * is what keeps a malformed entry from being reported as a malformed CSS export.
+ */
+function exportSchemaFor(
+  exportPath: string,
+  value: unknown,
+  entrySchema: z.ZodTypeAny,
+  stringSchema: z.ZodTypeAny,
+): z.ZodTypeAny {
+  if (typeof value === 'string') return stringSchema
+  if (exportPath.endsWith('.css')) return cssExportConditionsSchema
+  if (isRecord(value) && 'svelte' in value) return svelteExportSchema
+  return entrySchema
+}
+
+/**
+ * An `exports` map, with each subpath validated against the shape its name implies. The parsed
+ * values are kept as-is (the record cannot type them per key), and narrowed by the consumers.
+ */
+function exportsMapSchema(entrySchema: z.ZodTypeAny, stringSchema: z.ZodTypeAny) {
+  return z.record(z.string(), z.unknown()).transform((exportsMap, ctx) => {
+    const parsed: Record<string, unknown> = {}
+
+    for (const [exportPath, value] of Object.entries(exportsMap)) {
+      const result = exportSchemaFor(exportPath, value, entrySchema, stringSchema).safeParse(value)
+
+      if (result.success) {
+        parsed[exportPath] = result.data
+        continue
+      }
+
+      for (const issue of result.error.issues) {
+        ctx.addIssue({...issue, path: [exportPath, ...issue.path]})
+      }
+    }
+
+    return parsed
+  })
+}
 
 const basePkgSchema = z.object({
   type: z.enum(['commonjs', 'module']).default('commonjs'),
@@ -69,46 +167,15 @@ const basePkgSchema = z.object({
   browser: z.optional(z.record(z.string())),
   module: z.optional(z.string()),
   types: z.optional(z.string()),
-  exports: z.optional(
-    z.record(
-      z.union([
-        z.custom<`./${string}.json`>(
-          (val) => typeof val === 'string' && /^\.\/.*\.json$/.test(val),
-        ),
-        z.custom<`./${string}.css`>((val) => typeof val === 'string' && /^\.\/.*\.css$/.test(val)),
-        exportEntrySchema,
-        z.object({
-          types: z.optional(z.string()),
-          svelte: z.string(),
-          default: z.optional(z.string()),
-        }),
-        cssExportConditionsSchema,
-      ]),
-    ),
-  ),
+  exports: z.optional(exportsMapSchema(exportEntrySchema, passthroughExportSchema)),
   publishConfig: z.optional(
     z
       .object({
         access: z.optional(z.enum(['public', 'restricted'])),
         registry: z.optional(z.string()),
         tag: z.optional(z.string()),
-        exports: z.optional(
-          z.record(
-            z.union([
-              z.string(),
-              z.object({
-                types: z.optional(z.string()),
-                browser: z.optional(z.record(z.string())),
-                node: z.optional(z.record(z.string())),
-                import: z.optional(z.string()),
-                require: z.optional(z.string()),
-                default: z.optional(z.string()),
-                svelte: z.optional(z.string()),
-              }),
-              cssExportConditionsSchema,
-            ]),
-          ),
-        ),
+        // A publish map holds no `source`, so a single-target entry may be a plain string
+        exports: z.optional(exportsMapSchema(publishExportEntrySchema, z.string())),
       })
       .passthrough(), // Allow any other npm config options
   ),
@@ -128,25 +195,24 @@ const pkgSchema = basePkgSchema.transform((pkg): PackageJSON => {
   const transformedExports: Record<string, unknown> = {}
 
   for (const [key, value] of Object.entries(pkg.exports)) {
-    if (typeof value === 'string') {
+    // Strings, conditional CSS exports (a flat map of condition -> path, for which no `default`
+    // is computed) and svelte entries pass through untouched.
+    if (!isRecord(value) || key.endsWith('.css') || 'svelte' in value) {
       transformedExports[key] = value
-    } else if (key.endsWith('.css')) {
-      // Conditional CSS exports are a flat map of condition -> path; pass through untouched
-      // (no `default` is computed for CSS files).
-      transformedExports[key] = value
-    } else if ('svelte' in value) {
-      transformedExports[key] = value
-    } else {
-      // Compute default: use `import` for type: 'module', otherwise `require`
-      // The refine guarantees at least one of default/import/require exists
-      const computedDefault = isModule
-        ? (value.import ?? value.require)!
-        : (value.require ?? value.import)!
+      continue
+    }
 
-      transformedExports[key] = {
-        ...value,
-        default: value.default ?? computedDefault,
-      }
+    // Compute default: use `import` for type: 'module', otherwise `require`
+    // The refine guarantees at least one of default/import/require exists
+    const importTarget = asString(value['import'])
+    const requireTarget = asString(value['require'])
+    const computedDefault = isModule
+      ? (importTarget ?? requireTarget)
+      : (requireTarget ?? importTarget)
+
+    transformedExports[key] = {
+      ...value,
+      default: asString(value['default']) ?? computedDefault,
     }
   }
 

--- a/packages/@sanity/parse-package-json/src/types.ts
+++ b/packages/@sanity/parse-package-json/src/types.ts
@@ -101,16 +101,25 @@ export interface PackageJSON {
       | string
       | {
           types?: string
-          browser?: {
-            import?: string
-            require?: string
-            default?: string
-          }
-          node?: {
-            import?: string
-            require?: string
-            default?: string
-          }
+          /**
+           * A runtime condition may be condensed to a plain string when only one target is left to
+           * resolve to: `"browser": "./dist/index.browser.js"` and
+           * `"browser": {"default": "./dist/index.browser.js"}` resolve identically.
+           */
+          browser?:
+            | string
+            | {
+                import?: string
+                require?: string
+                default?: string
+              }
+          node?:
+            | string
+            | {
+                import?: string
+                require?: string
+                default?: string
+              }
           import?: string
           require?: string
           default: string

--- a/packages/@sanity/parse-package-json/test/parsePackage.test.ts
+++ b/packages/@sanity/parse-package-json/test/parsePackage.test.ts
@@ -1,5 +1,15 @@
-import {_typoMap, parsePackage, type PackageJSON} from '@sanity/parse-package-json'
+import {_typoMap, parsePackage, ZodError, type PackageJSON} from '@sanity/parse-package-json'
 import {describe, expect, test} from 'vitest'
+
+function issuesOf(input: unknown) {
+  try {
+    parsePackage(input)
+  } catch (err) {
+    if (err instanceof ZodError) return err.issues
+    throw err
+  }
+  return []
+}
 
 describe('parsePackage', () => {
   const template = {
@@ -326,6 +336,28 @@ describe('parsePackage', () => {
     expect(parsed.exports?.['./styles.css']).toBe('./dist/styles.css')
   })
 
+  test('passes a `svelte` entry through untouched', () => {
+    const pkg = {
+      ...template,
+      exports: {
+        ...template.exports,
+        './Component.svelte': {
+          types: './dist/Component.svelte.d.ts',
+          svelte: './dist/Component.svelte',
+          default: './dist/Component.js',
+        },
+      },
+    }
+
+    const parsed = parsePackage(pkg)
+
+    expect(parsed.exports?.['./Component.svelte']).toEqual({
+      types: './dist/Component.svelte.d.ts',
+      svelte: './dist/Component.svelte',
+      default: './dist/Component.js',
+    })
+  })
+
   test('rejects a conditional object export with no `.css` target that is otherwise malformed', () => {
     const pkg = {
       ...template,
@@ -337,6 +369,81 @@ describe('parsePackage', () => {
     }
 
     expect(() => parsePackage(pkg)).toThrow()
+  })
+
+  describe('conditional CSS exports are only expected on `.css` subpaths', () => {
+    test('reports the offending condition for a non-`.css` subpath, not a missing `.css` file', () => {
+      // A `node` condition in `exports` must be an object: the build derives the node variant of
+      // the entry from its `source`. The error must point at the condition that is wrong.
+      const issues = issuesOf({
+        ...template,
+        exports: {
+          ...template.exports,
+          '.': {
+            source: './src/index.ts',
+            node: './dist/index.node.js',
+            default: './dist/index.js',
+          },
+        },
+      })
+
+      expect(issues).toEqual([
+        expect.objectContaining({
+          code: 'invalid_type',
+          expected: 'object',
+          received: 'string',
+          path: ['exports', '.', 'node'],
+        }),
+      ])
+    })
+
+    test('still requires a `.css` target on a conditional `.css` export', () => {
+      const issues = issuesOf({
+        ...template,
+        exports: {
+          ...template.exports,
+          './bundle.css': {node: './dist/bundle-css.js', default: './dist/bundle-css.js'},
+        },
+      })
+
+      expect(issues).toEqual([
+        expect.objectContaining({
+          message: expect.stringContaining('".css" file'),
+          path: ['exports', './bundle.css'],
+        }),
+      ])
+    })
+  })
+
+  describe('publishConfig.exports', () => {
+    test('accepts a runtime condition condensed to a string', () => {
+      // `"node": "./dist/index.node.js"` is what is left of `{source, default}` once the `source`
+      // condition is stripped for publishing - the resolver treats it as `{default: <path>}`.
+      const pkg = {
+        ...template,
+        exports: {
+          ...template.exports,
+          '.': {
+            'source': './src/index.ts',
+            'react-server': './dist/index.js',
+            'node': {source: './src/index.node.ts', default: './dist/index.node.js'},
+            'default': './dist/index.js',
+          },
+        },
+        publishConfig: {
+          exports: {
+            '.': {
+              'react-server': './dist/index.js',
+              'node': './dist/index.node.js',
+              'default': './dist/index.js',
+            },
+            './package.json': './package.json',
+          },
+        },
+      }
+
+      expect(() => parsePackage(pkg)).not.toThrow()
+    })
   })
 })
 

--- a/packages/@sanity/pkg-utils/src/node/core/pkg/loadPkgWithReporting.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/pkg/loadPkgWithReporting.ts
@@ -6,10 +6,35 @@ import {checkDependencyPlacement} from './dependencyPlacement.ts'
 import {assertLast, assertOrder} from './helpers.ts'
 import {loadPkg} from './loadPkg.ts'
 
+/** The conditions that only resolve before publishing, and are stripped from the publish map. */
+const devConditions = new Set(['source', 'development', 'monorepo'])
+
+/**
+ * A nested runtime condition (`node`, `browser`) may be condensed to a plain string when `default`
+ * is the only condition left once the dev-only ones are stripped: the resolver treats
+ * `"node": "./dist/index.node.js"` and `"node": {"default": "./dist/index.node.js"}` identically.
+ * This is the same condensation `publishConfig.exports["<subpath>"]` itself allows at entry level.
+ */
+function condenseExportValue(value: unknown): unknown {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return value
+
+  const conditions = Object.entries(value).filter(([condition]) => !devConditions.has(condition))
+  const [first] = conditions
+
+  if (conditions.length === 1 && first?.[0] === 'default' && typeof first[1] === 'string') {
+    return first[1]
+  }
+
+  return value
+}
+
 /**
  * Helper function to recursively compare export values, excluding source, development, and monorepo conditions
  */
-function areExportValuesEqual(value1: unknown, value2: unknown): boolean {
+function areExportValuesEqual(input1: unknown, input2: unknown): boolean {
+  const value1 = condenseExportValue(input1)
+  const value2 = condenseExportValue(input2)
+
   // If both are strings, simple comparison
   if (typeof value1 === 'string' && typeof value2 === 'string') {
     return value1 === value2
@@ -32,12 +57,8 @@ function areExportValuesEqual(value1: unknown, value2: unknown): boolean {
     const obj1 = value1 as Record<string, any>
     const obj2 = value2 as Record<string, any>
 
-    const keys1 = Object.keys(obj1).filter(
-      (k) => k !== 'source' && k !== 'development' && k !== 'monorepo',
-    )
-    const keys2 = Object.keys(obj2).filter(
-      (k) => k !== 'source' && k !== 'development' && k !== 'monorepo',
-    )
+    const keys1 = Object.keys(obj1).filter((k) => !devConditions.has(k))
+    const keys2 = Object.keys(obj2).filter((k) => !devConditions.has(k))
 
     // Check if they have the same keys
     if (keys1.length !== keys2.length) {
@@ -426,7 +447,13 @@ export async function loadPkgWithReporting(options: {
           continue
         }
 
-        logger.error(issue)
+        // Every other issue carries its own message: report it against the path it was found at,
+        // rather than dumping the raw issue object.
+        logger.error(
+          issue.path.length
+            ? `\`${formatPath(issue.path)}\` in \`./package.json\` is invalid: ${issue.message}`
+            : `\`./package.json\` is invalid: ${issue.message}`,
+        )
       }
     } else {
       logger.error(err)

--- a/packages/@sanity/pkg-utils/test/publishConfigExports.test.ts
+++ b/packages/@sanity/pkg-utils/test/publishConfigExports.test.ts
@@ -314,6 +314,103 @@ describe('publishConfig.exports validation', () => {
     )
   })
 
+  test('should pass when a nested runtime condition is condensed to a string', async () => {
+    // `"node": "./dist/index.node.js"` is all that is left of `{source, default}` once the
+    // `source` condition is stripped for publishing, and resolves identically to
+    // `{"default": "./dist/index.node.js"}` - the same condensation the entry itself allows.
+    await testPackage(
+      {
+        name: 'test-pkg',
+        version: '1.0.0',
+        license: 'MIT',
+        type: 'module',
+        exports: {
+          '.': {
+            source: './src/index.ts',
+            node: {
+              source: './src/index.node.ts',
+              default: './dist/index.node.js',
+            },
+            default: './dist/index.js',
+          },
+        },
+        publishConfig: {
+          exports: {
+            '.': {
+              node: './dist/index.node.js',
+              default: './dist/index.js',
+            },
+          },
+        },
+        files: ['dist'],
+      },
+      false,
+    )
+  })
+
+  test('should fail when a condensed nested runtime condition points at the wrong file', async () => {
+    await testPackage(
+      {
+        name: 'test-pkg',
+        version: '1.0.0',
+        license: 'MIT',
+        type: 'module',
+        exports: {
+          '.': {
+            source: './src/index.ts',
+            node: {
+              source: './src/index.node.ts',
+              default: './dist/index.node.js',
+            },
+            default: './dist/index.js',
+          },
+        },
+        publishConfig: {
+          exports: {
+            '.': {
+              node: './dist/index.js',
+              default: './dist/index.js',
+            },
+          },
+        },
+        files: ['dist'],
+      },
+      true,
+    )
+  })
+
+  test('should fail when a nested runtime condition is condensed but has more than `default`', async () => {
+    await testPackage(
+      {
+        name: 'test-pkg',
+        version: '1.0.0',
+        license: 'MIT',
+        type: 'module',
+        exports: {
+          '.': {
+            source: './src/index.ts',
+            node: {
+              source: './src/index.node.ts',
+              require: './dist/index.node.cjs',
+              default: './dist/index.node.js',
+            },
+            default: './dist/index.js',
+          },
+        },
+        publishConfig: {
+          exports: {
+            '.': {
+              node: './dist/index.node.js',
+              default: './dist/index.js',
+            },
+          },
+        },
+        files: ['dist'],
+      },
+      true,
+    )
+  })
+
   test('should pass when a `.css` subpath declares only its `source`', async () => {
     // The documented way to ship a stylesheet: the author writes the `source` and the build
     // fills the remaining conditions into both maps. Before that first build `exports` holds


### PR DESCRIPTION
Reported against `@sanity/client`, where `pkg build --strict && pkg --strict` failed with:

```
[error] {
  code: 'custom',
  message: 'A conditional CSS export must resolve to at least one ".css" file',
  path: [ 'publishConfig', 'exports', '.' ]
}
```

for a `publishConfig.exports` entry that contains no CSS at all:

```json
"node": "./dist/index.node.js"
```

## Why the message was wrong

`parsePackage` validated every export subpath against a union of shapes and reported whichever error looked closest. One union member is the conditional CSS map, `z.record(z.string(), z.string())`, which structurally matches *any* flat condition to path map. The entry above is exactly that, so it was the only member that parsed, failing only its "at least one `.css` target" refinement. zod v3 reports a refinement-failed option's issues verbatim when no option is valid, so the CSS message masked the real mismatch: `node` was typed as object-only and the author wrote a string.

Validation now picks the expected shape from the subpath itself: a `.css` subpath gets the conditional CSS map, everything else an export entry. The CSS requirement can only be reported where it applies, and a malformed entry is reported against the condition that is wrong.

## Why it should not have been an error

`"node": "./dist/index.node.js"` and `"node": {"default": "./dist/index.node.js"}` resolve identically, and the string form is what is left of `{source, default}` once `source` is stripped for publishing. pkg-utils already accepts the same condensation one level up (`"./csm": "./dist/csm.js"`), so refusing it on a nested runtime condition was arbitrary. `publishConfig.exports` now accepts it, and the cross-map check compares it as equal to the nested form. The next build rewrites it to the nested shape the composer generates, so the file settles on its own.

It stays an error in the top-level `exports` map, which is build input: the build derives the node variant from `exports["."].node.source`, so a bare string there would name a file nothing builds. That case now reports:

```
[error] `exports["."].node` in `./package.json` must be of type object (received string)
```

## Changes

- `@sanity/parse-package-json`: per-subpath schema dispatch; `publishConfig.exports` accepts a condensed string `browser`/`node` condition, reflected in the public types. A malformed runtime condition says what is expected instead of `Invalid input`, and a plain-string entry that is neither `.json` nor `.css` explains that other subpaths are build entries.
- `@sanity/pkg-utils`: `areExportValuesEqual` treats a condensed string condition as equal to `{default: <path>}`. Non-`invalid_type` zod issues are printed as messages against their path instead of dumping the raw issue object.
- Tests: condensed `node` accepted, mismatched target still rejected, condensing an entry with more than `default` still rejected, non-CSS entries no longer blamed for CSS, `.css` subpaths still required to resolve to a stylesheet, plus first coverage for a `svelte` entry passing through untouched.

## Unrelated finding, not touched here

Running the suite rewrites `playground/css-entry/package.json`, moving `source` ahead of `types` in the `./ui/styles.css` export: `reconcileCssEntry` writes `{source, ...conditions}` without preserving authored order, so the committed fixture disagrees with what any build produces. Reverted to keep this diff focused.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared package.json parsing and strict validation used by many packages; behavior change is narrowly scoped to export shape rules and comparison logic, with broad test coverage.
> 
> **Overview**
> Fixes **strict `package.json` validation** failing on legitimate `publishConfig.exports` shapes (e.g. `@sanity/client`) with a misleading CSS export error when `"node"` was a path string instead of an object.
> 
> **`@sanity/parse-package-json`** validates each export subpath by **expected shape** (`.css` → conditional CSS map, `svelte` → svelte schema, strings → passthrough `.json`/`.css`, else build entry) instead of a Zod union that could mis-attribute errors. **`publishConfig.exports`** now allows **`browser` / `node` as either a string or a condition map** (string ≡ `{ default: path }` after stripping `source`). Types and error copy are updated accordingly.
> 
> **`@sanity/pkg-utils`** treats that same condensation when **comparing `exports` vs `publishConfig.exports`**, and prints **Zod issues with path + message** instead of dumping raw issue objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4372817e1e434784d6d0fd10447b7962021e0ecf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->