### PR TITLE
feat(tsdown-config): add first-class `bundleAnalyzer` option

### DIFF
--- a/.changeset/bundle-analyzer-option.md
+++ b/.changeset/bundle-analyzer-option.md
@@ -1,0 +1,14 @@
+---
+'@sanity/tsdown-config': minor
+'@sanity/pkg-utils': minor
+---
+
+Add a `bundleAnalyzer` option that wires Rolldown's experimental markdown bundle analyzer.
+
+`true` selects `format: 'md'` (an LLM-friendly `analyze-data.md` in `outDir`) rather than the plugin's own JSON default, so an env-gated opt-in is enough:
+
+```ts
+bundleAnalyzer: process.env.ENABLE_BUNDLE_ANALYZER === 'true'
+```
+
+Pass an object to customize `format` / `fileName`. The report is not a publishable artifact — exclude it from `package.json` `files` (e.g. `"!dist/analyze-data.md"`). `@sanity/pkg-utils` forwards the same option from `package.config.ts`.

--- a/packages/@sanity/pkg-utils/README.md
+++ b/packages/@sanity/pkg-utils/README.md
@@ -84,6 +84,26 @@ export default defineConfig({
 An array of entry points to bundle. This is useful if you want to bundle something that should not
 be exported by the package, e.g. CLI scripts or Node.js workers.
 
+#### `bundleAnalyzer`
+
+- Type: `boolean | PackageBundleAnalyzerOptions`
+- Default: `false`
+
+Enables Rolldown's experimental
+[`bundleAnalyzerPlugin`](https://rolldown.rs/builtin-plugins/bundle-analyzer) to emit a report of
+what the package itself bundles. Pass `true` for the defaults (`format: 'md'`, an LLM-friendly
+`analyze-data.md` in `dist`), or an options object to customize. Analysis adds work to the build,
+so this stays off by default — typical usage is an env-gated opt-in:
+
+```ts
+export default defineConfig({
+  bundleAnalyzer: process.env.ENABLE_BUNDLE_ANALYZER === 'true',
+})
+```
+
+The report is **not** a publishable artifact. Exclude it from `package.json` `files` (e.g.
+`"!dist/analyze-data.md"`) so an accidental analyze build cannot ship it.
+
 #### `clean`
 
 - Type: `boolean | string[]`

--- a/packages/@sanity/pkg-utils/src/node/core/config/types.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/config/types.ts
@@ -1,5 +1,6 @@
 import type {PkgExports} from '@sanity/parse-package-json'
 import type {
+  PackageBundleAnalyzerOptions,
   PackageCssOptions,
   PackageTsdocCustomTag,
   PackageTsdocOptions,
@@ -13,6 +14,7 @@ import type {StrictOptions} from '../../strict.ts'
 
 export type {PkgExport, PkgExports} from '@sanity/parse-package-json'
 export type {
+  PackageBundleAnalyzerOptions,
   PackageCssOptions,
   PackageTsdocCustomTag,
   PackageTsdocOptions,
@@ -65,6 +67,25 @@ export type PkgTsdocOptions = PackageTsdocOptions
 /** @public */
 export interface PkgConfigOptions {
   bundles?: PkgBundle[]
+  /**
+   * Enables Rolldown's experimental
+   * [`bundleAnalyzerPlugin`](https://rolldown.rs/builtin-plugins/bundle-analyzer) to emit a
+   * report of what the package itself bundles. Pass `true` for the defaults (`format: 'md'`,
+   * an LLM-friendly `analyze-data.md` in `dist`), or an options object to customize.
+   *
+   * Analysis adds work to the build, so this stays off by default — typical usage is an
+   * env-gated opt-in:
+   *
+   * ```ts
+   * bundleAnalyzer: process.env.ENABLE_BUNDLE_ANALYZER === 'true'
+   * ```
+   *
+   * The report is **not** a publishable artifact. Exclude it from `package.json` `files`
+   * (e.g. `"!dist/analyze-data.md"`) so an accidental analyze build cannot ship it.
+   * @defaultValue false
+   * @alpha This option wraps Rolldown's experimental analyzer, whose API may change.
+   */
+  bundleAnalyzer?: boolean | PackageBundleAnalyzerOptions
   /**
    * tsdown's `clean` option, passed through as-is. Cleaning is on by default: `true` (the
    * default) cleans the `dist` folder before the build, `false` skips cleaning, and a
@@ -145,7 +166,7 @@ export interface PkgConfigOptions {
   minify?: boolean
   /**
    * Extra rolldown plugins, appended after the plugins pkg-utils sets up (React Compiler,
-   * vanilla-extract). Most Rollup plugins are also compatible.
+   * vanilla-extract, bundle analyzer). Most Rollup plugins are also compatible.
    * @see https://tsdown.dev/advanced/plugins
    * @alpha
    */

--- a/packages/@sanity/pkg-utils/src/node/index.ts
+++ b/packages/@sanity/pkg-utils/src/node/index.ts
@@ -15,6 +15,7 @@ export type {
   PackageTsdocOptions,
   PackageTsdocRuleLevel,
   PkgConfigOptions,
+  PackageBundleAnalyzerOptions,
   PackageVanillaExtractOptions,
   ReactCompilerOptions,
   StyledComponentsOptions,

--- a/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
+++ b/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
@@ -177,6 +177,7 @@ export async function resolveTsdownConfig(
     reactCompiler: config?.reactCompiler,
     styledComponents: config?.styledComponents,
     vanillaExtract: config?.vanillaExtract,
+    bundleAnalyzer: config?.bundleAnalyzer,
     // Types-only builds still emit `.d.ts` files that deserve the check; watch mode skips it
     // so a failing TSDoc rule doesn't tear down the watcher on every save.
     tsdoc: options.watch ? false : tsdocOption,

--- a/packages/@sanity/pkg-utils/test/resolveTsdownConfig.test.ts
+++ b/packages/@sanity/pkg-utils/test/resolveTsdownConfig.test.ts
@@ -94,6 +94,55 @@ test('the `dts` object passthrough spreads over the defaults', async () => {
   expect(inlineConfig.dts).toEqual({newContext: true, tsgo: true, sourcemap: true})
 })
 
+test('forwards `bundleAnalyzer` to @sanity/tsdown-config', async () => {
+  const disabled = createContext({})
+  const [disabledBuild] = resolveTsdownBuilds(disabled)
+  if (!disabledBuild) throw new Error('expected a build')
+  const disabledConfig = await resolveTsdownConfig(disabled, disabledBuild, {clean: false})
+  expect(pluginNames(disabledConfig)).not.toContain('builtin:bundle-analyzer')
+
+  const enabled = createContext({bundleAnalyzer: true})
+  const [enabledBuild] = resolveTsdownBuilds(enabled)
+  if (!enabledBuild) throw new Error('expected a build')
+  const enabledConfig = await resolveTsdownConfig(enabled, enabledBuild, {clean: false})
+  expect(pluginNames(enabledConfig)).toContain('builtin:bundle-analyzer')
+  expect(bundleAnalyzerOptions(enabledConfig)).toEqual({format: 'md'})
+
+  const customized = createContext({
+    bundleAnalyzer: {format: 'json', fileName: 'bundle-analysis.json'},
+  })
+  const [customizedBuild] = resolveTsdownBuilds(customized)
+  if (!customizedBuild) throw new Error('expected a build')
+  const customizedConfig = await resolveTsdownConfig(customized, customizedBuild, {clean: false})
+  expect(bundleAnalyzerOptions(customizedConfig)).toEqual({
+    format: 'json',
+    fileName: 'bundle-analysis.json',
+  })
+})
+
+function pluginNames(config: {plugins?: unknown}): string[] {
+  const {plugins} = config
+  if (!Array.isArray(plugins)) return []
+  return plugins.flatMap((plugin) =>
+    plugin && typeof plugin === 'object' && 'name' in plugin && typeof plugin.name === 'string'
+      ? [plugin.name]
+      : [],
+  )
+}
+
+function bundleAnalyzerOptions(config: {plugins?: unknown}): unknown {
+  const {plugins} = config
+  if (!Array.isArray(plugins)) return undefined
+  const plugin = plugins.find(
+    (candidate) =>
+      candidate &&
+      typeof candidate === 'object' &&
+      'name' in candidate &&
+      candidate.name === 'builtin:bundle-analyzer',
+  )
+  return plugin && typeof plugin === 'object' && '_options' in plugin ? plugin._options : undefined
+}
+
 test('inherits the declaration-only circular dependency suppression', async () => {
   // `checks.circularDependency` comes from `@sanity/tsdown-config`, and so does the
   // `suppressWarnings` predicate that drops the type-only cycles of the declaration bundling

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -532,6 +532,52 @@ const config = await defineConfig({
 })
 ```
 
+## bundleAnalyzer
+
+Enables Rolldown's experimental
+[`bundleAnalyzerPlugin`](https://rolldown.rs/builtin-plugins/bundle-analyzer) to emit a report of
+what the package itself bundles — chunks, modules, dependency chains — next to the build output.
+The plugin is currently experimental (exported from `rolldown/experimental`); this option is
+`@alpha` to match.
+
+Analysis adds work to the build, so the option stays off by default. Typical usage is an
+env-gated opt-in so everyday `pnpm build` / publish is unchanged:
+
+```ts
+import {defineConfig} from '@sanity/tsdown-config'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  bundleAnalyzer: process.env.ENABLE_BUNDLE_ANALYZER === 'true',
+})
+```
+
+`true` selects `format: 'md'` — an LLM-friendly markdown report (`analyze-data.md` in `outDir`)
+— rather than the plugin's own `'json'` default. Pass an object to customize:
+
+```ts
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  bundleAnalyzer: {
+    format: 'json',
+    fileName: 'bundle-analysis.json',
+  },
+})
+```
+
+The report is **not** a publishable artifact. Exclude it from `package.json` `files` so an
+accidental analyze build cannot ship it:
+
+```json
+{
+  "files": ["dist", "!dist/analyze-data.md"]
+}
+```
+
+With [`reactCompiler.reactServer`](#react-server-components-reactserver) only the compiled
+(`default`) variant is analyzed — the `react-server` variant skips it so the two parallel
+builds don't overwrite one report in the shared `outDir`.
+
 ## checks
 
 Rolldown's [`checks.circularDependency`](https://rolldown.rs/reference/InputOptions.checks#circulardependency)
@@ -615,7 +661,8 @@ like `@sanity/pkg-utils` compose their own opinions over it programmatically. `m
 applies with tsdown's semantics:
 
 - `plugins` (top-level, `inputOptions`, `outputOptions`) are **appended**, so layering your own
-  plugins never clobbers the ones this config sets up (React Compiler, vanilla-extract),
+  plugins never clobbers the ones this config sets up (React Compiler, vanilla-extract, bundle
+  analyzer),
 - plain objects deep-merge over the defaults (e.g. `minify: {mangle: true}` keeps the
   `compress`/`codegen` defaults), and
 - scalars and non-plugin arrays replace (e.g. `publint: false`, `format: ['esm']`).

--- a/packages/@sanity/tsdown-config/package.json
+++ b/packages/@sanity/tsdown-config/package.json
@@ -54,7 +54,8 @@
     "jsonc-parser": "^3.3.1",
     "lightningcss": "catalog:",
     "package-manager-detector": "^1.8.0",
-    "publint": "^0.3.23"
+    "publint": "^0.3.23",
+    "rolldown": "~1.2.4"
   },
   "devDependencies": {
     "@sanity/pkg-utils": "workspace:^",
@@ -62,7 +63,6 @@
     "@tsdown/css": "^0.22.14",
     "@types/babel__core": "^7.20.5",
     "babel-plugin-react-compiler": "^1.0.0",
-    "rolldown": "~1.2.4",
     "tinyexec": "^1.3.0",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -93,6 +93,38 @@ export type PackageCssOptions = NonNullable<UserConfig['css']> & {
 }
 
 /**
+ * Options for the `bundleAnalyzer` option — the same options as Rolldown's experimental
+ * [`bundleAnalyzerPlugin`](https://rolldown.rs/builtin-plugins/bundle-analyzer)
+ * (`fileName`, `format`).
+ *
+ * When enabled with `true`, defaults to `{format: 'md'}` (an LLM-friendly markdown report)
+ * rather than the plugin's own `'json'` default — that's the report Sanity library builds
+ * want. Pass `{format: 'json'}` for the structured data file visualizers consume.
+ *
+ * The report is emitted into `outDir` (`analyze-data.md` by default) and is **not** a
+ * publishable artifact. Exclude it from `package.json` `files` (e.g.
+ * `"!dist/analyze-data.md"` / `"!lib/analyze-data.md"`) so an accidental analyze build
+ * cannot ship it.
+ * @public
+ * @alpha This option wraps Rolldown's experimental analyzer, whose API may change.
+ */
+export interface PackageBundleAnalyzerOptions {
+  /**
+   * The filename used for the emitted analysis asset. The file is written into the same
+   * output directory as the rest of the bundle.
+   * @defaultValue `'analyze-data.md'` when `format` is `'md'`, `'analyze-data.json'` when
+   * `format` is `'json'`
+   */
+  fileName?: string
+  /**
+   * `'md'` produces an LLM-friendly markdown report (Quick Summary, largest modules, entry
+   * points, dependency chains); `'json'` produces structured data for visualizers.
+   * @defaultValue `'md'`
+   */
+  format?: 'json' | 'md'
+}
+
+/**
  * Options for the `styled-components` transform, the same options as `babel-plugin-styled-components`.
  * @public
  */
@@ -266,6 +298,33 @@ export interface PackageOptions extends Pick<
    */
   css?: PackageCssOptions
   /**
+   * Enables Rolldown's experimental
+   * [`bundleAnalyzerPlugin`](https://rolldown.rs/builtin-plugins/bundle-analyzer)
+   * (`rolldown/experimental`) to emit a report of what the package itself bundles — chunks,
+   * modules, dependency chains — next to the build output. Pass `true` to use the defaults,
+   * or an object to customize.
+   *
+   * Unlike the plugin's own defaults (`format: 'json'`), `true` selects `format: 'md'`: an
+   * LLM-friendly markdown report (`analyze-data.md` in `outDir`). Pass `{format: 'json'}`
+   * for the structured data file visualizers consume. Analysis adds work to the build, so
+   * this stays off by default — typical usage is an env-gated opt-in:
+   *
+   * ```ts
+   * bundleAnalyzer: process.env.ENABLE_BUNDLE_ANALYZER === 'true'
+   * ```
+   *
+   * The report is **not** a publishable artifact. Exclude it from `package.json` `files`
+   * (e.g. `"!dist/analyze-data.md"` / `"!lib/analyze-data.md"`) so an accidental analyze
+   * build cannot ship it.
+   *
+   * With {@link ReactCompilerOptions.reactServer | `reactCompiler.reactServer`}, only the
+   * compiled (`default`) variant is analyzed — the `react-server` variant skips it so the
+   * two builds don't overwrite one report.
+   * @defaultValue false
+   * @alpha This option wraps Rolldown's experimental analyzer, whose API may change.
+   */
+  bundleAnalyzer?: boolean | PackageBundleAnalyzerOptions
+  /**
    * Runs `babel-plugin-react-compiler` on the source files before they are bundled, so published
    * components are memoized automatically. Pass `true` to use the defaults, or an options object
    * to configure the compiler (e.g. `{target: '18'}`).
@@ -423,6 +482,10 @@ async function resolvePackageConfig(
   // loads `react/compiler-runtime`, which throws in the `react-server` environment.
   const reactCompiler = isReactServer ? false : (options.reactCompiler ?? false)
   const styledComponents = options.styledComponents ?? false
+  // The `react-server` variant skips the analyzer so the two parallel builds don't race on
+  // one `analyze-data.md` in the shared `outDir`. The compiled variant is the published
+  // client bundle — that's the report worth reading.
+  const bundleAnalyzer = isReactServer ? false : (options.bundleAnalyzer ?? false)
   // The `react-server` variant skips TSDoc checking (it emits no `.d.ts` files — the compiled
   // variant's declarations serve both entries), matching how it skips `publint`.
   const tsdoc = isReactServer ? false : (options.tsdoc ?? false)
@@ -570,6 +633,19 @@ async function resolvePackageConfig(
       }),
     )
     css = {...css, inject: false}
+  }
+
+  if (bundleAnalyzer !== false) {
+    // Lazy loaded, like `reactCompiler` / `vanillaExtract`, so `rolldown/experimental` is
+    // only paid for when the option is enabled. `true` selects markdown — Rolldown's own
+    // default is JSON, which is worse for humans and coding agents.
+    const {bundleAnalyzerPlugin} = await import('rolldown/experimental')
+    plugins.push(
+      bundleAnalyzerPlugin({
+        format: 'md',
+        ...(typeof bundleAnalyzer === 'object' ? bundleAnalyzer : {}),
+      }),
+    )
   }
 
   // The `react-server` variant does not participate in `exports` generation: its files are

--- a/packages/@sanity/tsdown-config/test/bundle-analyzer.test.ts
+++ b/packages/@sanity/tsdown-config/test/bundle-analyzer.test.ts
@@ -1,0 +1,99 @@
+import {readFile} from 'node:fs/promises'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+import type {UserConfig} from 'tsdown'
+import {describe, expect, test} from 'vitest'
+import {defineConfig} from '../src/index.ts'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const fixtureDir = path.resolve(__dirname, 'fixtures/bundle-analyzer-library')
+
+const BUNDLE_ANALYZER_PLUGIN = 'builtin:bundle-analyzer'
+
+function getPlugins(config: UserConfig) {
+  const {plugins} = config
+  if (!Array.isArray(plugins)) return []
+  return plugins.filter(
+    (plugin): plugin is {name: string; _options?: unknown} =>
+      !!plugin && typeof plugin === 'object' && 'name' in plugin && typeof plugin.name === 'string',
+  )
+}
+
+function getPluginNames(config: UserConfig) {
+  return getPlugins(config).map((plugin) => plugin.name)
+}
+
+function getBundleAnalyzerOptions(config: UserConfig) {
+  return getPlugins(config).find((plugin) => plugin.name === BUNDLE_ANALYZER_PLUGIN)?._options
+}
+
+describe('bundleAnalyzer option', () => {
+  test('is disabled by default', async () => {
+    expect(getPluginNames(await defineConfig())).toEqual([])
+    expect(getPluginNames(await defineConfig({bundleAnalyzer: false}))).toEqual([])
+  })
+
+  test('adds the analyzer plugin with the markdown default when enabled', async () => {
+    // Rolldown's own default is `format: 'json'`; this config selects markdown so `true`
+    // matches the LLM-friendly report Sanity library builds want
+    expect(getPluginNames(await defineConfig({bundleAnalyzer: true}))).toEqual([
+      BUNDLE_ANALYZER_PLUGIN,
+    ])
+    expect(getBundleAnalyzerOptions(await defineConfig({bundleAnalyzer: true}))).toEqual({
+      format: 'md',
+    })
+  })
+
+  test('merges user provided options over the markdown default', async () => {
+    expect(
+      getBundleAnalyzerOptions(
+        await defineConfig({bundleAnalyzer: {fileName: 'bundle-analysis.json', format: 'json'}}),
+      ),
+    ).toEqual({
+      format: 'json',
+      fileName: 'bundle-analysis.json',
+    })
+    expect(
+      getBundleAnalyzerOptions(await defineConfig({bundleAnalyzer: {fileName: 'report.md'}})),
+    ).toEqual({
+      format: 'md',
+      fileName: 'report.md',
+    })
+  })
+
+  test('skips the analyzer on the react-server variant of a dual build', async () => {
+    // Both variants write to the same `outDir`; analyzing only the compiled (`default`)
+    // variant avoids a race on one `analyze-data.md` and reports the published client bundle
+    const configs = await defineConfig({
+      reactCompiler: {target: '19', reactServer: true},
+      bundleAnalyzer: true,
+    })
+    expect(configs).toHaveLength(2)
+    const [compiled, reactServer] = configs
+    if (!compiled || !reactServer)
+      throw new Error('expected the compiled and react-server variants')
+
+    expect(getPluginNames(compiled)).toEqual(['@rolldown/plugin-babel', BUNDLE_ANALYZER_PLUGIN])
+    expect(getPluginNames(reactServer)).toEqual([])
+  })
+})
+
+describe('bundle-analyzer-library', () => {
+  test('emits an LLM-friendly markdown report next to the build output', async () => {
+    const report = await readFile(path.join(fixtureDir, 'dist/analyze-data.md'), 'utf-8')
+
+    expect(report).toContain('# Bundle Analysis Report')
+    expect(report).toContain('## Quick Summary')
+    expect(report).toContain('## Largest Modules by Output Contribution')
+    expect(report).toContain('## Entry Point Analysis')
+    // The fixture's helper module must appear so the report is analyzing this package, not
+    // an empty graph
+    expect(report).toMatch(/util\.ts|helper/)
+  })
+
+  test('does not emit the JSON report when format is markdown', async () => {
+    await expect(
+      readFile(path.join(fixtureDir, 'dist/analyze-data.json'), 'utf-8'),
+    ).rejects.toThrow()
+  })
+})

--- a/packages/@sanity/tsdown-config/test/fixtures/bundle-analyzer-library/package.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/bundle-analyzer-library/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@fixtures/bundle-analyzer-library",
+  "version": "0.0.0-development",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.cts",
+  "files": [
+    "dist",
+    "!dist/analyze-data.md"
+  ],
+  "scripts": {
+    "build": "tsdown"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "import": "./dist/index.js",
+        "require": "./dist/index.cjs"
+      },
+      "./package.json": "./package.json"
+    }
+  }
+}

--- a/packages/@sanity/tsdown-config/test/fixtures/bundle-analyzer-library/src/index.ts
+++ b/packages/@sanity/tsdown-config/test/fixtures/bundle-analyzer-library/src/index.ts
@@ -1,0 +1,8 @@
+import {marker} from './util.ts'
+
+/** @public */
+export function greet(name: string): string {
+  return `${marker} ${name}`
+}
+
+export {marker} from './util.ts'

--- a/packages/@sanity/tsdown-config/test/fixtures/bundle-analyzer-library/src/util.ts
+++ b/packages/@sanity/tsdown-config/test/fixtures/bundle-analyzer-library/src/util.ts
@@ -1,0 +1,2 @@
+/** @public */
+export const marker = 'bundle-analyzer-fixture'

--- a/packages/@sanity/tsdown-config/test/fixtures/bundle-analyzer-library/tsconfig.dist.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/bundle-analyzer-library/tsconfig.dist.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["@sanity/tsconfig/strictest", "@sanity/tsconfig/isolated-declarations"],
+  "include": ["./src"],
+  "compilerOptions": {
+    "rootDir": "."
+  }
+}

--- a/packages/@sanity/tsdown-config/test/fixtures/bundle-analyzer-library/tsdown.config.ts
+++ b/packages/@sanity/tsdown-config/test/fixtures/bundle-analyzer-library/tsdown.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from '@sanity/tsdown-config'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  format: ['esm', 'cjs'],
+  bundleAnalyzer: true,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -862,6 +862,9 @@ importers:
       publint:
         specifier: ^0.3.23
         version: 0.3.23
+      rolldown:
+        specifier: ~1.2.4
+        version: 1.2.4
     devDependencies:
       '@sanity/pkg-utils':
         specifier: workspace:*
@@ -878,9 +881,6 @@ importers:
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
-      rolldown:
-        specifier: ~1.2.4
-        version: 1.2.4
       tinyexec:
         specifier: ^1.3.0
         version: 1.3.0
@@ -893,6 +893,8 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
+
+  packages/@sanity/tsdown-config/test/fixtures/bundle-analyzer-library: {}
 
   packages/@sanity/tsdown-config/test/fixtures/circular-dependency-library: {}
 
@@ -12403,6 +12405,7 @@ packages:
   remix@3.0.0-beta.6:
     resolution: {integrity: sha512-a2f2mc+rdK0rqX2qp2vB5WvZXhS18OzjNRvWUyNDl3XPvGXN94nImz+1ZqH6AZIlB+fL/l9txPDj7ylCIdag3Q==}
     engines: {node: '>=24.3.0'}
+    deprecated: 'Deprecated: use remix@3.0.0-beta.10 or newer. Beta.10 supersedes beta.6 through beta.9.'
     hasBin: true
     peerDependencies:
       mysql2: ^3.15.3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

[sanity-io/sanity#14106](https://github.com/sanity-io/sanity/pull/14106) wires Rolldown’s experimental bundle analyzer by hand:

```ts
import {bundleAnalyzerPlugin} from 'rolldown/experimental'
import {mergeConfig} from 'tsdown'

export default isBundleAnalyzerEnabled
  ? mergeConfig(config, {
      plugins: [bundleAnalyzerPlugin({format: 'md'})],
    })
  : config
```

That requires a direct `rolldown` dependency and a `mergeConfig` dance just to opt into an LLM-friendly report of what the published package bundles. This PR makes that a first-class option in `@sanity/tsdown-config`, which `@sanity/pkg-utils` also exposes.

## Usage

```ts
import {defineConfig} from '@sanity/tsdown-config'
// or: import {defineConfig} from '@sanity/pkg-utils'

export default defineConfig({
  bundleAnalyzer: process.env.ENABLE_BUNDLE_ANALYZER === 'true',
})
```

`true` selects `format: 'md'` (Rolldown’s own default is JSON) and emits `analyze-data.md` in `outDir`. Pass an object to customize `format` / `fileName`.

The report is **not** a publishable artifact — exclude it from `package.json` `files` (e.g. `"!dist/analyze-data.md"` / `"!lib/analyze-data.md"`).

With `reactCompiler.reactServer`, only the compiled (`default`) variant is analyzed so the two parallel builds don’t race on one report.

## Testing

- Unit tests for the option wiring in `@sanity/tsdown-config` (defaults, custom options, react-server skip)
- Fixture build (`@fixtures/bundle-analyzer-library`) asserts the markdown report is emitted
- `resolveTsdownConfig` test that `@sanity/pkg-utils` forwards the option
- `pnpm exec vitest run packages/@sanity/tsdown-config packages/@sanity/pkg-utils/test/resolveTsdownConfig.test.ts` — 14 files, 154 tests passed
- Targeted suite — 10/10 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51f11eff-dd10-4602-b534-6c0c54a61421?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51f11eff-dd10-4602-b534-6c0c54a61421&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

