### PR TITLE
feat(tsdown-config)!: opt-in babel pipeline, `'oxc'` as the default `reactCompiler` transform

### DIFF
--- a/.changeset/opt-in-babel-pipeline.md
+++ b/.changeset/opt-in-babel-pipeline.md
@@ -2,4 +2,4 @@
 '@sanity/tsdown-config': minor
 ---
 
-**Breaking:** the babel pipeline is now opt-in. `reactCompiler` defaults to the `'oxc'` transform (`oxc-transform-react`, the Rust port), and the babel toolchain moved out of the dependency tree: `@rolldown/plugin-babel` and `@babel/core` are optional peer dependencies now, so packages that don't use `babel-plugin-react-compiler` never install babel at all. To keep running the reference implementation, set `transform: 'babel'` and install the toolchain: `pnpm add -D @rolldown/plugin-babel @babel/core babel-plugin-react-compiler`.
+**Breaking:** the babel pipeline is opt-in. `reactCompiler` defaults to `transform: 'oxc'`, and `@rolldown/plugin-babel` + `@babel/core` are optional peer dependencies instead of dependencies. To stay on babel: set `transform: 'babel'` and `pnpm add -D @rolldown/plugin-babel @babel/core babel-plugin-react-compiler`.

--- a/.changeset/opt-in-babel-pipeline.md
+++ b/.changeset/opt-in-babel-pipeline.md
@@ -1,0 +1,5 @@
+---
+'@sanity/tsdown-config': minor
+---
+
+**Breaking:** the babel pipeline is now opt-in. `reactCompiler` defaults to the `'oxc'` transform (`oxc-transform-react`, the Rust port), and the babel toolchain moved out of the dependency tree: `@rolldown/plugin-babel` and `@babel/core` are optional peer dependencies now, so packages that don't use `babel-plugin-react-compiler` never install babel at all. To keep running the reference implementation, set `transform: 'babel'` and install the toolchain: `pnpm add -D @rolldown/plugin-babel @babel/core babel-plugin-react-compiler`.

--- a/.changeset/pkg-utils-babel-batteries.md
+++ b/.changeset/pkg-utils-babel-batteries.md
@@ -2,4 +2,4 @@
 '@sanity/pkg-utils': patch
 ---
 
-No behavior change from `@sanity/tsdown-config`'s new oxc default: `reactCompiler` keeps `'babel'` as its default transform, and the babel toolchain (`@rolldown/plugin-babel`, `@babel/core`) that tsdown-config made opt-in now ships with pkg-utils directly — as before, only the compiler itself (`babel-plugin-react-compiler`, or `oxc-transform-react` with `transform: 'oxc'`) needs to be installed.
+`reactCompiler` still defaults to the `'babel'` transform, and the babel toolchain `@sanity/tsdown-config` made opt-in now ships with pkg-utils — no changes needed.

--- a/.changeset/pkg-utils-babel-batteries.md
+++ b/.changeset/pkg-utils-babel-batteries.md
@@ -1,0 +1,5 @@
+---
+'@sanity/pkg-utils': patch
+---
+
+No behavior change from `@sanity/tsdown-config`'s new oxc default: `reactCompiler` keeps `'babel'` as its default transform, and the babel toolchain (`@rolldown/plugin-babel`, `@babel/core`) that tsdown-config made opt-in now ships with pkg-utils directly — as before, only the compiler itself (`babel-plugin-react-compiler`, or `oxc-transform-react` with `transform: 'oxc'`) needs to be installed.

--- a/packages/@sanity/pkg-utils/README.md
+++ b/packages/@sanity/pkg-utils/README.md
@@ -193,11 +193,8 @@ are memoized automatically. Pass `true` for the defaults, or an options object
 (e.g. `{target: '18'}`).
 
 `transform` picks the compiler implementation: `'babel'` (default, install
-`babel-plugin-react-compiler` — the rest of the babel toolchain ships with pkg-utils) or
-`'oxc'` (install `oxc-transform-react`, the Rust port) —
+`babel-plugin-react-compiler`) or `'oxc'` (install `oxc-transform-react`) —
 [details and caveats](https://github.com/sanity-io/pkg-utils/tree/main/packages/@sanity/tsdown-config#transforms-transform).
-Note that `@sanity/tsdown-config` defaults to `'oxc'` since 0.27; pkg-utils keeps `'babel'`
-as the default implementation.
 
 #### `runtime`
 

--- a/packages/@sanity/pkg-utils/README.md
+++ b/packages/@sanity/pkg-utils/README.md
@@ -193,8 +193,11 @@ are memoized automatically. Pass `true` for the defaults, or an options object
 (e.g. `{target: '18'}`).
 
 `transform` picks the compiler implementation: `'babel'` (default, install
-`babel-plugin-react-compiler`) or the experimental `'oxc'` (install `oxc-transform-react`) —
+`babel-plugin-react-compiler` — the rest of the babel toolchain ships with pkg-utils) or
+`'oxc'` (install `oxc-transform-react`, the Rust port) —
 [details and caveats](https://github.com/sanity-io/pkg-utils/tree/main/packages/@sanity/tsdown-config#transforms-transform).
+Note that `@sanity/tsdown-config` defaults to `'oxc'` since 0.27; pkg-utils keeps `'babel'`
+as the default implementation.
 
 #### `runtime`
 

--- a/packages/@sanity/pkg-utils/package.json
+++ b/packages/@sanity/pkg-utils/package.json
@@ -59,6 +59,8 @@
   },
   "browserslist": "extends @sanity/browserslist-config",
   "dependencies": {
+    "@babel/core": "^7.29.7",
+    "@rolldown/plugin-babel": "^0.2.3",
     "@sanity/browserslist-config": "^1.0.5",
     "@sanity/parse-package-json": "workspace:^",
     "@sanity/tsdown-config": "workspace:^",
@@ -87,6 +89,7 @@
   },
   "devDependencies": {
     "@sanity/tsconfig": "workspace:^",
+    "@types/babel__core": "^7.20.5",
     "@types/find-config": "^1.0.4",
     "@types/node": "catalog:",
     "@types/parse-github-url": "^1.0.3",

--- a/packages/@sanity/pkg-utils/src/node/core/config/types.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/config/types.ts
@@ -6,9 +6,11 @@ import type {
   PackageTsdocOptions,
   PackageTsdocRuleLevel,
   PackageVanillaExtractOptions,
-  ReactCompilerOptions,
+  ReactCompilerConfigOptions,
   StyledComponentsOptions,
 } from '@sanity/tsdown-config'
+import type {PluginOptions as BabelReactCompilerPluginOptions} from 'babel-plugin-react-compiler'
+import type {ReactCompilerOptions as OxcReactCompilerOptions} from 'oxc-transform-react'
 import type {UserConfig} from 'tsdown'
 import type {StrictOptions} from '../../strict.ts'
 
@@ -20,12 +22,68 @@ export type {
   PackageTsdocOptions,
   PackageTsdocRuleLevel,
   PackageVanillaExtractOptions,
-  ReactCompilerBabelOptions,
   ReactCompilerConfigOptions,
-  ReactCompilerOptions,
-  ReactCompilerOxcOptions,
   StyledComponentsOptions,
 } from '@sanity/tsdown-config'
+
+// pkg-utils declares its own `ReactCompiler*` shapes instead of re-exporting
+// `@sanity/tsdown-config`'s: since 0.27 that config defaults `reactCompiler.transform` to
+// `'oxc'` (its babel shape requires an explicit `transform: 'babel'`), while `pkg build`
+// keeps `'babel'` as the default implementation — flipping it would break published configs,
+// whose compiler package is a peer the package itself installs (`reactCompiler: true`
+// projects have `babel-plugin-react-compiler`, not `oxc-transform-react`).
+// `resolveTsdownConfig` pins the transform before the options are forwarded.
+//
+// Both shapes are `interface … extends` (heritage clauses) rather than intersection type
+// aliases because the base types come from optional peer dependencies: in consumers that
+// don't install one of them, an intersection would degrade to `any` (`skipLibCheck` silences
+// the unresolved import inside the emitted declarations) and absorb the whole
+// `ReactCompilerOptions` union, while an unresolvable heritage clause is dropped — the shape
+// degrades to its own `transform` member and the union keeps discriminating.
+
+/**
+ * The default `reactCompiler` shape: `babel-plugin-react-compiler` (an optional peer
+ * dependency) runs the compiler, with its own `PluginOptions` — the typings resolve once the
+ * package is installed. Until then the compiler options fall away and only `transform` and
+ * `reactServer` remain typed.
+ * @public
+ */
+export interface ReactCompilerBabelOptions
+  extends Partial<BabelReactCompilerPluginOptions>,
+    ReactCompilerConfigOptions {
+  /**
+   * `babel-plugin-react-compiler`, the reference implementation. The rest of the babel
+   * toolchain (`@rolldown/plugin-babel`, `@babel/core`) ships with pkg-utils.
+   * @defaultValue 'babel'
+   */
+  transform?: 'babel'
+}
+
+/**
+ * The `transform: 'oxc'` shape: `oxc-transform-react` (an optional peer dependency) runs the
+ * compiler, with its own `ReactCompilerOptions` — the serializable subset of the babel
+ * plugin's (no `logger`, no function-valued `sources`); the typings resolve once the package
+ * is installed. Until then the compiler options fall away and only `transform` and
+ * `reactServer` remain typed.
+ * @public
+ */
+export interface ReactCompilerOxcOptions
+  extends OxcReactCompilerOptions,
+    ReactCompilerConfigOptions {
+  /**
+   * `oxc-transform-react`, the Rust port. Its one native pass also strips TypeScript and
+   * lowers JSX (automatic runtime, `react` import source) — stay on `'babel'` with a
+   * custom `jsxImportSource`.
+   */
+  transform: 'oxc'
+}
+
+/**
+ * Options for the React Compiler: the compiler's own options, plus `transform` (which
+ * implementation runs) — handled by `pkg build`, never forwarded to the compiler.
+ * @public
+ */
+export type ReactCompilerOptions = ReactCompilerBabelOptions | ReactCompilerOxcOptions
 
 /** @public */
 export type PkgFormat = 'commonjs' | 'esm'
@@ -178,8 +236,10 @@ export interface PkgConfigOptions {
    * Runs the React Compiler on the source files before they are bundled, so published
    * components are memoized automatically. Pass `true` to use the defaults, or an options
    * object (e.g. `{target: '18'}`). `transform` picks the implementation: `'babel'`
-   * (default, requires `babel-plugin-react-compiler`) or the experimental `'oxc'` (requires
-   * `oxc-transform-react`, the Rust port).
+   * (default, requires `babel-plugin-react-compiler` — the rest of the babel toolchain ships
+   * with pkg-utils) or `'oxc'` (requires `oxc-transform-react`, the Rust port). Unlike
+   * `@sanity/tsdown-config` (which defaults to `'oxc'` since 0.27), pkg-utils keeps `'babel'`
+   * as the default implementation.
    */
   reactCompiler?: boolean | ReactCompilerOptions
   /**

--- a/packages/@sanity/pkg-utils/src/node/core/config/types.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/config/types.ts
@@ -26,34 +26,21 @@ export type {
   StyledComponentsOptions,
 } from '@sanity/tsdown-config'
 
-// pkg-utils declares its own `ReactCompiler*` shapes instead of re-exporting
-// `@sanity/tsdown-config`'s: since 0.27 that config defaults `reactCompiler.transform` to
-// `'oxc'` (its babel shape requires an explicit `transform: 'babel'`), while `pkg build`
-// keeps `'babel'` as the default implementation — flipping it would break published configs,
-// whose compiler package is a peer the package itself installs (`reactCompiler: true`
-// projects have `babel-plugin-react-compiler`, not `oxc-transform-react`).
-// `resolveTsdownConfig` pins the transform before the options are forwarded.
-//
-// Both shapes are `interface … extends` (heritage clauses) rather than intersection type
-// aliases because the base types come from optional peer dependencies: in consumers that
-// don't install one of them, an intersection would degrade to `any` (`skipLibCheck` silences
-// the unresolved import inside the emitted declarations) and absorb the whole
-// `ReactCompilerOptions` union, while an unresolvable heritage clause is dropped — the shape
-// degrades to its own `transform` member and the union keeps discriminating.
+// Declared locally instead of re-exported: `@sanity/tsdown-config` 0.27+ defaults
+// `reactCompiler.transform` to `'oxc'`, pkg-utils keeps `'babel'` (flipping would break
+// published configs). `interface … extends` so an uninstalled optional peer drops the
+// heritage clause instead of degrading the union to `any`.
 
 /**
  * The default `reactCompiler` shape: `babel-plugin-react-compiler` (an optional peer
- * dependency) runs the compiler, with its own `PluginOptions` — the typings resolve once the
- * package is installed. Until then the compiler options fall away and only `transform` and
- * `reactServer` remain typed.
+ * dependency) runs the compiler, with its own `PluginOptions`.
  * @public
  */
 export interface ReactCompilerBabelOptions
   extends Partial<BabelReactCompilerPluginOptions>,
     ReactCompilerConfigOptions {
   /**
-   * `babel-plugin-react-compiler`, the reference implementation. The rest of the babel
-   * toolchain (`@rolldown/plugin-babel`, `@babel/core`) ships with pkg-utils.
+   * `babel-plugin-react-compiler`, the reference implementation.
    * @defaultValue 'babel'
    */
   transform?: 'babel'
@@ -61,26 +48,18 @@ export interface ReactCompilerBabelOptions
 
 /**
  * The `transform: 'oxc'` shape: `oxc-transform-react` (an optional peer dependency) runs the
- * compiler, with its own `ReactCompilerOptions` — the serializable subset of the babel
- * plugin's (no `logger`, no function-valued `sources`); the typings resolve once the package
- * is installed. Until then the compiler options fall away and only `transform` and
- * `reactServer` remain typed.
+ * compiler — the serializable subset of the babel plugin's options.
  * @public
  */
 export interface ReactCompilerOxcOptions
   extends OxcReactCompilerOptions,
     ReactCompilerConfigOptions {
-  /**
-   * `oxc-transform-react`, the Rust port. Its one native pass also strips TypeScript and
-   * lowers JSX (automatic runtime, `react` import source) — stay on `'babel'` with a
-   * custom `jsxImportSource`.
-   */
+  /** `oxc-transform-react`, the Rust port — stay on `'babel'` for a custom `jsxImportSource`. */
   transform: 'oxc'
 }
 
 /**
- * Options for the React Compiler: the compiler's own options, plus `transform` (which
- * implementation runs) — handled by `pkg build`, never forwarded to the compiler.
+ * Options for the React Compiler: the compiler's own options, plus `transform`.
  * @public
  */
 export type ReactCompilerOptions = ReactCompilerBabelOptions | ReactCompilerOxcOptions
@@ -236,10 +215,8 @@ export interface PkgConfigOptions {
    * Runs the React Compiler on the source files before they are bundled, so published
    * components are memoized automatically. Pass `true` to use the defaults, or an options
    * object (e.g. `{target: '18'}`). `transform` picks the implementation: `'babel'`
-   * (default, requires `babel-plugin-react-compiler` — the rest of the babel toolchain ships
-   * with pkg-utils) or `'oxc'` (requires `oxc-transform-react`, the Rust port). Unlike
-   * `@sanity/tsdown-config` (which defaults to `'oxc'` since 0.27), pkg-utils keeps `'babel'`
-   * as the default implementation.
+   * (default, requires `babel-plugin-react-compiler`) or `'oxc'` (requires
+   * `oxc-transform-react`, the Rust port).
    */
   reactCompiler?: boolean | ReactCompilerOptions
   /**

--- a/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
+++ b/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
@@ -48,12 +48,8 @@ export async function resolveTsdownConfig(
       ].join('\n'),
     )
   }
-  // pkg-utils keeps `'babel'` as the default React Compiler implementation, while
-  // `@sanity/tsdown-config` defaults to `'oxc'` since 0.27: inheriting the flip would break
-  // published configs, whose compiler package is a peer the package itself installs
-  // (`reactCompiler: true` projects have `babel-plugin-react-compiler`, not
-  // `oxc-transform-react`). The transform is pinned here so tsdown-config's default never
-  // applies — the babel toolchain the plugin needs ships with pkg-utils.
+  // Pin the `'babel'` default before forwarding: `@sanity/tsdown-config` defaults to `'oxc'`
+  // since 0.27, and inheriting the flip would break published configs.
   const reactCompilerOption: TsdownConfigReactCompilerOptions | boolean | undefined =
     typeof reactCompiler === 'object'
       ? reactCompiler.transform === 'oxc'

--- a/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
+++ b/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
@@ -1,5 +1,8 @@
 import path from 'node:path'
-import {defineConfig} from '@sanity/tsdown-config'
+import {
+  defineConfig,
+  type ReactCompilerOptions as TsdownConfigReactCompilerOptions,
+} from '@sanity/tsdown-config'
 import {mergeConfig, type InlineConfig, type UserConfig} from 'tsdown'
 import type {PkgConfigOptions} from '../../core/config/types.ts'
 import type {BuildContext} from '../../core/contexts/buildContext.ts'
@@ -45,6 +48,20 @@ export async function resolveTsdownConfig(
       ].join('\n'),
     )
   }
+  // pkg-utils keeps `'babel'` as the default React Compiler implementation, while
+  // `@sanity/tsdown-config` defaults to `'oxc'` since 0.27: inheriting the flip would break
+  // published configs, whose compiler package is a peer the package itself installs
+  // (`reactCompiler: true` projects have `babel-plugin-react-compiler`, not
+  // `oxc-transform-react`). The transform is pinned here so tsdown-config's default never
+  // applies — the babel toolchain the plugin needs ships with pkg-utils.
+  const reactCompilerOption: TsdownConfigReactCompilerOptions | boolean | undefined =
+    typeof reactCompiler === 'object'
+      ? reactCompiler.transform === 'oxc'
+        ? reactCompiler
+        : {...reactCompiler, transform: 'babel'}
+      : reactCompiler === true
+        ? {transform: 'babel'}
+        : reactCompiler
 
   const entry: Record<string, string> = {}
   for (const buildEntry of build.entries) {
@@ -174,7 +191,7 @@ export async function resolveTsdownConfig(
     deps: ctx.deps,
     exports,
     css,
-    reactCompiler: config?.reactCompiler,
+    reactCompiler: reactCompilerOption,
     styledComponents: config?.styledComponents,
     vanillaExtract: config?.vanillaExtract,
     bundleAnalyzer: config?.bundleAnalyzer,

--- a/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
+++ b/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
@@ -37,7 +37,9 @@ export async function resolveTsdownConfig(
 ): Promise<InlineConfig> {
   const {config, cwd, distPath, pkg} = ctx
 
-  const reactCompiler = config?.reactCompiler
+  // `?? false` up front (like tsdown-config's own normalization): JS configs bypass the
+  // types, and a `reactCompiler: null` would pass the `typeof … === 'object'` checks below
+  const reactCompiler = config?.reactCompiler ?? false
   if (typeof reactCompiler === 'object' && reactCompiler.reactServer === true) {
     throw new Error(
       [
@@ -50,14 +52,14 @@ export async function resolveTsdownConfig(
   }
   // Pin the `'babel'` default before forwarding: `@sanity/tsdown-config` defaults to `'oxc'`
   // since 0.27, and inheriting the flip would break published configs.
-  const reactCompilerOption: TsdownConfigReactCompilerOptions | boolean | undefined =
+  const reactCompilerOption: TsdownConfigReactCompilerOptions | boolean =
     typeof reactCompiler === 'object'
       ? reactCompiler.transform === 'oxc'
         ? reactCompiler
         : {...reactCompiler, transform: 'babel'}
-      : reactCompiler === true
+      : reactCompiler
         ? {transform: 'babel'}
-        : reactCompiler
+        : false
 
   const entry: Record<string, string> = {}
   for (const buildEntry of build.entries) {

--- a/packages/@sanity/pkg-utils/test/resolveTsdownConfig.test.ts
+++ b/packages/@sanity/pkg-utils/test/resolveTsdownConfig.test.ts
@@ -140,6 +140,19 @@ test('keeps `babel` as the default `reactCompiler` transform', async () => {
   expect(pluginNames(config)).not.toContain('@rolldown/plugin-babel')
 })
 
+test('a JS config with `reactCompiler: null` disables the compiler instead of crashing', async () => {
+  // JS configs bypass the types, and `typeof null === 'object'`
+  const nullConfig: PkgConfigOptions = JSON.parse('{"reactCompiler": null}')
+  const ctx = createContext(nullConfig)
+  const [build] = resolveTsdownBuilds(ctx)
+  if (!build) throw new Error('expected a build')
+
+  const config = await resolveTsdownConfig(ctx, build, {clean: false})
+
+  expect(pluginNames(config)).not.toContain('@rolldown/plugin-babel')
+  expect(pluginNames(config)).not.toContain('vite:react-compiler')
+})
+
 function pluginNames(config: {plugins?: unknown}): string[] {
   const {plugins} = config
   if (!Array.isArray(plugins)) return []

--- a/packages/@sanity/pkg-utils/test/resolveTsdownConfig.test.ts
+++ b/packages/@sanity/pkg-utils/test/resolveTsdownConfig.test.ts
@@ -120,6 +120,28 @@ test('forwards `bundleAnalyzer` to @sanity/tsdown-config', async () => {
   })
 })
 
+test('keeps `babel` as the default `reactCompiler` transform', async () => {
+  // `@sanity/tsdown-config` defaults `reactCompiler.transform` to `'oxc'` since 0.27;
+  // pkg-utils pins `'babel'` before forwarding so published configs keep building with the
+  // compiler package they installed (`babel-plugin-react-compiler`)
+  for (const reactCompiler of [true, {target: '18'}] as const) {
+    const ctx = createContext({reactCompiler})
+    const [build] = resolveTsdownBuilds(ctx)
+    if (!build) throw new Error('expected a build')
+    const config = await resolveTsdownConfig(ctx, build, {clean: false})
+    expect(pluginNames(config)).toContain('@rolldown/plugin-babel')
+    expect(pluginNames(config)).not.toContain('vite:react-compiler')
+  }
+
+  // An explicit `transform: 'oxc'` still selects the Rust port
+  const ctx = createContext({reactCompiler: {target: '19', transform: 'oxc'}})
+  const [build] = resolveTsdownBuilds(ctx)
+  if (!build) throw new Error('expected a build')
+  const config = await resolveTsdownConfig(ctx, build, {clean: false})
+  expect(pluginNames(config)).toContain('vite:react-compiler')
+  expect(pluginNames(config)).not.toContain('@rolldown/plugin-babel')
+})
+
 function pluginNames(config: {plugins?: unknown}): string[] {
   const {plugins} = config
   if (!Array.isArray(plugins)) return []

--- a/packages/@sanity/pkg-utils/test/resolveTsdownConfig.test.ts
+++ b/packages/@sanity/pkg-utils/test/resolveTsdownConfig.test.ts
@@ -121,9 +121,7 @@ test('forwards `bundleAnalyzer` to @sanity/tsdown-config', async () => {
 })
 
 test('keeps `babel` as the default `reactCompiler` transform', async () => {
-  // `@sanity/tsdown-config` defaults `reactCompiler.transform` to `'oxc'` since 0.27;
-  // pkg-utils pins `'babel'` before forwarding so published configs keep building with the
-  // compiler package they installed (`babel-plugin-react-compiler`)
+  // pkg-utils pins `'babel'` before forwarding — tsdown-config defaults to `'oxc'` since 0.27
   for (const reactCompiler of [true, {target: '18'}] as const) {
     const ctx = createContext({reactCompiler})
     const [build] = resolveTsdownBuilds(ctx)

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -20,7 +20,7 @@ bundled, so published components are memoized automatically. The compiler needs 
 installed separately:
 
 ```sh
-pnpm add --save-dev babel-plugin-react-compiler
+pnpm add --save-dev oxc-transform-react
 ```
 
 Then enable it:
@@ -47,25 +47,28 @@ export default defineConfig({
 
 `transform` picks which implementation of the compiler runs:
 
-| `transform`         | Runs                                                                                       | Install                                   |
-| ------------------- | ------------------------------------------------------------------------------------------ | ----------------------------------------- |
-| `'babel'` (default) | [`babel-plugin-react-compiler`](https://www.npmjs.com/package/babel-plugin-react-compiler) | `pnpm add -D babel-plugin-react-compiler` |
-| `'oxc'`             | [`oxc-transform-react`](https://www.npmjs.com/package/oxc-transform-react), the Rust port  | `pnpm add -D oxc-transform-react`         |
+| `transform`       | Runs                                                                                       | Install                                                                      |
+| ----------------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| `'oxc'` (default) | [`oxc-transform-react`](https://www.npmjs.com/package/oxc-transform-react), the Rust port  | `pnpm add -D oxc-transform-react`                                             |
+| `'babel'`         | [`babel-plugin-react-compiler`](https://www.npmjs.com/package/babel-plugin-react-compiler) | `pnpm add -D @rolldown/plugin-babel @babel/core babel-plugin-react-compiler` |
 
 ```ts
 export default defineConfig({
   tsconfig: 'tsconfig.dist.json',
-  reactCompiler: {target: '19', transform: 'oxc'},
+  reactCompiler: {target: '19', transform: 'babel'},
 })
 ```
 
-Good to know about `'oxc'` (via `@vitejs/plugin-react`'s [`compiler` option](https://github.com/vitejs/vite-plugin-react/pull/1419)):
+Good to know about the default `'oxc'` (via `@vitejs/plugin-react`'s [`compiler` option](https://github.com/vitejs/vite-plugin-react/pull/1419)):
 
-- One native pass compiles, strips TypeScript, and lowers JSX. Custom `jsxImportSource`? Stay on `'babel'`.
+- One native pass compiles, strips TypeScript, and lowers JSX. Custom `jsxImportSource`? Opt into `'babel'`.
 - Options are the serializable subset: no `logger`, no function-valued `sources`.
 
-> [!WARNING]
-> The Rust port is experimental (`transform: 'oxc'` is `@alpha`): review the generated output before publishing.
+`'babel'` runs `babel-plugin-react-compiler`, the reference implementation, and covers those
+cases — the compiler leaves TypeScript and JSX in place for rolldown's own transform. The
+babel pipeline is opt-in: `@rolldown/plugin-babel` and `@babel/core` are optional peer
+dependencies of this config, so babel never lands in `node_modules` unless a package sets
+`transform: 'babel'` and installs them.
 
 ### React Server Components (`reactServer`)
 

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -64,11 +64,8 @@ Good to know about the default `'oxc'` (via `@vitejs/plugin-react`'s [`compiler`
 - One native pass compiles, strips TypeScript, and lowers JSX. Custom `jsxImportSource`? Opt into `'babel'`.
 - Options are the serializable subset: no `logger`, no function-valued `sources`.
 
-`'babel'` runs `babel-plugin-react-compiler`, the reference implementation, and covers those
-cases — the compiler leaves TypeScript and JSX in place for rolldown's own transform. The
-babel pipeline is opt-in: `@rolldown/plugin-babel` and `@babel/core` are optional peer
-dependencies of this config, so babel never lands in `node_modules` unless a package sets
-`transform: 'babel'` and installs them.
+`'babel'` runs the reference implementation and covers those cases. It's opt-in: babel never
+lands in `node_modules` unless you set `transform: 'babel'` and install the toolchain.
 
 ### React Server Components (`reactServer`)
 

--- a/packages/@sanity/tsdown-config/package.json
+++ b/packages/@sanity/tsdown-config/package.json
@@ -42,10 +42,8 @@
     "typecheck": "tsc --build"
   },
   "dependencies": {
-    "@babel/core": "^7.29.7",
     "@microsoft/api-extractor": "^7.58.12",
     "@microsoft/tsdoc-config": "^0.18.1",
-    "@rolldown/plugin-babel": "^0.2.3",
     "@sanity/browserslist-config": "^1.0.5",
     "@sanity/vanilla-extract-tsdown-plugin": "workspace:^",
     "@typescript/typescript6": "^6.0.2",
@@ -58,6 +56,8 @@
     "rolldown": "~1.2.4"
   },
   "devDependencies": {
+    "@babel/core": "^7.29.7",
+    "@rolldown/plugin-babel": "^0.2.3",
     "@sanity/pkg-utils": "workspace:^",
     "@sanity/tsconfig": "workspace:^",
     "@tsdown/css": "^0.22.14",
@@ -70,6 +70,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
+    "@babel/core": "*",
+    "@rolldown/plugin-babel": "*",
     "@tsdown/css": "*",
     "babel-plugin-react-compiler": "*",
     "oxc-transform-react": "*",
@@ -77,6 +79,12 @@
     "typescript": "6.x || 7.x"
   },
   "peerDependenciesMeta": {
+    "@babel/core": {
+      "optional": true
+    },
+    "@rolldown/plugin-babel": {
+      "optional": true
+    },
     "@tsdown/css": {
       "optional": true
     },

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -190,23 +190,26 @@ export interface ReactCompilerConfigOptions {
 }
 
 /**
- * The default `reactCompiler` shape: `babel-plugin-react-compiler` (an optional peer
- * dependency) runs the compiler, with its own `PluginOptions` — the typings resolve once the
- * package is installed.
+ * The `transform: 'babel'` shape: `babel-plugin-react-compiler` (an optional peer dependency)
+ * runs the compiler, with its own `PluginOptions` — the typings resolve once the package is
+ * installed. The babel toolchain is not part of this config's dependency tree, so opting in
+ * also means installing `@rolldown/plugin-babel` and `@babel/core` (both optional peer
+ * dependencies).
  * @public
  */
 export type ReactCompilerBabelOptions = Partial<BabelReactCompilerPluginOptions> &
   ReactCompilerConfigOptions & {
     /**
-     * `babel-plugin-react-compiler`, the reference implementation.
-     * @defaultValue 'babel'
+     * `babel-plugin-react-compiler`, the reference implementation — the opt-in for
+     * capabilities the Rust port lacks: a custom `jsxImportSource` (babel leaves JSX to
+     * rolldown's own transform), a `logger`, or function-valued `sources`.
      */
-    transform?: 'babel'
+    transform: 'babel'
   }
 
 /**
- * The `transform: 'oxc'` shape: `oxc-transform-react` (an optional peer dependency) runs the
- * compiler, with its own `ReactCompilerOptions` — the serializable subset of the babel
+ * The default `reactCompiler` shape: `oxc-transform-react` (an optional peer dependency) runs
+ * the compiler, with its own `ReactCompilerOptions` — the serializable subset of the babel
  * plugin's (no `logger`, no function-valued `sources`); the typings resolve once the package
  * is installed.
  * @public
@@ -215,11 +218,11 @@ export type ReactCompilerOxcOptions = OxcReactCompilerOptions &
   ReactCompilerConfigOptions & {
     /**
      * `oxc-transform-react`, the Rust port. Its one native pass also strips TypeScript and
-     * lowers JSX (automatic runtime, `react` import source) — stay on `'babel'` with a
+     * lowers JSX (automatic runtime, `react` import source) — opt into `'babel'` for a
      * custom `jsxImportSource`.
-     * @alpha Experimental — review the generated output before publishing.
+     * @defaultValue 'oxc'
      */
-    transform: 'oxc'
+    transform?: 'oxc'
   }
 
 /**
@@ -364,11 +367,11 @@ export interface PackageOptions extends Pick<
    * Runs the React Compiler on the source files before they are bundled, so published
    * components are memoized automatically. Pass `true` to use the defaults, or an options
    * object (e.g. `{target: '18'}`). This is the same feature as the
-   * `babel: {reactCompiler: true}` and `reactCompilerOptions` options in `@sanity/pkg-utils`.
+   * `reactCompiler` option in `@sanity/pkg-utils`.
    *
-   * `transform` picks the implementation — `'babel'` (default, requires
-   * `babel-plugin-react-compiler`) or the experimental `'oxc'` (requires
-   * `oxc-transform-react`), see {@link ReactCompilerOxcOptions} — and `reactServer` adds the
+   * `transform` picks the implementation — `'oxc'` (default, requires `oxc-transform-react`)
+   * or `'babel'` (requires `babel-plugin-react-compiler`, `@rolldown/plugin-babel` and
+   * `@babel/core`), see {@link ReactCompilerBabelOptions} — and `reactServer` adds the
    * uncompiled `react-server` build, see {@link ReactCompilerConfigOptions.reactServer}.
    * @defaultValue false
    */
@@ -589,15 +592,41 @@ async function resolvePackageConfig(
   const plugins: Rolldown.Plugin[] = []
   if (reactCompiler !== false) {
     // Lazy loaded so the toolchain is only paid for when enabled. The compiler package itself
-    // (`babel-plugin-react-compiler` / `oxc-transform-react`, per `transform`) resolves from
-    // the consumer package, which is why both are optional peer dependencies.
+    // (`oxc-transform-react` / `babel-plugin-react-compiler`, per `transform`) resolves from
+    // the consumer package, which is why both are optional peer dependencies — and so is the
+    // whole babel toolchain (`@rolldown/plugin-babel`, `@babel/core`), so packages that stay
+    // on the default `oxc` transform never install babel at all.
     const reactCompilerOptions: ReactCompilerOptions = reactCompiler === true ? {} : reactCompiler
-    if (reactCompilerOptions.transform === 'oxc') {
-      // `@vitejs/plugin-react`'s `compiler` option: `oxc-transform-react` compiles, strips
-      // TypeScript and lowers JSX in one native pass. Only the `vite:react-compiler` plugin is
-      // cherry-picked — the rest of the array is Vite-only (Fast Refresh wrapper, dev config).
-      // Outside Vite its defaults are what a library build wants: production JSX, sourcemaps,
-      // no Fast Refresh. `transform`/`reactServer` are this config's — drop before forwarding.
+    if (reactCompilerOptions.transform === 'babel') {
+      // The opt-in reference implementation follows the official tsdown recipe for the React
+      // Compiler: https://tsdown.dev/recipes/react-support#enabling-react-compiler
+      // The compiler leaves TypeScript and JSX in place for rolldown's own transform.
+      const [{default: pluginBabel}, {reactCompilerPreset}] = await Promise.all([
+        import('@rolldown/plugin-babel').catch((cause: unknown) => {
+          throw new Error(
+            '`reactCompiler: {transform: "babel"}` needs the babel toolchain, which `@sanity/tsdown-config` does not install — run `pnpm add -D @rolldown/plugin-babel @babel/core babel-plugin-react-compiler` (or drop `transform` for the default `oxc` implementation, which only needs `oxc-transform-react`).',
+            {cause},
+          )
+        }),
+        import('@vitejs/plugin-react'),
+      ])
+      const {
+        reactServer: _reactServer,
+        transform: _transform,
+        ...compilerOptions
+      } = reactCompilerOptions
+      plugins.push(
+        await pluginBabel({
+          presets: [reactCompilerPreset(compilerOptions)],
+        }),
+      )
+    } else {
+      // The default: `@vitejs/plugin-react`'s `compiler` option — `oxc-transform-react`
+      // compiles, strips TypeScript and lowers JSX in one native pass. Only the
+      // `vite:react-compiler` plugin is cherry-picked — the rest of the array is Vite-only
+      // (Fast Refresh wrapper, dev config). Outside Vite its defaults are what a library
+      // build wants: production JSX, sourcemaps, no Fast Refresh. `transform`/`reactServer`
+      // are this config's — drop before forwarding.
       const {
         reactServer: _reactServer,
         transform: _transform,
@@ -615,28 +644,10 @@ async function resolvePackageConfig(
       }).find((plugin) => plugin.name === 'vite:react-compiler')
       if (!compilerPlugin) {
         throw new Error(
-          '`@vitejs/plugin-react` returned no `vite:react-compiler` plugin — the installed version does not support `reactCompiler: {transform: "oxc"}`.',
+          '`@vitejs/plugin-react` returned no `vite:react-compiler` plugin — the installed version does not support the default `oxc` implementation of the `reactCompiler` option.',
         )
       }
       plugins.push(compilerPlugin)
-    } else {
-      // The default implementation follows the official tsdown recipe for the React Compiler:
-      // https://tsdown.dev/recipes/react-support#enabling-react-compiler
-      // The compiler leaves TypeScript and JSX in place for rolldown's own transform.
-      const [{default: pluginBabel}, {reactCompilerPreset}] = await Promise.all([
-        import('@rolldown/plugin-babel'),
-        import('@vitejs/plugin-react'),
-      ])
-      const {
-        reactServer: _reactServer,
-        transform: _transform,
-        ...compilerOptions
-      } = reactCompilerOptions
-      plugins.push(
-        await pluginBabel({
-          presets: [reactCompilerPreset(compilerOptions)],
-        }),
-      )
     }
   }
   if (options.vanillaExtract) {

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -191,18 +191,15 @@ export interface ReactCompilerConfigOptions {
 
 /**
  * The `transform: 'babel'` shape: `babel-plugin-react-compiler` (an optional peer dependency)
- * runs the compiler, with its own `PluginOptions` — the typings resolve once the package is
- * installed. The babel toolchain is not part of this config's dependency tree, so opting in
- * also means installing `@rolldown/plugin-babel` and `@babel/core` (both optional peer
- * dependencies).
+ * runs the compiler, with its own `PluginOptions` — install it together with
+ * `@rolldown/plugin-babel` and `@babel/core`.
  * @public
  */
 export type ReactCompilerBabelOptions = Partial<BabelReactCompilerPluginOptions> &
   ReactCompilerConfigOptions & {
     /**
-     * `babel-plugin-react-compiler`, the reference implementation — the opt-in for
-     * capabilities the Rust port lacks: a custom `jsxImportSource` (babel leaves JSX to
-     * rolldown's own transform), a `logger`, or function-valued `sources`.
+     * The reference implementation — for what the Rust port lacks: custom `jsxImportSource`,
+     * `logger`, function-valued `sources`.
      */
     transform: 'babel'
   }
@@ -593,9 +590,7 @@ async function resolvePackageConfig(
   if (reactCompiler !== false) {
     // Lazy loaded so the toolchain is only paid for when enabled. The compiler package itself
     // (`oxc-transform-react` / `babel-plugin-react-compiler`, per `transform`) resolves from
-    // the consumer package, which is why both are optional peer dependencies — and so is the
-    // whole babel toolchain (`@rolldown/plugin-babel`, `@babel/core`), so packages that stay
-    // on the default `oxc` transform never install babel at all.
+    // the consumer package — everything babel-flavored is an optional peer dependency.
     const reactCompilerOptions: ReactCompilerOptions = reactCompiler === true ? {} : reactCompiler
     if (reactCompilerOptions.transform === 'babel') {
       // The opt-in reference implementation follows the official tsdown recipe for the React
@@ -604,7 +599,7 @@ async function resolvePackageConfig(
       const [{default: pluginBabel}, {reactCompilerPreset}] = await Promise.all([
         import('@rolldown/plugin-babel').catch((cause: unknown) => {
           throw new Error(
-            '`reactCompiler: {transform: "babel"}` needs the babel toolchain, which `@sanity/tsdown-config` does not install — run `pnpm add -D @rolldown/plugin-babel @babel/core babel-plugin-react-compiler` (or drop `transform` for the default `oxc` implementation, which only needs `oxc-transform-react`).',
+            '`reactCompiler: {transform: "babel"}` needs `pnpm add -D @rolldown/plugin-babel @babel/core babel-plugin-react-compiler`.',
             {cause},
           )
         }),

--- a/packages/@sanity/tsdown-config/test/bundle-analyzer.test.ts
+++ b/packages/@sanity/tsdown-config/test/bundle-analyzer.test.ts
@@ -73,7 +73,7 @@ describe('bundleAnalyzer option', () => {
     if (!compiled || !reactServer)
       throw new Error('expected the compiled and react-server variants')
 
-    expect(getPluginNames(compiled)).toEqual(['@rolldown/plugin-babel', BUNDLE_ANALYZER_PLUGIN])
+    expect(getPluginNames(compiled)).toEqual(['vite:react-compiler', BUNDLE_ANALYZER_PLUGIN])
     expect(getPluginNames(reactServer)).toEqual([])
   })
 })

--- a/packages/@sanity/tsdown-config/test/fixtures/react-19-library/tsdown.config.ts
+++ b/packages/@sanity/tsdown-config/test/fixtures/react-19-library/tsdown.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   tsconfig: 'tsconfig.dist.json',
   format: ['esm', 'cjs'],
   platform: 'neutral',
-  reactCompiler: {target: '19', transform: 'oxc'},
+  reactCompiler: {target: '19'},
   define: {'process.env.NODE_ENV': JSON.stringify('production')},
 })

--- a/packages/@sanity/tsdown-config/test/fixtures/react-server-library/package.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/react-server-library/package.json
@@ -17,6 +17,8 @@
     "build": "tsdown"
   },
   "devDependencies": {
+    "@babel/core": "^7.29.7",
+    "@rolldown/plugin-babel": "^0.2.3",
     "@types/react": "^19.2.18",
     "babel-plugin-react-compiler": "^1.0.0",
     "react": "^19.2.8"

--- a/packages/@sanity/tsdown-config/test/fixtures/react-server-library/tsdown.config.ts
+++ b/packages/@sanity/tsdown-config/test/fixtures/react-server-library/tsdown.config.ts
@@ -2,5 +2,5 @@ import {defineConfig} from '@sanity/tsdown-config'
 
 export default defineConfig({
   tsconfig: 'tsconfig.dist.json',
-  reactCompiler: {target: '19', reactServer: true},
+  reactCompiler: {target: '19', transform: 'babel', reactServer: true},
 })

--- a/packages/@sanity/tsdown-config/test/react-server.test.ts
+++ b/packages/@sanity/tsdown-config/test/react-server.test.ts
@@ -87,7 +87,7 @@ describe('reactCompiler.reactServer option', () => {
       await defineConfig({reactCompiler: {target: '19', reactServer: false}}),
     ]) {
       expect(Array.isArray(config)).toBe(false)
-      expect(getPluginNames(config)).toEqual(['@rolldown/plugin-babel'])
+      expect(getPluginNames(config)).toEqual(['vite:react-compiler'])
       expect(config.exports).not.toHaveProperty('customExports')
       expect(config.outExtensions).toBeUndefined()
     }
@@ -123,7 +123,7 @@ describe('reactCompiler.reactServer option', () => {
 
     // The compiled variant is the classic single build: the React Compiler applied, and it
     // owns `dts`, `exports` generation and `publint`
-    expect(getPluginNames(compiled)).toEqual(['@rolldown/plugin-babel'])
+    expect(getPluginNames(compiled)).toEqual(['vite:react-compiler'])
     expect(compiled.publint).toBe(true)
     expect(compiled.exports).toMatchObject({enabled: true, devExports: true})
 
@@ -139,14 +139,14 @@ describe('reactCompiler.reactServer option', () => {
     expect(reactServer.hooks).toBeUndefined()
   })
 
-  test('combines with `transform: "oxc"`', async () => {
+  test('combines with `transform: "babel"`', async () => {
     const [compiled, reactServer] = await defineDualConfig({
-      reactCompiler: {target: '19', transform: 'oxc'},
+      reactCompiler: {target: '19', transform: 'babel'},
     })
 
-    // Only the compiled variant runs the oxc implementation; the react-server variant stays
-    // uncompiled either way (rolldown lowers its TypeScript/JSX)
-    expect(getPluginNames(compiled)).toEqual(['vite:react-compiler'])
+    // Only the compiled variant runs the opt-in babel implementation; the react-server
+    // variant stays uncompiled either way (rolldown lowers its TypeScript/JSX)
+    expect(getPluginNames(compiled)).toEqual(['@rolldown/plugin-babel'])
     expect(getPluginNames(reactServer)).toEqual([])
   })
 
@@ -389,7 +389,9 @@ describe('react-server-library', () => {
     ])
 
     // The compiled output is auto-memoized with the memo cache provided by
-    // `react/compiler-runtime` (the fixture sets `reactCompiler: {target: '19'}`)
+    // `react/compiler-runtime` (the fixture sets
+    // `reactCompiler: {target: '19', transform: 'babel'}`, so this exercises the opt-in
+    // babel implementation end-to-end)
     expect(distIndexJs).toContain('react/compiler-runtime')
 
     // The react-server output is the same source without the compiler: no

--- a/packages/@sanity/tsdown-config/test/react-server.test.ts
+++ b/packages/@sanity/tsdown-config/test/react-server.test.ts
@@ -389,9 +389,7 @@ describe('react-server-library', () => {
     ])
 
     // The compiled output is auto-memoized with the memo cache provided by
-    // `react/compiler-runtime` (the fixture sets
-    // `reactCompiler: {target: '19', transform: 'babel'}`, so this exercises the opt-in
-    // babel implementation end-to-end)
+    // `react/compiler-runtime` (the fixture opts into `transform: 'babel'`)
     expect(distIndexJs).toContain('react/compiler-runtime')
 
     // The react-server output is the same source without the compiler: no

--- a/packages/@sanity/tsdown-config/test/react.test.ts
+++ b/packages/@sanity/tsdown-config/test/react.test.ts
@@ -22,25 +22,25 @@ describe('reactCompiler option', () => {
     expect(getPluginNames(await defineConfig({reactCompiler: false}))).toEqual([])
   })
 
-  test('adds the babel plugin when enabled', async () => {
+  test('adds the oxc compiler plugin when enabled', async () => {
     expect(getPluginNames(await defineConfig({reactCompiler: true}))).toEqual([
-      '@rolldown/plugin-babel',
+      'vite:react-compiler',
     ])
     expect(getPluginNames(await defineConfig({reactCompiler: {target: '19'}}))).toEqual([
-      '@rolldown/plugin-babel',
-    ])
-    expect(
-      getPluginNames(await defineConfig({reactCompiler: {target: '19', transform: 'babel'}})),
-    ).toEqual(['@rolldown/plugin-babel'])
-  })
-
-  test('adds the oxc compiler plugin with `transform: "oxc"`', async () => {
-    expect(getPluginNames(await defineConfig({reactCompiler: {transform: 'oxc'}}))).toEqual([
       'vite:react-compiler',
     ])
     expect(
       getPluginNames(await defineConfig({reactCompiler: {target: '19', transform: 'oxc'}})),
     ).toEqual(['vite:react-compiler'])
+  })
+
+  test('adds the babel plugin with `transform: "babel"`', async () => {
+    expect(getPluginNames(await defineConfig({reactCompiler: {transform: 'babel'}}))).toEqual([
+      '@rolldown/plugin-babel',
+    ])
+    expect(
+      getPluginNames(await defineConfig({reactCompiler: {target: '19', transform: 'babel'}})),
+    ).toEqual(['@rolldown/plugin-babel'])
   })
 })
 
@@ -52,9 +52,8 @@ describe('react-19-library', () => {
     ])
 
     // The React Compiler memoizes components with a memo cache provided by
-    // `react/compiler-runtime` — the fixture sets
-    // `reactCompiler: {target: '19', transform: 'oxc'}`, so this exercises the
-    // `oxc-transform-react` implementation end-to-end
+    // `react/compiler-runtime` — the fixture sets `reactCompiler: {target: '19'}`, so this
+    // exercises the default `oxc-transform-react` implementation end-to-end
     expect(distIndexJs).toContain('import { c } from "react/compiler-runtime"')
     expect(distIndexJs).toContain('$ = c(')
     expect(distIndexJs).toContain('react.memo_cache_sentinel')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -703,6 +703,12 @@ importers:
 
   packages/@sanity/pkg-utils:
     dependencies:
+      '@babel/core':
+        specifier: ^7.29.7
+        version: 7.29.7(supports-color@10.2.2)
+      '@rolldown/plugin-babel':
+        specifier: ^0.2.3
+        version: 0.2.3(@babel/core@7.29.7(supports-color@10.2.2))(@babel/runtime@7.29.7)(rolldown@1.2.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
       '@sanity/browserslist-config':
         specifier: ^1.0.5
         version: 1.0.5
@@ -785,6 +791,9 @@ importers:
       '@sanity/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
+      '@types/babel__core':
+        specifier: ^7.20.5
+        version: 7.20.5
       '@types/find-config':
         specifier: ^1.0.4
         version: 1.0.4
@@ -826,18 +835,12 @@ importers:
 
   packages/@sanity/tsdown-config:
     dependencies:
-      '@babel/core':
-        specifier: ^7.29.7
-        version: 7.29.7(supports-color@10.2.2)
       '@microsoft/api-extractor':
         specifier: ^7.58.12
         version: 7.58.12(@types/node@24.13.3)
       '@microsoft/tsdoc-config':
         specifier: ^0.18.1
         version: 0.18.1
-      '@rolldown/plugin-babel':
-        specifier: ^0.2.3
-        version: 0.2.3(@babel/core@7.29.7(supports-color@10.2.2))(@babel/runtime@7.29.7)(rolldown@1.2.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
       '@sanity/browserslist-config':
         specifier: ^1.0.5
         version: 1.0.5
@@ -869,6 +872,12 @@ importers:
         specifier: ~1.2.4
         version: 1.2.4
     devDependencies:
+      '@babel/core':
+        specifier: ^7.29.7
+        version: 7.29.7(supports-color@10.2.2)
+      '@rolldown/plugin-babel':
+        specifier: ^0.2.3
+        version: 0.2.3(@babel/core@7.29.7(supports-color@10.2.2))(@babel/runtime@7.29.7)(rolldown@1.2.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
       '@sanity/pkg-utils':
         specifier: workspace:*
         version: link:../pkg-utils
@@ -931,6 +940,12 @@ importers:
 
   packages/@sanity/tsdown-config/test/fixtures/react-server-library:
     devDependencies:
+      '@babel/core':
+        specifier: ^7.29.7
+        version: 7.29.7(supports-color@10.2.2)
+      '@rolldown/plugin-babel':
+        specifier: ^0.2.3
+        version: 0.2.3(@babel/core@7.29.7(supports-color@10.2.2))(@babel/runtime@7.29.7)(rolldown@1.2.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(yaml@2.9.0))
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Makes the babel pipeline in `@sanity/tsdown-config` opt-in: `reactCompiler` defaults to `transform: 'oxc'`, and `@rolldown/plugin-babel` + `@babel/core` move from dependencies to optional peers — no babel in `node_modules` unless you set `transform: 'babel'`. Breaking, released as a minor (v0.x).

`@sanity/pkg-utils` is unchanged for users: it pins `transform: 'babel'` before forwarding and ships the babel toolchain as regular dependencies. Its `ReactCompiler*` types are declared locally to keep the babel-default union shape.

Overlaps with #3319 in the two `ReactCompiler*` type declarations — whichever lands second has a small mechanical conflict.

## Test plan

- tsdown-config suite: 152 tests pass; fixtures cover the oxc default (`react-19-library`) and explicit babel (`react-server-library`)
- Root `pnpm test`: 515 tests pass, playground snapshots unchanged (no pkg-utils behavior change)
- `pnpm typecheck`, `pnpm build`, `pnpm lint`, `pnpm knip` all pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95ff7d43-ccd6-4eff-b793-3193c5daf652?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95ff7d43-ccd6-4eff-b793-3193c5daf652&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

