### PR TITLE
Add deslop skill from cursor/plugins

### DIFF
--- a/.agent/skills/deslop
+++ b/.agent/skills/deslop
@@ -1,0 +1,1 @@
+../../.agents/skills/deslop

--- a/.agents/skills/deslop/SKILL.md
+++ b/.agents/skills/deslop/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: deslop
+description: Remove AI-generated code slop and clean up code style
+---
+
+# Remove AI code slop
+
+Check the diff against main and remove AI-generated slop introduced in the branch.
+
+## Focus Areas
+
+- Extra comments that are unnecessary or inconsistent with local style
+- Defensive checks or try/catch blocks that are abnormal for trusted code paths
+- Casts to `any` used only to bypass type issues
+- Deeply nested code that should be simplified with early returns
+- Other patterns inconsistent with the file and surrounding codebase
+
+## Guardrails
+
+- Keep behavior unchanged unless fixing a clear bug.
+- Prefer minimal, focused edits over broad rewrites.
+- Keep the final summary concise (1-3 sentences).

--- a/.claude/skills/deslop
+++ b/.claude/skills/deslop
@@ -1,0 +1,1 @@
+../../.agents/skills/deslop

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,12 @@
 {
   "version": 1,
   "skills": {
+    "deslop": {
+      "source": "cursor/plugins",
+      "sourceType": "github",
+      "skillPath": "cursor-team-kit/skills/deslop/SKILL.md",
+      "computedHash": "8883a7d459c07a0b2ee06972e79baa634009aa3bab969a6650acbefac394ad41"
+    },
     "tsdown": {
       "source": "rolldown/tsdown",
       "sourceType": "github",

--- a/skills/deslop
+++ b/skills/deslop
@@ -1,0 +1,1 @@
+../.agents/skills/deslop


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Installs the [`deslop`](https://www.skills.sh/cursor/plugins/deslop) agent skill from [`cursor/plugins`](https://github.com/cursor/plugins) so agents can strip AI-generated slop from branch diffs.

## What changed

- Ran `npx skills add https://github.com/cursor/plugins --skill deslop -y`
- Canonical copy at `.agents/skills/deslop/SKILL.md`
- Symlinks for the same agents as the existing tsdown/vitest skills (`skills/`, `.claude/skills/`, `.agent/skills/`)
- `skills-lock.json` entry for `cursor/plugins` at `cursor-team-kit/skills/deslop/SKILL.md`

## Verification

`npx skills list` reports `deslop` as a project skill for Cursor, Claude Code, and OpenClaw, alongside tsdown and vitest. All symlink paths resolve to the same `SKILL.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f4e5efb-ef79-4471-807e-938422d6415b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f4e5efb-ef79-4471-807e-938422d6415b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

