### PR TITLE
chore(ci): drop unused options from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,15 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
+      - name: Get app token user id
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Setup git user
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
@@ -43,4 +52,5 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           publish-script: pnpm release
         env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: ${{ github.event.repository.visibility == 'public' && 'true' || 'false' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,6 @@ jobs:
   release:
     if: github.repository_owner == 'sanity-io'
     runs-on: ubuntu-latest
-    env:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     permissions:
       contents: read # for checkout
       id-token: write # to enable use of OIDC for npm provenance
@@ -32,15 +28,6 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
-      - name: Get app token user id
-        id: get-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-      - name: Setup git user
-        run: |
-          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
@@ -49,21 +36,11 @@ jobs:
           node-version: lts/*
       - name: Update npm to use trusted publishing (OIDC)
         run: npm install -g npm@latest
-      - name: Authenticate with private npm
-        if: ${{ env.NPM_TOKEN != '' }}
-        run: echo "//registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}" > ~/.npmrc
       - run: pnpm install
-      - name: Remove npm auth
-        if: ${{ env.NPM_TOKEN != '' }}
-        run: rm -f ~/.npmrc
       - name: Create Release Pull Request or Publish to npm
-        id: changesets
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           publish-script: pnpm release
-          pr-title: Version Packages
-          commit-message: Version Packages
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: ${{ github.event.repository.visibility == 'public' && 'true' || 'false' }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the options in the inlined release workflow that do nothing in this repository, verified against the pinned `changesets/action` v2.1.1 source and the first live v3 release run ([33406247496](https://github.com/sanity-io/pkg-utils/actions/runs/33406247496), which published 6 packages successfully):

- Private npm auth (`NPM_TOKEN` env, `Authenticate with private npm`, `Remove npm auth`): every dependency installs from the public registry, and the `.npmrc` was deleted before the publish step anyway — publishing authenticates via OIDC trusted publishing, never the token.
- `TURBO_TEAM` / `TURBO_TOKEN`: this repo does not use turborepo; nothing reads them.
- `pr-title` / `commit-message`: both were set to `Version Packages`, which is the action's default for both inputs.
- Unused `id: changesets` step id.

## Kept after review

- `Get app token user id` / `Setup git user` and the step-level `GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}` env: initially removed, restored in a149d486 per review — release commits/tags and anything the publish script spawns should use the minted Ecospark app token identity rather than the action's `github-actions[bot]` fallback.
- `Update npm to use trusted publishing (OIDC)` and `NPM_CONFIG_PROVENANCE`: Changesets v3 publishes with the detected package manager, and `pnpm publish` delegates the actual registry publish to the npm binary (`runNpm(opts.npmPath, ["publish", ...])` in the pnpm CLI), so the npm upgrade and the provenance flag are load-bearing.
- `fetch-depth: 0`: `@changesets/changelog-github` resolves the commit that added each changeset via git history; a shallow clone would drop PR/commit links from changelogs.

## Testing

- `actionlint` on the workflow: no findings beyond its two known stale-database false positives on `client-id` (the real `actions/create-github-app-token@v3` manifest defines `client-id` and deprecates `app-id`; the step succeeded in the live run above)
- `prettier --check` passes
- Behavior evidence: run [33406247496](https://github.com/sanity-io/pkg-utils/actions/runs/33406247496) logs show the removed options doing nothing during a real publish (no private packages fetched, turbo vars unread)

> [!NOTE]
> The earlier `Node.js lts/* / windows-latest` failure was the pre-existing `namespace-reexport.test.ts` 5s-timeout flake, unrelated to this change (the release workflow does not run in PR CI). The identical test timed out on `main` runs [33404379967](https://github.com/sanity-io/pkg-utils/actions/runs/33404379967) and [33403470603](https://github.com/sanity-io/pkg-utils/actions/runs/33403470603) before this PR existed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4f3eda5-2949-4f2a-92ba-b1716c120c3a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4f3eda5-2949-4f2a-92ba-b1716c120c3a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

