### PR TITLE
fix: pin release workflow npm to 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,11 @@ jobs:
           cache: pnpm
           check-latest: true
           node-version: lts/*
+      # npm 12 wraps `npm info --json` in an array; @changesets/cli@3.0.1's pnpm
+      # parser does not unwrap it (changesets/changesets#2274). Trusted publishing
+      # still works at npm >=11.5.1.
       - name: Update npm to use trusted publishing (OIDC)
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - run: pnpm install
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Pin the release workflow's global npm to 11.

`npm@latest` is now 12. Repos that copy this template and use pnpm + `@changesets/cli@3.0.1` crash on `changeset publish`:

`TypeError: Cannot read properties of undefined (reading 'includes')` at `getPublishPlan.mjs:613`

npm 12 wraps `npm info --json` in an array; the pnpm parser does not unwrap it (changesets/changesets#2274). Confirmed on sanity-io/visual-editing Release run 33517457076.

Trusted publishing still works at npm >=11.5.1. Git user, `GITHUB_TOKEN`, and OIDC are unchanged. `@changesets/*` is not bumped.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd77bbfd-6a4f-4d1a-bc78-31a9088659c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd77bbfd-6a4f-4d1a-bc78-31a9088659c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

