### PR TITLE
feat(pkg-utils)!: upgrade tsdown to 0.23

### DIFF
--- a/.changeset/dependencies-GH-3392.md
+++ b/.changeset/dependencies-GH-3392.md
@@ -16,10 +16,13 @@ Upgrade tsdown and `@tsdown/css` to 0.23.
 tsdown 0.23 removes deprecated config options. Replace `dts.tsgo: true` and
 `dts.oxc: true` with `dts.generator: 'tsgo'` and `dts.generator: 'oxc'`.
 Replace `dts.oxc: false` with `dts.generator: 'tsc'`. Remove `dts.cjsReexport`.
+Replace `dts.volarPlugins` with `dts.customLanguages` and rename each language's
+`create` hook to `createVolarPlugins`.
 Under `deps`, replace `skipNodeModulesBundle: true` with `neverBundle: true`
 and `onlyAllowBundle` with `onlyBundle`.
 
 The `@sanity/tsdown-config` and `@sanity/vanilla-extract-tsdown-plugin` peer
 ranges still accept tsdown 0.22. `deps.resolveDepSubpath: true` preserves the
 old dependency-specifier behavior. `pkg watch` now closes tsdown's native watch
-handle, including its Rolldown watchers and keyboard-shortcut resources.
+handle, including its Rolldown watchers and keyboard-shortcut resources. CSS
+builds now require `@tsdown/css@^0.23.0`.

--- a/.changeset/dependencies-GH-3392.md
+++ b/.changeset/dependencies-GH-3392.md
@@ -2,14 +2,24 @@
 "@sanity/tsdown-config": patch
 "@sanity/vanilla-extract-tsdown-plugin": patch
 "@sanity/parse-package-json": patch
-"@sanity/pkg-utils": patch
+"@sanity/pkg-utils": major
 "@sanity/vanilla-extract-integration": patch
 "@sanity/vanilla-extract-rolldown-plugin": patch
 "@sanity/vanilla-extract-vite-plugin": patch
 ---
 
-fix(deps): update tsdown to ^0.23.0 and adapt to TsdownHandle
+Upgrade tsdown and `@tsdown/css` to 0.23.
 
-tsdown 0.23's `build()` returns `{bundles, watch}` instead of `TsdownBundle[]`.
-pkg-utils takes `.bundles` from that handle. Select the Go dts generator with
-`dts: {generator: 'tsgo'}` (`dts.tsgo: true` is gone).
+**BREAKING (`@sanity/pkg-utils`):** Node.js 25 can no longer run the build. Use Node
+`^22.18.0`, `^24.11.0`, or `>=26.0.0`.
+
+tsdown 0.23 removes deprecated config options. Replace `dts.tsgo: true` and
+`dts.oxc: true` with `dts.generator: 'tsgo'` and `dts.generator: 'oxc'`.
+Replace `dts.oxc: false` with `dts.generator: 'tsc'`. Remove `dts.cjsReexport`.
+Under `deps`, replace `skipNodeModulesBundle: true` with `neverBundle: true`
+and `onlyAllowBundle` with `onlyBundle`.
+
+The `@sanity/tsdown-config` and `@sanity/vanilla-extract-tsdown-plugin` peer
+ranges still accept tsdown 0.22. `deps.resolveDepSubpath: true` preserves the
+old dependency-specifier behavior. `pkg watch` now closes tsdown's native watch
+handle, including its Rolldown watchers and keyboard-shortcut resources.

--- a/.changeset/dependencies-GH-3392.md
+++ b/.changeset/dependencies-GH-3392.md
@@ -1,0 +1,14 @@
+---
+"@sanity/tsdown-config": patch
+"@sanity/vanilla-extract-tsdown-plugin": patch
+"@sanity/parse-package-json": patch
+"@sanity/pkg-utils": patch
+"@sanity/vanilla-extract-integration": patch
+"@sanity/vanilla-extract-rolldown-plugin": patch
+"@sanity/vanilla-extract-vite-plugin": patch
+---
+
+fix(deps): update tsdown to ^0.23.0 and adapt to TsdownHandle
+
+tsdown 0.23's `build()` returns `{bundles, watch}` instead of `TsdownBundle[]`.
+pkg-utils now takes `.bundles` from that handle.

--- a/.changeset/dependencies-GH-3392.md
+++ b/.changeset/dependencies-GH-3392.md
@@ -24,5 +24,7 @@ and `onlyAllowBundle` with `onlyBundle`.
 The `@sanity/tsdown-config` and `@sanity/vanilla-extract-tsdown-plugin` peer
 ranges still accept tsdown 0.22. `deps.resolveDepSubpath: true` preserves the
 old dependency-specifier behavior. `pkg watch` now closes tsdown's native watch
-handle, including its Rolldown watchers and keyboard-shortcut resources. CSS
-builds now require `@tsdown/css@^0.23.0`.
+handle, including its Rolldown watchers and keyboard-shortcut resources, and
+sets `ignoreWatch` on `package.json` and `tsconfig.json` so tsdown does not
+restart itself and orphan a watcher that abort cannot close. CSS builds now
+require `@tsdown/css@^0.23.0`.

--- a/.changeset/dependencies-GH-3392.md
+++ b/.changeset/dependencies-GH-3392.md
@@ -1,6 +1,6 @@
 ---
-"@sanity/tsdown-config": patch
-"@sanity/vanilla-extract-tsdown-plugin": patch
+"@sanity/tsdown-config": minor
+"@sanity/vanilla-extract-tsdown-plugin": minor
 "@sanity/parse-package-json": patch
 "@sanity/pkg-utils": major
 "@sanity/vanilla-extract-integration": patch
@@ -10,8 +10,10 @@
 
 Upgrade tsdown and `@tsdown/css` to 0.23.
 
-**BREAKING (`@sanity/pkg-utils`):** Node.js 25 can no longer run the build. Use Node
-`^22.18.0`, `^24.11.0`, or `>=26.0.0`.
+**BREAKING:** the `@sanity/tsdown-config` and `@sanity/vanilla-extract-tsdown-plugin`
+`tsdown` peer range is now `^0.23.0`; tsdown 0.22 is no longer supported. Node.js 25
+can no longer run either package or `pkg build`. Use Node `^22.18.0`, `^24.11.0`, or
+`>=26.0.0`.
 
 tsdown 0.23 removes deprecated config options. Replace `dts.tsgo: true` and
 `dts.oxc: true` with `dts.generator: 'tsgo'` and `dts.generator: 'oxc'`.
@@ -21,10 +23,14 @@ Replace `dts.volarPlugins` with `dts.customLanguages` and rename each language's
 Under `deps`, replace `skipNodeModulesBundle: true` with `neverBundle: true`
 and `onlyAllowBundle` with `onlyBundle`.
 
-The `@sanity/tsdown-config` and `@sanity/vanilla-extract-tsdown-plugin` peer
-ranges still accept tsdown 0.22. `deps.resolveDepSubpath: true` preserves the
-old dependency-specifier behavior. `pkg watch` now closes tsdown's native watch
-handle, including its Rolldown watchers and keyboard-shortcut resources, and
-sets `ignoreWatch` on `package.json` and `tsconfig.json` so tsdown does not
-restart itself and orphan a watcher that abort cannot close. CSS builds now
-require `@tsdown/css@^0.23.0`.
+`deps.resolveDepSubpath: true` preserves the old dependency-specifier behavior.
+`pkg watch` now closes tsdown's native watch handle, including its Rolldown watchers
+and keyboard-shortcut resources, and sets `ignoreWatch` on `package.json` and
+`tsconfig.json` so tsdown does not restart itself and orphan a watcher that abort
+cannot close. CSS builds now need `@tsdown/css@0.23.0`, the exact version tsdown 0.23
+pins.
+
+tsdown 0.23 also emits declarations with inline `export declare` modifiers instead of
+a trailing export list. A `.d.ts` with no export statement is an export context, so a
+type that the source left unexported becomes part of the published API. Export the
+types you mean to publish and tag them `@public`.

--- a/.changeset/dependencies-GH-3392.md
+++ b/.changeset/dependencies-GH-3392.md
@@ -11,4 +11,5 @@
 fix(deps): update tsdown to ^0.23.0 and adapt to TsdownHandle
 
 tsdown 0.23's `build()` returns `{bundles, watch}` instead of `TsdownBundle[]`.
-pkg-utils now takes `.bundles` from that handle.
+pkg-utils takes `.bundles` from that handle. Select the Go dts generator with
+`dts: {generator: 'tsgo'}` (`dts.tsgo: true` is gone).

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,8 +10,15 @@
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {
-      "description": "Update the core Rolldown toolchain without the default release-age delay",
-      "matchPackageNames": ["tsdown", "rolldown", "rolldown-plugin-dts"],
+      "description": "Update tsdown and @tsdown/css together without the default release-age delay",
+      "matchPackageNames": ["tsdown", "@tsdown/css"],
+      "groupName": "tsdown",
+      "groupSlug": "tsdown",
+      "minimumReleaseAge": null
+    },
+    {
+      "description": "Update Rolldown and rolldown-plugin-dts without the default release-age delay",
+      "matchPackageNames": ["rolldown", "rolldown-plugin-dts"],
       "minimumReleaseAge": null
     },
     {

--- a/packages/@sanity/pkg-utils/MIGRATE.md
+++ b/packages/@sanity/pkg-utils/MIGRATE.md
@@ -13,7 +13,7 @@ stops with an error that contains these same migration instructions (skipped whe
 | ---------------------------------------------- | --------------------------------------------------------------------------------------- |
 | `dts: 'rolldown'`                              | delete it (it's the default now)                                                        |
 | `dts: 'api-extractor'`                         | delete it (types come from tsdown)                                                      |
-| `tsgo: true`                                   | `dts: {tsgo: true}`                                                                     |
+| `tsgo: true`                                   | `dts: {generator: 'tsgo'}`                                                              |
 | `babel: {reactCompiler: true}`                 | `reactCompiler: true`                                                                   |
 | `reactCompilerOptions: {...}`                  | `reactCompiler: {...}`                                                                  |
 | `babel: {styledComponents: true}`              | `styledComponents: true`                                                                |

--- a/packages/@sanity/pkg-utils/README.md
+++ b/packages/@sanity/pkg-utils/README.md
@@ -147,8 +147,8 @@ The path to the directory to which bundle and chunk files should be written.
 - Default: `undefined`
 
 tsdown's [`dts` options](https://tsdown.dev/options/dts), passed through as-is (an object, or
-`false` to skip generating `.d.ts` files entirely). For example `dts: {tsgo: true}` selects the
-Go-native TypeScript compiler for type generation.
+`false` to skip generating `.d.ts` files entirely). For example `dts: {generator: 'tsgo'}`
+selects the Go-native TypeScript compiler for type generation.
 
 #### `exports`
 

--- a/packages/@sanity/pkg-utils/package.json
+++ b/packages/@sanity/pkg-utils/package.json
@@ -105,7 +105,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@tsdown/css": "^0.23.0",
+    "@tsdown/css": "*",
     "babel-plugin-react-compiler": "*",
     "oxc-transform-react": "*",
     "typescript": "6.x || 7.x"

--- a/packages/@sanity/pkg-utils/package.json
+++ b/packages/@sanity/pkg-utils/package.json
@@ -89,6 +89,7 @@
   },
   "devDependencies": {
     "@sanity/tsconfig": "workspace:^",
+    "@tsdown/css": "catalog:",
     "@types/babel__core": "^7.20.5",
     "@types/find-config": "^1.0.4",
     "@types/node": "catalog:",
@@ -104,7 +105,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@tsdown/css": "*",
+    "@tsdown/css": "^0.23.0",
     "babel-plugin-react-compiler": "*",
     "oxc-transform-react": "*",
     "typescript": "6.x || 7.x"
@@ -121,7 +122,7 @@
     }
   },
   "engines": {
-    "node": "^22.18.0 || >=24.11.0"
+    "node": "^22.18.0 || ^24.11.0 || >=26.0.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@sanity/pkg-utils/src/node/build.ts
+++ b/packages/@sanity/pkg-utils/src/node/build.ts
@@ -98,7 +98,7 @@ export async function build(options: {
       const inlineConfig = await resolveTsdownConfig(ctx, buildDef, {clean: first && clean})
       first = false
 
-      const bundles = await tsdownBuild(inlineConfig)
+      const {bundles} = await tsdownBuild(inlineConfig)
 
       if (ctx.emitDeclarationOnly) {
         // `dts.emitDtsOnly` suppresses the JS chunks of the ES pass, but the CJS pass emits

--- a/packages/@sanity/pkg-utils/src/node/core/config/legacyConfig.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/config/legacyConfig.ts
@@ -30,7 +30,7 @@ const tombstones: LegacyCheck[] = [
       '',
       '  // package.config.ts',
       '  export default defineConfig({',
-      '    dts: {tsgo: true},',
+      "    dts: {generator: 'tsgo'},",
       '  })',
     ],
   },
@@ -165,7 +165,7 @@ export function runLegacyConfigChecks(config: Record<string, unknown>): void {
         ...(dts === 'rolldown'
           ? [
               "`dts: 'rolldown'` is the default behavior now: delete the option. Options that",
-              'accompanied it move into the object, e.g. `tsgo: true` becomes `dts: {tsgo: true}`.',
+              "accompanied it move into the object, e.g. `dts: {generator: 'tsgo'}`.",
             ]
           : [
               "`dts: 'api-extractor'` type generation was removed. Types are generated with",

--- a/packages/@sanity/pkg-utils/src/node/core/config/types.ts
+++ b/packages/@sanity/pkg-utils/src/node/core/config/types.ts
@@ -169,8 +169,8 @@ export interface PkgConfigOptions {
   dist?: string
   /**
    * tsdown's `dts` options, passed through as-is (an object, or `false` to skip generating
-   * `.d.ts` files entirely). For example `dts: {tsgo: true}` selects the Go-native TypeScript
-   * compiler for type generation.
+   * `.d.ts` files entirely). For example `dts: {generator: 'tsgo'}` selects the Go-native
+   * TypeScript compiler for type generation.
    * @see https://tsdown.dev/options/dts
    */
   dts?: false | Extract<NonNullable<UserConfig['dts']>, object>
@@ -310,8 +310,8 @@ export interface PkgConfigOptions {
    */
   rollup?: never
   /**
-   * @deprecated Removed in v12. Set `dts: {tsgo: true}` instead — the `dts` option is passed
-   * through to tsdown as-is.
+   * @deprecated Removed in v12. Set `dts: {generator: 'tsgo'}` instead — the `dts` option is
+   * passed through to tsdown as-is.
    */
   tsgo?: never
 }

--- a/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
+++ b/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
@@ -12,6 +12,14 @@ import type {TsdownBuild} from './resolveTsdownBuilds.ts'
 
 const RE_TS_SOURCE = /\.[cm]?tsx?$/
 
+function hasNativePreview(pkg: {devDependencies?: unknown}): boolean {
+  return (
+    typeof pkg.devDependencies === 'object' &&
+    pkg.devDependencies !== null &&
+    '@typescript/native-preview' in pkg.devDependencies
+  )
+}
+
 /**
  * Composes the tsdown config for one build of the waterfall: `@sanity/tsdown-config`'s
  * `defineConfig()` provides the shared Sanity base, and the pkg-utils opinions (browserslist
@@ -116,25 +124,16 @@ export async function resolveTsdownConfig(
     define[key] = JSON.stringify(value)
   }
 
-  // Types are generated with tsdown (rolldown-plugin-dts). `@typescript/native-preview` in
-  // devDependencies selects the `tsgo` generator, like v11; an explicit `dts.generator` wins.
-  // Only the object form spreads: when the `legacyChecks` migration errors are skipped
-  // (`NODE_ENV=production` / `legacyChecks: false`), a leftover v11 string like
-  // `dts: 'rolldown'` must degrade to the default behavior (which is what it meant) instead
-  // of spreading into numeric character keys.
   const hasTsSources =
     !build.css && build.entries.some((buildEntry) => RE_TS_SOURCE.test(buildEntry.source))
-  const dtsPassthrough = typeof config?.dts === 'object' ? config.dts : undefined
+  const dtsObject = typeof config?.dts === 'object' ? config.dts : undefined
+  const nativePreviewGenerator = hasNativePreview(pkg) ? ({generator: 'tsgo'} as const) : undefined
   const dts =
     hasTsSources && config?.dts !== false
       ? {
-          ...(typeof pkg.devDependencies === 'object' &&
-          '@typescript/native-preview' in pkg.devDependencies
-            ? {generator: 'tsgo' as const}
-            : {}),
-          // Always create dts from scratch, don't reuse contexts from previous builds
+          ...nativePreviewGenerator,
           newContext: true,
-          ...dtsPassthrough,
+          ...dtsObject,
           ...(ctx.emitDeclarationOnly ? {emitDtsOnly: true} : {}),
         }
       : false

--- a/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
+++ b/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
@@ -221,7 +221,14 @@ export async function resolveTsdownConfig(
     ...merged,
     config: false,
     logLevel: 'warn',
-    ...(options.watch ? {watch: true} : {}),
+    ...(options.watch
+      ? {
+          watch: true,
+          // tsdown restarts itself on these paths and discards the handle pkg-utils
+          // holds. pkg watch reloads the waterfall instead.
+          ignoreWatch: [path.join(cwd, 'package.json'), ctx.ts.configPath ?? 'tsconfig.json'],
+        }
+      : {}),
   }
 }
 

--- a/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
+++ b/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
@@ -117,8 +117,8 @@ export async function resolveTsdownConfig(
   }
 
   // Types are generated with tsdown (rolldown-plugin-dts). `@typescript/native-preview` in
-  // devDependencies auto-enables tsgo, like v11; an explicit `dts.tsgo` wins. Only the object
-  // form spreads: when the `legacyChecks` migration errors are skipped
+  // devDependencies selects the `tsgo` generator, like v11; an explicit `dts.generator` wins.
+  // Only the object form spreads: when the `legacyChecks` migration errors are skipped
   // (`NODE_ENV=production` / `legacyChecks: false`), a leftover v11 string like
   // `dts: 'rolldown'` must degrade to the default behavior (which is what it meant) instead
   // of spreading into numeric character keys.
@@ -130,7 +130,7 @@ export async function resolveTsdownConfig(
       ? {
           ...(typeof pkg.devDependencies === 'object' &&
           '@typescript/native-preview' in pkg.devDependencies
-            ? {tsgo: true}
+            ? {generator: 'tsgo' as const}
             : {}),
           // Always create dts from scratch, don't reuse contexts from previous builds
           newContext: true,

--- a/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
+++ b/packages/@sanity/pkg-utils/src/node/tasks/tsdown/resolveTsdownConfig.ts
@@ -225,21 +225,7 @@ export async function resolveTsdownConfig(
   }
 }
 
-/**
- * Declares the conditional export of every CSS file a watch rebuild emitted.
- *
- * A full build leaves this to `cssNodeCompatPlugin`, which composes into tsdown's
- * `exports.customExports`. Watch mode turns tsdown's `exports` feature off (a `package.json`
- * write per rebuild would loop the watcher), so `pkg watch` maintains the exports itself. Most
- * of them are known before the build and are written once per context in `watch.ts`, but the
- * merged `style.css` of CSS imported from JS only exists when something actually imports CSS —
- * declaring it from the config alone would point the export at files nobody produced.
- *
- * `build:done` is the only place that knows: in watch mode `build()` resolves before the first
- * rebuild runs, so the returned bundle's chunks are still empty. The write is idempotent, so
- * the `package.json` watcher settles after one extra rebuild rather than looping.
- * @internal
- */
+/** @internal */
 function createWatchCssExportsHook(
   ctx: BuildContext,
   css: NonNullable<PkgConfigOptions['css']>,

--- a/packages/@sanity/pkg-utils/src/node/watch.ts
+++ b/packages/@sanity/pkg-utils/src/node/watch.ts
@@ -1,7 +1,7 @@
 import {up as findPkgPath} from 'empathic/package'
 import type {Subscription} from 'rxjs'
 import {switchMap} from 'rxjs'
-import {build as tsdownBuild, type TsdownBundle} from 'tsdown'
+import {build as tsdownBuild, type TsdownHandle} from 'tsdown'
 import {loadConfig} from './core/config/loadConfig.ts'
 import {usesCssExportNodeCompat} from './core/pkg/cssExportOptions.ts'
 import {loadPkgWithReporting} from './core/pkg/loadPkgWithReporting.ts'
@@ -10,9 +10,6 @@ import {createLogger} from './logger.ts'
 import {resolveBuildContext} from './resolveBuildContext.ts'
 import {resolveTsdownBuilds} from './tasks/tsdown/resolveTsdownBuilds.ts'
 import {resolveTsdownConfig} from './tasks/tsdown/resolveTsdownConfig.ts'
-
-const asyncDispose: typeof Symbol.asyncDispose =
-  Symbol.asyncDispose || Symbol.for('Symbol.asyncDispose')
 
 /** @public */
 export async function watch(options: {
@@ -28,19 +25,15 @@ export async function watch(options: {
   const {watchConfigFiles} = await import('./watchConfigFiles.ts')
   const configFiles$ = await watchConfigFiles({cwd, logger})
 
-  // Every rebuild of the waterfall holds tsdown watchers (one per platform build); they are
-  // disposed when the config files change (the waterfall restarts) or the signal aborts.
-  // RxJS does not await async subscriber callbacks, so a monotonically increasing run id
-  // guards the rebuilds: only the latest run may publish into `bundles`, and a run that turns
-  // stale mid-flight (a newer config-file event, or the abort signal) disposes the watchers
-  // it created instead of leaking them.
-  let bundles: TsdownBundle[] = []
+  // RxJS does not await async subscriber callbacks. Only the latest runId may
+  // publish handles; a stale or aborted run must close the handles it created.
+  let handles: TsdownHandle[] = []
   let runId = 0
-  const disposeBundles = async () => {
-    const disposing = bundles
-    bundles = []
-    for (const bundle of disposing) {
-      await bundle[asyncDispose]()
+  const closeHandles = async () => {
+    const closing = handles
+    handles = []
+    for (const handle of closing) {
+      await handle.watch.close()
     }
   }
 
@@ -63,14 +56,10 @@ export async function watch(options: {
 
   const ctxSubscription: Subscription = ctx$.subscribe(async (ctx) => {
     const id = ++runId
-    const runBundles: TsdownBundle[] = []
+    const runHandles: TsdownHandle[] = []
     try {
-      await disposeBundles()
+      await closeHandles()
 
-      // Full builds write the conditional `./<css>` export through tsdown's
-      // `exports.customExports` composition, but watch mode disables tsdown's `exports` feature
-      // (a package.json write per rebuild would loop the watcher). Keep the export in sync here
-      // instead, once per context, like v11 — the write is idempotent, so it won't loop.
       const cssNames: string[] = []
       const cssSources: Record<string, string> = {}
 
@@ -119,19 +108,17 @@ export async function watch(options: {
         })
         first = false
 
-        runBundles.push(...(await tsdownBuild(inlineConfig)).bundles)
+        runHandles.push(await tsdownBuild(inlineConfig))
       }
 
       if (id !== runId) {
-        // A newer run (or the abort signal) took over while this rebuild was in flight —
-        // dispose everything this run created instead of publishing it
-        for (const bundle of runBundles) {
-          await bundle[asyncDispose]()
+        for (const handle of runHandles) {
+          await handle.watch.close()
         }
         return
       }
 
-      bundles = runBundles
+      handles = runHandles
 
       logger.success(`${ctx.pkg.name}: watching for file changes\u2026`)
       logger.log()
@@ -149,7 +136,7 @@ export async function watch(options: {
       () => {
         runId++
         ctxSubscription.unsubscribe()
-        void disposeBundles()
+        void closeHandles()
       },
       {once: true},
     )

--- a/packages/@sanity/pkg-utils/src/node/watch.ts
+++ b/packages/@sanity/pkg-utils/src/node/watch.ts
@@ -146,7 +146,7 @@ export async function watch(options: {
       () => {
         runId++
         ctxSubscription.unsubscribe()
-        void closeHandles()
+        closeHandles().catch((err) => logger.error(err))
       },
       {once: true},
     )

--- a/packages/@sanity/pkg-utils/src/node/watch.ts
+++ b/packages/@sanity/pkg-utils/src/node/watch.ts
@@ -22,12 +22,14 @@ export async function watch(options: {
 
   const logger = createLogger()
 
-  const pkgPath = findPkgPath({cwd})
-  if (!pkgPath) {
+  const bootstrapPkgPath = findPkgPath({cwd})
+  if (!bootstrapPkgPath) {
     throw new Error('missing package.json', {cause: {cwd}})
   }
 
-  const bootstrapConfig = await loadConfig({cwd, pkgPath})
+  // The watched tsconfig is fixed when the watcher starts, so a `tsconfig` that a later
+  // `package.config.ts` edit introduces is not picked up.
+  const bootstrapConfig = await loadConfig({cwd, pkgPath: bootstrapPkgPath})
   const watchedTsconfig = tsconfigOption || bootstrapConfig?.tsconfig || 'tsconfig.json'
 
   const {watchConfigFiles} = await import('./watchConfigFiles.ts')

--- a/packages/@sanity/pkg-utils/src/node/watch.ts
+++ b/packages/@sanity/pkg-utils/src/node/watch.ts
@@ -119,7 +119,7 @@ export async function watch(options: {
         })
         first = false
 
-        runBundles.push(...(await tsdownBuild(inlineConfig)))
+        runBundles.push(...(await tsdownBuild(inlineConfig)).bundles)
       }
 
       if (id !== runId) {

--- a/packages/@sanity/pkg-utils/src/node/watch.ts
+++ b/packages/@sanity/pkg-utils/src/node/watch.ts
@@ -22,8 +22,16 @@ export async function watch(options: {
 
   const logger = createLogger()
 
+  const pkgPath = findPkgPath({cwd})
+  if (!pkgPath) {
+    throw new Error('missing package.json', {cause: {cwd}})
+  }
+
+  const bootstrapConfig = await loadConfig({cwd, pkgPath})
+  const watchedTsconfig = tsconfigOption || bootstrapConfig?.tsconfig || 'tsconfig.json'
+
   const {watchConfigFiles} = await import('./watchConfigFiles.ts')
-  const configFiles$ = await watchConfigFiles({cwd, logger})
+  const configFiles$ = await watchConfigFiles({cwd, logger, tsconfig: watchedTsconfig})
 
   // RxJS does not await async subscriber callbacks. Only the latest runId may
   // publish handles; a stale or aborted run must close the handles it created.

--- a/packages/@sanity/pkg-utils/src/node/watchConfigFiles.ts
+++ b/packages/@sanity/pkg-utils/src/node/watchConfigFiles.ts
@@ -8,26 +8,22 @@ import {watchFiles} from './watchFiles.ts'
 export async function watchConfigFiles(options: {
   cwd: string
   logger: Logger
+  tsconfig?: string
 }): Promise<Observable<string[]>> {
-  const {cwd, logger} = options
+  const {cwd, logger, tsconfig = 'tsconfig.json'} = options
 
-  const initialFiles = await globFiles([
+  const configFiles = [
     path.resolve(cwd, 'package.json'),
+    path.resolve(cwd, tsconfig),
     path.resolve(cwd, 'package.config.cjs'),
     path.resolve(cwd, 'package.config.js'),
     path.resolve(cwd, 'package.config.ts'),
     path.resolve(cwd, 'package.config.mjs'),
     path.resolve(cwd, 'package.config.mts'),
-  ])
+  ]
 
-  const fileEvent$ = watchFiles([
-    path.resolve(cwd, 'package.json'),
-    path.resolve(cwd, 'package.config.cjs'),
-    path.resolve(cwd, 'package.config.js'),
-    path.resolve(cwd, 'package.config.ts'),
-    path.resolve(cwd, 'package.config.mjs'),
-    path.resolve(cwd, 'package.config.mts'),
-  ])
+  const initialFiles = await globFiles(configFiles)
+  const fileEvent$ = watchFiles(configFiles)
 
   return fileEvent$.pipe(
     scan((files, fileEvent) => {

--- a/packages/@sanity/pkg-utils/test/__snapshots__/cli.test.ts.snap
+++ b/packages/@sanity/pkg-utils/test/__snapshots__/cli.test.ts.snap
@@ -128,8 +128,8 @@ exports.defineConfig = defineConfig, exports.definePlugin = definePlugin;
 `;
 
 exports[`cli > should build \`multi-export\` package > ./dist/index.d.ts 1`] = `
-"/** @internal */
-interface PluginOptions {
+"/** @public */
+export interface PluginOptions {
   /**
    * @defaultValue true
    */
@@ -138,7 +138,6 @@ interface PluginOptions {
 /** @public */
 export interface Plugin {
   name: string;
-  /** @internal */
   options?: PluginOptions;
 }
 /** @public */

--- a/packages/@sanity/pkg-utils/test/__snapshots__/cli.test.ts.snap
+++ b/packages/@sanity/pkg-utils/test/__snapshots__/cli.test.ts.snap
@@ -44,8 +44,7 @@ exports[`cli > should build \`custom-dist\` package > ./lib/index.cjs 1`] = `
 
 exports[`cli > should build \`custom-dist\` package > ./lib/index.d.ts 1`] = `
 "/** @public */
-declare const VERSION = "1.0.0";
-export { VERSION };
+export declare const VERSION = "1.0.0";
 //# sourceMappingURL=index.d.ts.map"
 `;
 
@@ -73,8 +72,7 @@ exports[`cli > should build \`dummy-module\` package > ./dist/extra.cjs 1`] = `
 
 exports[`cli > should build \`dummy-module\` package > ./dist/extra.d.ts 1`] = `
 "/** @public */
-declare const version: string;
-export { version };
+export declare const version: string;
 //# sourceMappingURL=extra.d.ts.map"
 `;
 
@@ -102,8 +100,7 @@ exports[`cli > should build \`dummy-module\` package > ./dist/index.cjs 1`] = `
 
 exports[`cli > should build \`dummy-module\` package > ./dist/index.d.ts 1`] = `
 "/** @public */
-declare const version: string;
-export { version };
+export declare const version: string;
 //# sourceMappingURL=index.d.ts.map"
 `;
 
@@ -131,26 +128,27 @@ exports.defineConfig = defineConfig, exports.definePlugin = definePlugin;
 `;
 
 exports[`cli > should build \`multi-export\` package > ./dist/index.d.ts 1`] = `
-"interface PluginOptions {
+"/** @internal */
+interface PluginOptions {
   /**
    * @defaultValue true
    */
   enabled?: boolean;
 }
 /** @public */
-interface Plugin {
+export interface Plugin {
   name: string;
+  /** @internal */
   options?: PluginOptions;
 }
 /** @public */
-interface Config extends Plugin {
+export interface Config extends Plugin {
   plugins?: Plugin[];
 }
 /** @public */
-declare function defineConfig(options: Config): Config;
+export declare function defineConfig(options: Config): Config;
 /** @public */
-declare function definePlugin(plugin: Plugin): Plugin;
-export { Config, Plugin, defineConfig, definePlugin };
+export declare function definePlugin(plugin: Plugin): Plugin;
 //# sourceMappingURL=index.d.ts.map"
 `;
 
@@ -183,8 +181,7 @@ exports.plugin = plugin;
 exports[`cli > should build \`multi-export\` package > ./dist/plugin.d.ts 1`] = `
 "import { Plugin } from "multi-export";
 /** @public */
-declare function plugin(): Plugin;
-export { plugin };
+export declare function plugin(): Plugin;
 //# sourceMappingURL=plugin.d.ts.map"
 `;
 
@@ -207,8 +204,7 @@ exports[`cli > should build \`node-condition\` package > ./dist/index.cjs 1`] = 
 
 exports[`cli > should build \`node-condition\` package > ./dist/index.d.ts 1`] = `
 "/** @public */
-declare const version: string;
-export { version };
+export declare const version: string;
 //# sourceMappingURL=index.d.ts.map"
 `;
 
@@ -234,10 +230,9 @@ exports.readPackageJson = readPackageJson, exports.version = "1.0.0";
 
 exports[`cli > should build \`node-condition\` package > ./dist/index.node.d.ts 1`] = `
 "/** @public */
-declare const version: string;
+export declare const version: string;
 /** @public */
-declare function readPackageJson(filePath: string): string;
-export { readPackageJson, version };
+export declare function readPackageJson(filePath: string): string;
 //# sourceMappingURL=index.node.d.ts.map"
 `;
 
@@ -256,12 +251,11 @@ export { readPackageJson, version };
 
 exports[`cli > should build \`react-18\` package > ./dist/index.d.ts 1`] = `
 "/** @public */
-declare function App(): React.JSX.Element;
+export declare function App(): React.JSX.Element;
 /** @public */
-declare const Input: import("react").ForwardRefExoticComponent<Omit<{
+export declare const Input: import("react").ForwardRefExoticComponent<Omit<{
   label?: React.ReactNode;
 } & import("react").HTMLProps<HTMLInputElement>, "ref"> & import("react").RefAttributes<HTMLInputElement>>;
-export { App, Input };
 //# sourceMappingURL=index.d.ts.map"
 `;
 
@@ -449,13 +443,12 @@ export { App, Input };
 
 exports[`cli > should build \`react-19\` package > ./dist/index.d.ts 1`] = `
 "/** @public */
-declare function App(): React.JSX.Element;
+export declare function App(): React.JSX.Element;
 /** @public */
-declare function Input(props: {
+export declare function Input(props: {
   label?: React.ReactNode;
   ref: React.Ref<HTMLInputElement>;
 } & React.HTMLProps<HTMLInputElement>): React.JSX.Element;
-export { App, Input };
 //# sourceMappingURL=index.d.ts.map"
 `;
 
@@ -678,7 +671,7 @@ interface ColorSchemaType extends StringSchemaType {
 }
 type ColorInputProps = StringInputProps<ColorSchemaType>;
 /** @public */
-declare const ColorInput: React.LazyExoticComponent<React.ComponentType<ColorInputProps>>;
+export declare const ColorInput: React.LazyExoticComponent<React.ComponentType<ColorInputProps>>;
 declare const colorTypeName: 'color';
 /**
  * @public
@@ -693,8 +686,8 @@ declare module 'sanity' {
   }
 }
 /** @public */
-declare const colorInput: Plugin<void>;
-export { type ColorDefinition, ColorInput, colorInput };
+export declare const colorInput: Plugin<void>;
+export type { ColorDefinition };
 //# sourceMappingURL=index.d.ts.map"
 `;
 
@@ -767,7 +760,7 @@ interface ColorSchemaType extends StringSchemaType {
 }
 type ColorInputProps = StringInputProps<ColorSchemaType>;
 /** @public */
-declare const ColorInput: React.LazyExoticComponent<React.ComponentType<ColorInputProps>>;
+export declare const ColorInput: React.LazyExoticComponent<React.ComponentType<ColorInputProps>>;
 declare const colorTypeName: 'color';
 /**
  * @public
@@ -782,8 +775,8 @@ declare module 'sanity' {
   }
 }
 /** @public */
-declare const colorInput: Plugin<void>;
-export { type ColorDefinition, ColorInput, colorInput };
+export declare const colorInput: Plugin<void>;
+export type { ColorDefinition };
 //# sourceMappingURL=index.d.ts.map"
 `;
 
@@ -811,13 +804,13 @@ exports[`cli > should build \`ts\` package > ./dist/index.d.ts 1`] = `
 "/**
  * @public
  */
-interface IncludedModuleDummy {
+export interface IncludedModuleDummy {
   field: string;
 }
 /**
  * @internal
  */
-interface _Dummy {
+export interface _Dummy {
   field: string;
 }
 declare module "./module2" {
@@ -826,8 +819,7 @@ declare module "./module2" {
   }
 }
 /** @public */
-declare const VERSION = "1.0.0";
-export { IncludedModuleDummy, VERSION, _Dummy };
+export declare const VERSION = "1.0.0";
 //# sourceMappingURL=index.d.ts.map"
 `;
 
@@ -835,13 +827,13 @@ exports[`cli > should build \`ts-bundler\` package > ./dist/index.d.ts 1`] = `
 "/**
  * @public
  */
-interface IncludedModuleDummy {
+export interface IncludedModuleDummy {
   field: string;
 }
 /**
  * @internal
  */
-interface _Dummy {
+export interface _Dummy {
   field: string;
 }
 declare module './module2' {
@@ -850,8 +842,7 @@ declare module './module2' {
   }
 }
 /** @public */
-declare const VERSION = "1.0.0";
-export { IncludedModuleDummy, VERSION, _Dummy };
+export declare const VERSION = "1.0.0";
 //# sourceMappingURL=index.d.ts.map"
 `;
 
@@ -868,10 +859,10 @@ declare namespace other_d_exports {
 /** @public */
 declare const answer: number;
 /** @public */
-declare const VERSION = "1.0.0";
+export declare const VERSION = "1.0.0";
 /** @public */
 declare const inner_d_exports$1: string;
-export { VERSION, inner_d_exports as inner, inner_d_exports$1 as inner_d_exports, other_d_exports as other };
+export { inner_d_exports as inner, inner_d_exports$1 as inner_d_exports, other_d_exports as other };
 //# sourceMappingURL=index.d.ts.map"
 `;
 
@@ -879,13 +870,13 @@ exports[`cli > should build \`ts-node16\` package > ./dist/index.d.ts 1`] = `
 "/**
  * @public
  */
-interface IncludedModuleDummy {
+export interface IncludedModuleDummy {
   field: string;
 }
 /**
  * @internal
  */
-interface _Dummy {
+export interface _Dummy {
   field: string;
 }
 declare module './module2.js' {
@@ -894,8 +885,7 @@ declare module './module2.js' {
   }
 }
 /** @public */
-declare const VERSION = "1.0.0";
-export { IncludedModuleDummy, VERSION, _Dummy };
+export declare const VERSION = "1.0.0";
 //# sourceMappingURL=index.d.ts.map"
 `;
 
@@ -910,16 +900,16 @@ exports.a = "a", exports.c = require_c.t;
 exports[`cli > should build \`ts-rolldown\` package > ./dist/a.d.cts 1`] = `
 "import { t as c } from "./c-BCyBvqMe.cjs";
 /** @public */
-declare const a = "a";
-export { a, c };
+export declare const a = "a";
+export { c };
 //# sourceMappingURL=a.d.cts.map"
 `;
 
 exports[`cli > should build \`ts-rolldown\` package > ./dist/a.d.ts 1`] = `
 "import { t as c } from "./c-BCyBvqMe.js";
 /** @public */
-declare const a = "a";
-export { a, c };
+export declare const a = "a";
+export { c };
 //# sourceMappingURL=a.d.ts.map"
 `;
 
@@ -943,16 +933,16 @@ exports.b = "b", exports.c = require_c.t;
 exports[`cli > should build \`ts-rolldown\` package > ./dist/b.d.cts 1`] = `
 "import { t as c } from "./c-BCyBvqMe.cjs";
 /** @public */
-declare const b = "b";
-export { b, c };
+export declare const b = "b";
+export { c };
 //# sourceMappingURL=b.d.cts.map"
 `;
 
 exports[`cli > should build \`ts-rolldown\` package > ./dist/b.d.ts 1`] = `
 "import { t as c } from "./c-BCyBvqMe.js";
 /** @public */
-declare const b = "b";
-export { b, c };
+export declare const b = "b";
+export { c };
 //# sourceMappingURL=b.d.ts.map"
 `;
 
@@ -1006,15 +996,13 @@ exports[`cli > should build \`ts-rolldown\` package > ./dist/index.cjs 1`] = `
 
 exports[`cli > should build \`ts-rolldown\` package > ./dist/index.d.cts 1`] = `
 "/** @public */
-declare const VERSION: string;
-export { VERSION };
+export declare const VERSION: string;
 //# sourceMappingURL=index.d.cts.map"
 `;
 
 exports[`cli > should build \`ts-rolldown\` package > ./dist/index.d.ts 1`] = `
 "/** @public */
-declare const VERSION: string;
-export { VERSION };
+export declare const VERSION: string;
 //# sourceMappingURL=index.d.ts.map"
 `;
 
@@ -1105,8 +1093,8 @@ declare type StackablePerspective = ('published' | 'drafts' | string) & {};
 /**
  * @internal - it may have breaking changes in any release
  */
-declare function validateApiPerspective(perspective: unknown): asserts perspective is ClientPerspective;
-export { RemoveIcon, SanityLogo, validateApiPerspective };
+export declare function validateApiPerspective(perspective: unknown): asserts perspective is ClientPerspective;
+export { RemoveIcon, SanityLogo };
 //# sourceMappingURL=index.d.cts.map"
 `;
 
@@ -1142,8 +1130,8 @@ declare type StackablePerspective = ('published' | 'drafts' | string) & {};
 /**
  * @internal - it may have breaking changes in any release
  */
-declare function validateApiPerspective(perspective: unknown): asserts perspective is ClientPerspective;
-export { RemoveIcon, SanityLogo, validateApiPerspective };
+export declare function validateApiPerspective(perspective: unknown): asserts perspective is ClientPerspective;
+export { RemoveIcon, SanityLogo };
 //# sourceMappingURL=index.d.ts.map"
 `;
 
@@ -1386,14 +1374,13 @@ exports[`cli > should build \`ts-rolldown-external-subpath-import\` package > ./
 /**
  * @public
  */
-interface ExternalSubpathImport {
+export interface ExternalSubpathImport {
   path: AgentActionPath;
 }
 /**
  * @public
  */
-declare function identity(path: AgentActionPath): AgentActionPath;
-export { ExternalSubpathImport, identity };
+export declare function identity(path: AgentActionPath): AgentActionPath;
 //# sourceMappingURL=index.d.cts.map"
 `;
 
@@ -1402,14 +1389,13 @@ exports[`cli > should build \`ts-rolldown-external-subpath-import\` package > ./
 /**
  * @public
  */
-interface ExternalSubpathImport {
+export interface ExternalSubpathImport {
   path: AgentActionPath;
 }
 /**
  * @public
  */
-declare function identity(path: AgentActionPath): AgentActionPath;
-export { ExternalSubpathImport, identity };
+export declare function identity(path: AgentActionPath): AgentActionPath;
 //# sourceMappingURL=index.d.ts.map"
 `;
 
@@ -1514,14 +1500,12 @@ exports[`cli > should build \`ts-rolldown-without-extract\` package > ./dist/ind
 `;
 
 exports[`cli > should build \`ts-rolldown-without-extract\` package > ./dist/index.d.cts 1`] = `
-"declare const VERSION = "1.0.0";
-export { VERSION };
+"export declare const VERSION = "1.0.0";
 //# sourceMappingURL=index.d.cts.map"
 `;
 
 exports[`cli > should build \`ts-rolldown-without-extract\` package > ./dist/index.d.ts 1`] = `
-"declare const VERSION = "1.0.0";
-export { VERSION };
+"export declare const VERSION = "1.0.0";
 //# sourceMappingURL=index.d.ts.map"
 `;
 
@@ -1533,8 +1517,7 @@ export { VERSION };
 `;
 
 exports[`cli > should build \`ts-without-extract\` package > ./dist/index.d.ts 1`] = `
-"declare const VERSION = "1.0.0";
-export { VERSION };
+"export declare const VERSION = "1.0.0";
 //# sourceMappingURL=index.d.ts.map"
 `;
 
@@ -1542,13 +1525,13 @@ exports[`cli > should build with \`--quiet\` flag suppressing output > ./dist/in
 "/**
  * @public
  */
-interface IncludedModuleDummy {
+export interface IncludedModuleDummy {
   field: string;
 }
 /**
  * @internal
  */
-interface _Dummy {
+export interface _Dummy {
   field: string;
 }
 declare module "./module2" {
@@ -1557,7 +1540,6 @@ declare module "./module2" {
   }
 }
 /** @public */
-declare const VERSION = "1.0.0";
-export { IncludedModuleDummy, VERSION, _Dummy };
+export declare const VERSION = "1.0.0";
 //# sourceMappingURL=index.d.ts.map"
 `;

--- a/packages/@sanity/pkg-utils/test/resolveTsdownConfig.test.ts
+++ b/packages/@sanity/pkg-utils/test/resolveTsdownConfig.test.ts
@@ -85,13 +85,13 @@ test('a leftover v11 `dts` string degrades to the default instead of spreading',
 })
 
 test('the `dts` object passthrough spreads over the defaults', async () => {
-  const ctx = createContext({dts: {tsgo: true, sourcemap: true}})
+  const ctx = createContext({dts: {generator: 'tsgo', sourcemap: true}})
   const [build] = resolveTsdownBuilds(ctx)
   if (!build) throw new Error('expected a build')
 
   const inlineConfig = await resolveTsdownConfig(ctx, build, {clean: false})
 
-  expect(inlineConfig.dts).toEqual({newContext: true, tsgo: true, sourcemap: true})
+  expect(inlineConfig.dts).toEqual({newContext: true, generator: 'tsgo', sourcemap: true})
 })
 
 test('forwards `bundleAnalyzer` to @sanity/tsdown-config', async () => {

--- a/packages/@sanity/pkg-utils/test/resolveTsdownConfig.test.ts
+++ b/packages/@sanity/pkg-utils/test/resolveTsdownConfig.test.ts
@@ -176,6 +176,21 @@ function bundleAnalyzerOptions(config: {plugins?: unknown}): unknown {
   return plugin && typeof plugin === 'object' && '_options' in plugin ? plugin._options : undefined
 }
 
+test('watch mode ignores package.json and tsconfig so tsdown cannot orphan the handle', async () => {
+  const ctx = createContext({})
+  ctx.ts = {configPath: 'tsconfig.json'}
+  const [build] = resolveTsdownBuilds(ctx)
+  if (!build) throw new Error('expected a build')
+
+  const watchConfig = await resolveTsdownConfig(ctx, build, {clean: true, watch: true})
+  expect(watchConfig.ignoreWatch).toEqual([path.join(cwd, 'package.json'), 'tsconfig.json'])
+  expect(watchConfig.watch).toBe(true)
+
+  const buildConfig = await resolveTsdownConfig(ctx, build, {clean: false})
+  expect(buildConfig.ignoreWatch).toBeUndefined()
+  expect(buildConfig.watch).toBeUndefined()
+})
+
 test('inherits the declaration-only circular dependency suppression', async () => {
   // `checks.circularDependency` comes from `@sanity/tsdown-config`, and so does the
   // `suppressWarnings` predicate that drops the type-only cycles of the declaration bundling

--- a/packages/@sanity/pkg-utils/test/watch-orphan.test.ts
+++ b/packages/@sanity/pkg-utils/test/watch-orphan.test.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+import {watch} from '../src/node/watch'
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+const mtime = (file: string) => fs.statSync(file, {throwIfNoEntry: false})?.mtimeMs ?? -1
+
+async function touch(file: string) {
+  const src = await fsp.readFile(file, 'utf8')
+  await fsp.writeFile(file, src.endsWith('\n') ? src.slice(0, -1) : `${src}\n`)
+}
+
+async function waitForWrite(file: string, since: number) {
+  await vi.waitFor(() => expect(mtime(file)).not.toBe(since), {timeout: 10_000, interval: 25})
+  return mtime(file)
+}
+
+describe.skipIf(process.platform === 'win32')('watch orphaned tsdown handles', () => {
+  let cwd: string | undefined
+  let abort: AbortController | undefined
+
+  afterEach(async () => {
+    abort?.abort()
+    abort = undefined
+    await sleep(300)
+    if (cwd) await fsp.rm(cwd, {recursive: true, force: true})
+    cwd = undefined
+  })
+
+  test('abort after a package.json reload stops every tsdown watcher', async () => {
+    cwd = await fsp.mkdtemp(path.join(os.tmpdir(), 'pkg-watch-'))
+    const fixture = path.resolve(__dirname, '../../../../playground/multi-exports-commonjs')
+    for (const entry of ['package.json', 'tsconfig.json', 'src']) {
+      await fsp.cp(path.join(fixture, entry), path.join(cwd, entry), {recursive: true})
+    }
+    await fsp.symlink(
+      path.resolve(__dirname, '../../../../node_modules'),
+      path.join(cwd, 'node_modules'),
+    )
+
+    const distIndex = path.join(cwd, 'dist/index.js')
+    const srcIndex = path.join(cwd, 'src/index.ts')
+
+    abort = new AbortController()
+    await watch({cwd, strict: false, signal: abort.signal})
+    let seen = await waitForWrite(distIndex, -1)
+
+    await touch(srcIndex)
+    seen = await waitForWrite(distIndex, seen)
+
+    await touch(path.join(cwd, 'package.json'))
+    seen = await waitForWrite(distIndex, seen)
+    await sleep(1000)
+    seen = mtime(distIndex)
+
+    abort.abort()
+    await sleep(500)
+
+    await touch(srcIndex)
+    await sleep(2000)
+    expect(mtime(distIndex)).toBe(seen)
+  })
+})

--- a/packages/@sanity/pkg-utils/test/watch.test.ts
+++ b/packages/@sanity/pkg-utils/test/watch.test.ts
@@ -1,5 +1,6 @@
 import {up as findPkgPath} from 'empathic/package'
-import {describe, expect, test} from 'vitest'
+import {build as tsdownBuild, type TsdownHandle} from 'tsdown'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 import {loadConfig} from '../src/node/core/config/loadConfig'
 import {loadPkgWithReporting} from '../src/node/core/pkg/loadPkgWithReporting'
 import {createLogger} from '../src/node/logger'
@@ -7,6 +8,30 @@ import {resolveBuildContext} from '../src/node/resolveBuildContext'
 import {resolveTsdownBuilds} from '../src/node/tasks/tsdown/resolveTsdownBuilds'
 import {watch} from '../src/node/watch'
 import {spawnProject} from './env/spawnProject'
+
+vi.mock('tsdown', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('tsdown')>()
+  return {
+    ...actual,
+    build: vi.fn(),
+  }
+})
+
+function mockWatchHandle(): {
+  handle: TsdownHandle
+  close: ReturnType<typeof vi.fn>
+  restart: ReturnType<typeof vi.fn>
+} {
+  const close = vi.fn(async () => {})
+  const restart = vi.fn(async () => {
+    throw new Error('watch.restart() must not be used')
+  })
+  return {
+    close,
+    restart,
+    handle: {bundles: [], watch: {close, restart}},
+  }
+}
 
 async function resolveProjectBuilds(projectCwd: string) {
   const logger = createLogger(true) // quiet mode
@@ -29,6 +54,17 @@ async function resolveProjectBuilds(projectCwd: string) {
 }
 
 describe.skipIf(process.platform === 'win32')('watch functionality', () => {
+  let abort: AbortController | undefined
+
+  beforeEach(() => {
+    vi.mocked(tsdownBuild).mockReset()
+  })
+
+  afterEach(() => {
+    abort?.abort()
+    abort = undefined
+  })
+
   test('resolves the build waterfall for a TypeScript project', async () => {
     const project = await spawnProject('ts')
     const builds = await resolveProjectBuilds(project.cwd)
@@ -68,33 +104,63 @@ describe.skipIf(process.platform === 'win32')('watch functionality', () => {
     expect(builds.at(-1)?.canonical).toBe(true)
   })
 
-  test(
-    'watch function should initialize and clean up with AbortController',
-    {retry: process.platform === 'darwin' ? 3 : 0},
-    async () => {
-      // A fixture no other test file builds: `watch()` cleans `dist` on startup and rebuilds
-      // it, which races the parallel `cli.test.ts` worker when they share a fixture — publint
-      // packs the package there, and a pack that lands in the cleaned window sees an empty
-      // `dist` and reports every export target as not published.
-      const project = await spawnProject('multi-exports-commonjs')
-      const ac = new AbortController()
+  test('abort closes published handles and does not start another build', async () => {
+    const project = await spawnProject('multi-exports-commonjs')
+    const builds = await resolveProjectBuilds(project.cwd)
+    const published = Array.from({length: builds.length}, () => mockWatchHandle())
+    vi.mocked(tsdownBuild).mockImplementation(async () => {
+      const next = published[vi.mocked(tsdownBuild).mock.calls.length - 1]
+      if (!next) throw new Error('unexpected extra tsdown build')
+      return next.handle
+    })
 
-      // This test verifies that watch() can be called and initialized
-      // We don't let it run indefinitely, just verify it starts without error
-      void watch({
-        cwd: project.cwd,
-        strict: false,
-        signal: ac.signal,
-      })
+    abort = new AbortController()
+    await watch({
+      cwd: project.cwd,
+      strict: false,
+      signal: abort.signal,
+    })
 
-      // Give it a moment to initialize
-      await new Promise((resolve) => setTimeout(resolve, 1000))
+    await vi.waitFor(() => {
+      expect(tsdownBuild).toHaveBeenCalledTimes(builds.length)
+    })
 
-      // Clean up the watch subscriptions
-      ac.abort()
+    abort.abort()
 
-      // If we got here without an error being thrown, the watch initialized successfully
-      expect(true).toBe(true)
-    },
-  )
+    await vi.waitFor(() => {
+      for (const {close, restart} of published) {
+        expect(close).toHaveBeenCalledTimes(1)
+        expect(restart).not.toHaveBeenCalled()
+      }
+    })
+    expect(tsdownBuild).toHaveBeenCalledTimes(builds.length)
+  })
+
+  test('abort during an in-flight build closes that handle and does not rebuild', async () => {
+    const project = await spawnProject('multi-exports-commonjs')
+    const pending = Promise.withResolvers<TsdownHandle>()
+    vi.mocked(tsdownBuild).mockReturnValue(pending.promise)
+
+    abort = new AbortController()
+    await watch({
+      cwd: project.cwd,
+      strict: false,
+      signal: abort.signal,
+    })
+
+    await vi.waitFor(() => {
+      expect(tsdownBuild).toHaveBeenCalledTimes(1)
+    })
+
+    abort.abort()
+
+    const {handle, close, restart} = mockWatchHandle()
+    pending.resolve(handle)
+
+    await vi.waitFor(() => {
+      expect(close).toHaveBeenCalledTimes(1)
+    })
+    expect(restart).not.toHaveBeenCalled()
+    expect(tsdownBuild).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/@sanity/tsdown-config/README.md
+++ b/packages/@sanity/tsdown-config/README.md
@@ -295,7 +295,7 @@ import {defineConfig} from '@sanity/tsdown-config'
 
 export default defineConfig({
   tsconfig: 'tsconfig.dist.json',
-  dts: {tsgo: true},
+  dts: {generator: 'tsgo'},
 })
 ```
 

--- a/packages/@sanity/tsdown-config/package.json
+++ b/packages/@sanity/tsdown-config/package.json
@@ -76,7 +76,7 @@
     "@tsdown/css": "*",
     "babel-plugin-react-compiler": "*",
     "oxc-transform-react": "*",
-    "tsdown": "^0.22.7 || ^0.23.0",
+    "tsdown": "^0.23.0",
     "typescript": "6.x || 7.x"
   },
   "peerDependenciesMeta": {
@@ -97,7 +97,7 @@
     }
   },
   "engines": {
-    "node": "^22.18.0 || >=24.11.0"
+    "node": "^22.18.0 || ^24.11.0 || >=26.0.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@sanity/tsdown-config/package.json
+++ b/packages/@sanity/tsdown-config/package.json
@@ -76,7 +76,7 @@
     "@tsdown/css": "*",
     "babel-plugin-react-compiler": "*",
     "oxc-transform-react": "*",
-    "tsdown": "^0.22.7",
+    "tsdown": "^0.23.0",
     "typescript": "6.x || 7.x"
   },
   "peerDependenciesMeta": {

--- a/packages/@sanity/tsdown-config/package.json
+++ b/packages/@sanity/tsdown-config/package.json
@@ -61,7 +61,7 @@
     "@rolldown/plugin-babel": "^0.2.3",
     "@sanity/pkg-utils": "workspace:^",
     "@sanity/tsconfig": "workspace:^",
-    "@tsdown/css": "^0.22.14",
+    "@tsdown/css": "catalog:",
     "@types/babel__core": "^7.20.5",
     "babel-plugin-react-compiler": "^1.0.0",
     "oxc-transform-react": "catalog:",
@@ -76,7 +76,7 @@
     "@tsdown/css": "*",
     "babel-plugin-react-compiler": "*",
     "oxc-transform-react": "*",
-    "tsdown": "^0.23.0",
+    "tsdown": "^0.22.7 || ^0.23.0",
     "typescript": "6.x || 7.x"
   },
   "peerDependenciesMeta": {

--- a/packages/@sanity/tsdown-config/src/index.ts
+++ b/packages/@sanity/tsdown-config/src/index.ts
@@ -581,13 +581,11 @@ async function resolvePackageConfig(
           : Array.isArray(userNeverBundle)
             ? [nodeBuiltinExternal, ...userNeverBundle]
             : [nodeBuiltinExternal, userNeverBundle]
-  const deps: UserConfig['deps'] =
-    options.deps === undefined && neverBundle === undefined
-      ? undefined
-      : {
-          ...options.deps,
-          ...(neverBundle === undefined ? {} : {neverBundle}),
-        }
+  const deps: UserConfig['deps'] = {
+    resolveDepSubpath: true,
+    ...options.deps,
+    ...(neverBundle === undefined ? {} : {neverBundle}),
+  }
 
   // `outputOptions` is left to tsdown's defaults - notably chunk filenames keep tsdown's hashed
   // default (unless userland sets `hash`), which prevents chunk/entry filename collisions

--- a/packages/@sanity/tsdown-config/test/fixtures/react-19-library/dist/index.d.cts
+++ b/packages/@sanity/tsdown-config/test/fixtures/react-19-library/dist/index.d.cts
@@ -1,6 +1,5 @@
-declare function Button({ children, type }: {
+export declare function Button({ children, type }: {
   children: React.ReactNode;
   type?: "submit" | "button" | "reset";
 }): React.JSX.Element;
-export { Button };
 //# sourceMappingURL=index.d.cts.map

--- a/packages/@sanity/tsdown-config/test/fixtures/react-19-library/dist/index.d.cts.map
+++ b/packages/@sanity/tsdown-config/test/fixtures/react-19-library/dist/index.d.cts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.d.cts","names":[],"sources":["../src/Button.tsx"],"mappings":"AAWA,iBAAgB,SACd,UACA;EAEA,UAAU,MAAM;EAChB;IACE,MAAM,IAAI"}
+{"version":3,"file":"index.d.cts","names":[],"sources":["../src/Button.tsx"],"mappings":"AAWA,wBAAgB,SACd,UACA;EAEA,UAAU,MAAM;EAChB;IACE,MAAM,IAAI"}

--- a/packages/@sanity/tsdown-config/test/fixtures/react-19-library/dist/index.d.ts
+++ b/packages/@sanity/tsdown-config/test/fixtures/react-19-library/dist/index.d.ts
@@ -1,6 +1,5 @@
-declare function Button({ children, type }: {
+export declare function Button({ children, type }: {
   children: React.ReactNode;
   type?: "submit" | "button" | "reset";
 }): React.JSX.Element;
-export { Button };
 //# sourceMappingURL=index.d.ts.map

--- a/packages/@sanity/tsdown-config/test/fixtures/react-19-library/dist/index.d.ts.map
+++ b/packages/@sanity/tsdown-config/test/fixtures/react-19-library/dist/index.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.d.ts","names":[],"sources":["../src/Button.tsx"],"mappings":"AAWA,iBAAgB,SACd,UACA;EAEA,UAAU,MAAM;EAChB;IACE,MAAM,IAAI"}
+{"version":3,"file":"index.d.ts","names":[],"sources":["../src/Button.tsx"],"mappings":"AAWA,wBAAgB,SACd,UACA;EAEA,UAAU,MAAM;EAChB;IACE,MAAM,IAAI"}

--- a/packages/@sanity/tsdown-config/test/fixtures/vanilla-extract-css-modules-library/package.json
+++ b/packages/@sanity/tsdown-config/test/fixtures/vanilla-extract-css-modules-library/package.json
@@ -34,7 +34,7 @@
     "build": "tsdown"
   },
   "devDependencies": {
-    "@tsdown/css": "^0.22.14",
+    "@tsdown/css": "catalog:",
     "@vanilla-extract/css": "^1.21.2"
   },
   "publishConfig": {

--- a/packages/@sanity/tsdown-config/test/options.test.ts
+++ b/packages/@sanity/tsdown-config/test/options.test.ts
@@ -206,14 +206,34 @@ describe('sourcemap option', () => {
 
 describe('deps option', () => {
   test('defaults to neverBundle `/^node:/` when platform is neutral', async () => {
-    expect((await defineConfig()).deps).toEqual({neverBundle: [/^node:/]})
-    expect((await defineConfig({platform: 'neutral'})).deps).toEqual({neverBundle: [/^node:/]})
+    expect((await defineConfig()).deps).toEqual({
+      resolveDepSubpath: true,
+      neverBundle: [/^node:/],
+    })
+    expect((await defineConfig({platform: 'neutral'})).deps).toEqual({
+      resolveDepSubpath: true,
+      neverBundle: [/^node:/],
+    })
   })
 
   test('does not add `/^node:/` when platform is not neutral', async () => {
-    expect((await defineConfig({platform: 'node'})).deps).toBeUndefined()
+    expect((await defineConfig({platform: 'node'})).deps).toEqual({resolveDepSubpath: true})
+    expect((await defineConfig({platform: 'browser'})).deps).toEqual({resolveDepSubpath: true})
     expect((await defineConfig({platform: 'node', deps: {neverBundle: true}})).deps).toEqual({
+      resolveDepSubpath: true,
       neverBundle: true,
+    })
+  })
+
+  test('keeps resolveDepSubpath true unless the user sets false', async () => {
+    expect((await defineConfig({deps: {onlyBundle: false}})).deps).toEqual({
+      resolveDepSubpath: true,
+      onlyBundle: false,
+      neverBundle: [/^node:/],
+    })
+    expect((await defineConfig({deps: {resolveDepSubpath: false}})).deps).toEqual({
+      resolveDepSubpath: false,
+      neverBundle: [/^node:/],
     })
   })
 
@@ -221,6 +241,7 @@ describe('deps option', () => {
     // tsdown's `mergeConfig` would replace the array; concatenate so per-package externals
     // (e.g. self-references like `/^sanity(\\/|$)/`) add to the node builtins instead
     expect((await defineConfig({deps: {neverBundle: [/^sanity(\/|$)/]}})).deps).toEqual({
+      resolveDepSubpath: true,
       neverBundle: [/^node:/, /^sanity(\/|$)/],
     })
   })

--- a/packages/@sanity/tsdown-config/test/options.test.ts
+++ b/packages/@sanity/tsdown-config/test/options.test.ts
@@ -10,10 +10,10 @@ describe('dts option', () => {
   test('is passed through to tsdown as-is', async () => {
     expect((await defineConfig({dts: false})).dts).toBe(false)
     expect((await defineConfig({dts: true})).dts).toBe(true)
-    expect((await defineConfig({dts: {tsgo: true}})).dts).toEqual({tsgo: true})
-    expect((await defineConfig({dts: {sourcemap: true, oxc: false}})).dts).toEqual({
+    expect((await defineConfig({dts: {generator: 'tsgo'}})).dts).toEqual({generator: 'tsgo'})
+    expect((await defineConfig({dts: {sourcemap: true, generator: 'tsc'}})).dts).toEqual({
       sourcemap: true,
-      oxc: false,
+      generator: 'tsc',
     })
   })
 })

--- a/packages/@sanity/tsdown-config/test/options.test.ts
+++ b/packages/@sanity/tsdown-config/test/options.test.ts
@@ -212,9 +212,9 @@ describe('deps option', () => {
 
   test('does not add `/^node:/` when platform is not neutral', async () => {
     expect((await defineConfig({platform: 'node'})).deps).toBeUndefined()
-    expect(
-      (await defineConfig({platform: 'node', deps: {skipNodeModulesBundle: true}})).deps,
-    ).toEqual({skipNodeModulesBundle: true})
+    expect((await defineConfig({platform: 'node', deps: {neverBundle: true}})).deps).toEqual({
+      neverBundle: true,
+    })
   })
 
   test('appends userland neverBundle entries to the `/^node:/` default', async () => {
@@ -222,16 +222,6 @@ describe('deps option', () => {
     // (e.g. self-references like `/^sanity(\\/|$)/`) add to the node builtins instead
     expect((await defineConfig({deps: {neverBundle: [/^sanity(\/|$)/]}})).deps).toEqual({
       neverBundle: [/^node:/, /^sanity(\/|$)/],
-    })
-    expect(
-      (
-        await defineConfig({
-          deps: {neverBundle: [/^sanity(\/|$)/], skipNodeModulesBundle: true},
-        })
-      ).deps,
-    ).toEqual({
-      neverBundle: [/^node:/, /^sanity(\/|$)/],
-      skipNodeModulesBundle: true,
     })
   })
 

--- a/packages/@sanity/vanilla-extract-tsdown-plugin/package.json
+++ b/packages/@sanity/vanilla-extract-tsdown-plugin/package.json
@@ -54,7 +54,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "tsdown": "^0.22.5 || ^0.23.0"
+    "tsdown": "^0.23.0"
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"

--- a/packages/@sanity/vanilla-extract-tsdown-plugin/package.json
+++ b/packages/@sanity/vanilla-extract-tsdown-plugin/package.json
@@ -54,7 +54,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "tsdown": "^0.23.0"
+    "tsdown": "^0.22.5 || ^0.23.0"
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"

--- a/packages/@sanity/vanilla-extract-tsdown-plugin/package.json
+++ b/packages/@sanity/vanilla-extract-tsdown-plugin/package.json
@@ -54,7 +54,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "tsdown": "^0.22.5"
+    "tsdown": "^0.23.0"
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"

--- a/playground/css-entry/package.json
+++ b/playground/css-entry/package.json
@@ -15,8 +15,8 @@
       "default": "./dist/ui/index.js"
     },
     "./ui/styles.css": {
-      "types": "./dist/ui/styles-css.d.ts",
       "source": "./src/ui/styles.css",
+      "types": "./dist/ui/styles-css.d.ts",
       "browser": "./dist/ui/styles.css",
       "style": "./dist/ui/styles.css",
       "node": "./dist/ui/styles-css.js",

--- a/playground/css-entry/package.json
+++ b/playground/css-entry/package.json
@@ -15,8 +15,8 @@
       "default": "./dist/ui/index.js"
     },
     "./ui/styles.css": {
-      "source": "./src/ui/styles.css",
       "types": "./dist/ui/styles-css.d.ts",
+      "source": "./src/ui/styles.css",
       "browser": "./dist/ui/styles.css",
       "style": "./dist/ui/styles.css",
       "node": "./dist/ui/styles-css.js",

--- a/playground/css-entry/package.json
+++ b/playground/css-entry/package.json
@@ -37,7 +37,7 @@
   "browserslist": "extends @sanity/browserslist-config",
   "devDependencies": {
     "@sanity/browserslist-config": "^1.0.5",
-    "@tsdown/css": "^0.22.14"
+    "@tsdown/css": "catalog:"
   },
   "publishConfig": {
     "exports": {

--- a/playground/css-import/package.json
+++ b/playground/css-import/package.json
@@ -32,7 +32,7 @@
   "browserslist": "extends @sanity/browserslist-config",
   "devDependencies": {
     "@sanity/browserslist-config": "^1.0.5",
-    "@tsdown/css": "^0.22.14"
+    "@tsdown/css": "catalog:"
   },
   "publishConfig": {
     "exports": {

--- a/playground/multi-export/src/types.ts
+++ b/playground/multi-export/src/types.ts
@@ -1,5 +1,5 @@
-/** @internal */
-interface PluginOptions {
+/** @public */
+export interface PluginOptions {
   /**
    * @defaultValue true
    */
@@ -9,7 +9,6 @@ interface PluginOptions {
 /** @public */
 export interface Plugin {
   name: string
-  /** @internal */
   options?: PluginOptions
 }
 

--- a/playground/multi-export/src/types.ts
+++ b/playground/multi-export/src/types.ts
@@ -1,3 +1,4 @@
+/** @internal */
 interface PluginOptions {
   /**
    * @defaultValue true
@@ -8,6 +9,7 @@ interface PluginOptions {
 /** @public */
 export interface Plugin {
   name: string
+  /** @internal */
   options?: PluginOptions
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: ^0.3.24
       version: 0.3.24
     tsdown:
-      specifier: ^0.22.14
-      version: 0.22.14
+      specifier: ^0.23.0
+      version: 0.23.0
     typescript:
       specifier: 7.0.2
       version: 7.0.2
@@ -97,7 +97,7 @@ importers:
         version: 2.1.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.14(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+        version: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -696,7 +696,7 @@ importers:
         version: 0.3.24
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.14(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+        version: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -780,7 +780,7 @@ importers:
         version: 1.1.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.14(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+        version: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
       tsx:
         specifier: ^4.23.13
         version: 4.23.13
@@ -889,7 +889,7 @@ importers:
         version: link:../tsconfig
       '@tsdown/css':
         specifier: ^0.22.14
-        version: 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.22.14)(tsx@4.23.13)(yaml@2.9.0)
+        version: 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
@@ -904,7 +904,7 @@ importers:
         version: 1.3.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.14(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+        version: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -984,7 +984,7 @@ importers:
     devDependencies:
       '@tsdown/css':
         specifier: ^0.22.14
-        version: 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.22.14)(tsx@4.23.13)(yaml@2.9.0)
+        version: 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)
       '@vanilla-extract/css':
         specifier: ^1.21.2
         version: 1.21.2
@@ -1030,7 +1030,7 @@ importers:
         version: 0.3.24
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.14(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+        version: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1067,7 +1067,7 @@ importers:
         version: 1.2.7
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.14(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+        version: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1101,7 +1101,7 @@ importers:
         version: 1.2.7
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.14(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+        version: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1132,7 +1132,7 @@ importers:
         version: 0.3.24
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.14(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+        version: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1164,7 +1164,7 @@ importers:
         version: 1.0.5
       '@tsdown/css':
         specifier: ^0.22.14
-        version: 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.22.14)(tsx@4.23.13)(yaml@2.9.0)
+        version: 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)
 
   playground/css-export: {}
 
@@ -1175,7 +1175,7 @@ importers:
         version: 1.0.5
       '@tsdown/css':
         specifier: ^0.22.14
-        version: 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.22.14)(tsx@4.23.13)(yaml@2.9.0)
+        version: 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)
 
   playground/custom-dist: {}
 
@@ -7855,8 +7855,18 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@yuku-codegen/binding-android-arm64@0.9.4':
+    resolution: {integrity: sha512-6ViGFAr+N2Yjnc8wBx16wJZGB0pGmClILO+FUC3kzwEydfjXQovWEdcFyl98RVtWdj9ahS41XXe2zKFl+L3uWg==}
+    cpu: [arm64]
+    os: [android]
+
   '@yuku-codegen/binding-darwin-arm64@0.8.7':
     resolution: {integrity: sha512-/u+REDMI4a0/lsJXTM4c53/w31OGZLOReZIyg62uhgLs0kc8NHsj/nOcxTdlQjq5gi0zhdkccD9LaLTXcdzPvw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@yuku-codegen/binding-darwin-arm64@0.9.4':
+    resolution: {integrity: sha512-0BTB70ha+wRsz6fI5HosevJpMmvgndmf+6ND1OneFKCrWhNzX/2xIQ36Z8rUgv5bpnWjKl6bRvzSFV3PU+WOlQ==}
     cpu: [arm64]
     os: [darwin]
 
@@ -7865,13 +7875,29 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@yuku-codegen/binding-darwin-x64@0.9.4':
+    resolution: {integrity: sha512-9QVVqq8LCD6v+Gl099u32YJ0999HBCoe09ecIeifKTi4Y1azX44DkF9q9pP2lxgwRUvR3GmWl5k1pLe3ojR2rg==}
+    cpu: [x64]
+    os: [darwin]
+
   '@yuku-codegen/binding-freebsd-x64@0.8.7':
     resolution: {integrity: sha512-MpdpKXix9P+Y1rKgjvcNeNtGjXeL1CmttNhYINrWls8kRpm4xM/oBGTmn6w7to8lAlwj5jm8q03dQPl5mRv4Qw==}
     cpu: [x64]
     os: [freebsd]
 
+  '@yuku-codegen/binding-freebsd-x64@0.9.4':
+    resolution: {integrity: sha512-Qm3ky33Em9w1XVSryq+D/arLVapeqp0Bu1719UGV6olmfp4kTD+NfsLG9bRx5hOJSu1Zl3r9LbyTP1oTmcHAsg==}
+    cpu: [x64]
+    os: [freebsd]
+
   '@yuku-codegen/binding-linux-arm-gnu@0.8.7':
     resolution: {integrity: sha512-rr1srFLlPAmC1vtxfc9C1YLDe3iH09YjfSeeIidBqKhzx1MATjOAq4mjlRUOnhr/L27MotWIYOFKwVsd5JZFOg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-codegen/binding-linux-arm-gnu@0.9.4':
+    resolution: {integrity: sha512-euKmS7pnkeJylEN6+9bfu0jHtGfbQRfFBIpmTe8YVnWzQ5Rjyrns13+1kao2RSS9DNkucX1RXIdiTvQoDUXF0w==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -7882,8 +7908,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@yuku-codegen/binding-linux-arm-musl@0.9.4':
+    resolution: {integrity: sha512-7JTizi2O+ks9/dLPDLYmVLsYQUC9Fxu0e6LNA+F6FFQ/sV2o7owBb1eTccMKkgauWGGUpJYQvlXrCKpGwguvhA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
   '@yuku-codegen/binding-linux-arm64-gnu@0.8.7':
     resolution: {integrity: sha512-gw4w6wPoHObBrdIC4duVWLmJOvpdE25j5D7yrM5mACNlK4klRz/lv8hK+ssQk9EJHBgZjSaqZIJVFgqNYbfv7A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-codegen/binding-linux-arm64-gnu@0.9.4':
+    resolution: {integrity: sha512-f7eLYDwmcz56Jzvp8UmXUehFzTAn6hEHt64GDWNWGSqrphHRvWLEshQ+sQv8DfNpkXFaOQ49erl4gb2Wm0JM+A==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -7894,8 +7932,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@yuku-codegen/binding-linux-arm64-musl@0.9.4':
+    resolution: {integrity: sha512-bLdjCgo+u3dU3HH/t+WZ8FsAo2IgdOzruTHZ+XTFquj6j//QJjH9xfyRtu7h65lCT3CQVW9aGEe6/A/HPyA9KQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@yuku-codegen/binding-linux-x64-gnu@0.8.7':
     resolution: {integrity: sha512-dzyAbltJmf3Cqlb8HcFuYIf5Yn0fl1vTr3XJ9HiVNNvOlhqPSArOqtw9vI1p6/VTXTjrMLXlU+s+/kNHiIy/Cw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-codegen/binding-linux-x64-gnu@0.9.4':
+    resolution: {integrity: sha512-hDMB71QCDx2AAxhlCBgakngMAa4KK6f6rcTt9v8nrzoXs681cmZultGeZk0tjONxli+N+VMhXQUoiVCSJuKiQg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -7906,13 +7956,29 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@yuku-codegen/binding-linux-x64-musl@0.9.4':
+    resolution: {integrity: sha512-uk1hOZA79AqziAH9A/eSD05VchNRdnLb6zxFGHhCbLYeeGYL+KOEL0+kCIPtaKuQ7wdxDOooiKE1D0jpaWQ0aA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@yuku-codegen/binding-win32-arm64@0.8.7':
     resolution: {integrity: sha512-qo/jyrzryiBuKEsFiuWaBCBe3tRMynQ0qFWFgOEjcCMQeZfBm+wKiVEUEFXXLc7bh8YezguAWp0Mtnhq4ARNyA==}
     cpu: [arm64]
     os: [win32]
 
+  '@yuku-codegen/binding-win32-arm64@0.9.4':
+    resolution: {integrity: sha512-IbZuNVrctjts5lAKUEd9ppnzvylaPdYBTv8AVDtY6EyQ5hpgUfsReqbqODJVGpn2/uIk1fa1jWP012orPoiK+A==}
+    cpu: [arm64]
+    os: [win32]
+
   '@yuku-codegen/binding-win32-x64@0.8.7':
     resolution: {integrity: sha512-D5lDsVDx6m00E6bWySlWdH72Ca4TPSaphDqB6QjU6MpuNLIJqoGoatYyq2rOmBE8Zv/kunot/o58KGL03P3eiA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@yuku-codegen/binding-win32-x64@0.9.4':
+    resolution: {integrity: sha512-UqC4C0PlVAPEQ8fYr0AamuW2zKAkqQFiaaQ88Rl3YlzSNlshj+VmDoSbJRw4TFYL22+Vw53zDSJ95aXyjJN/aw==}
     cpu: [x64]
     os: [win32]
 
@@ -8053,6 +8119,9 @@ packages:
 
   '@yuku-toolchain/types@0.9.3':
     resolution: {integrity: sha512-rFE+5P4g2wxko5C85MugJOlVjBHEQq87dIkhLkniLXLp63PEtgaFjD954i5HXlfnyzLxPcZHsSOVDVgmo1HToA==}
+
+  '@yuku-toolchain/types@0.9.4':
+    resolution: {integrity: sha512-dqnMswJWE7YBbPEvGstgFlWFTRn20V/Hu82XTDjWxzaU18rGpxBqxhKlBlgyWrPARRvNLIqY2XA6S9edR+2AsA==}
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -9802,6 +9871,10 @@ packages:
 
   get-tsconfig@5.0.0-beta.5:
     resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
+    engines: {node: '>=20.20.0'}
+
+  get-tsconfig@5.0.0-beta.6:
+    resolution: {integrity: sha512-X6fBC0pmImC70gvX2zm56go9hx0MyoGVdG0tUCkg/D+Xnh5TJsOZ7iDbOdI3PvmtrDxnu1YdDufpK2QJX1Meqw==}
     engines: {node: '>=20.20.0'}
 
   giget@3.3.1:
@@ -12511,6 +12584,25 @@ packages:
       vue-tsc:
         optional: true
 
+  rolldown-plugin-dts@0.28.5:
+    resolution: {integrity: sha512-yYd3C9CeJwqjOc9X23m0Tyxcqic491uLZlfg51szT287S8zCCqLR2uoySoElgqy2CLn7PdXcEo1dlkBs4n1WHg==}
+    engines: {node: ^22.18.0 || ^24.11.0 || >=26.0.0}
+    peerDependencies:
+      '@typescript/native-preview': '*'
+      '@volar/typescript': ~2.4.0
+      rolldown: ^1.2.0
+      typescript: ^5.0.0 || ^6.0.0 || ~7.0.0
+      vue-tsc: ~3.2.0 || ~3.3.0
+    peerDependenciesMeta:
+      '@typescript/native-preview':
+        optional: true
+      '@volar/typescript':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
+
   rolldown-string@0.3.1:
     resolution: {integrity: sha512-dv8GOXkYqUQdI0rsXB8hmzO95pKWSuX2eg5/JSJa9czfEVIFuKNR7ZJDfat8LlmD35RAhWY+evS7/wXXqFDfSg==}
     engines: {node: '>=20.19.0'}
@@ -13207,6 +13299,10 @@ packages:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
 
+  tinyexec@1.3.1:
+    resolution: {integrity: sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -13316,6 +13412,40 @@ packages:
       tsx: '*'
       typescript: ^5.0.0 || ^6.0.0 || ^7.0.0
       unplugin-unused: ^0.5.0
+      unrun: '*'
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      '@tsdown/css':
+        optional: true
+      '@tsdown/exe':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      publint:
+        optional: true
+      tsx:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-unused:
+        optional: true
+      unrun:
+        optional: true
+
+  tsdown@0.23.0:
+    resolution: {integrity: sha512-BaT+ep1xnj5hdyICLd5r5SYYE+TXnI1ATePLykv9vcKpHpFTWUWRH+x1AF/E2qcu3YB6+vI8IdyxIIIffEqw5Q==}
+    engines: {node: ^22.18.0 || ^24.11.0 || >=26.0.0}
+    hasBin: true
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      '@tsdown/css': 0.23.0
+      '@tsdown/exe': 0.23.0
+      '@vitejs/devtools': '*'
+      publint: ^0.3.8
+      tsx: '*'
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0
+      unplugin-unused: '>=0.5.0'
       unrun: '*'
     peerDependenciesMeta:
       '@arethetypeswrong/core':
@@ -14352,6 +14482,9 @@ packages:
 
   yuku-codegen@0.8.7:
     resolution: {integrity: sha512-adwDZSh8oVDzhE6Du9PwVWxcOxeV0e2EVhUuMKWfhSY4wkrDq9eqixlxFF3l/XGUV1E7UFzhpz9393MUumkyNw==}
+
+  yuku-codegen@0.9.4:
+    resolution: {integrity: sha512-pPr8xA8wBjrebER5VFeqS1XqATED1dQXU7JoAectAi1RBG4YFJz5yBirnmmmHZHldgnMKs/pMGkDtwGVQX+Efg==}
 
   yuku-parser@0.8.7:
     resolution: {integrity: sha512-vRD9nwt4L3aYpxNqeSC4WqLv58xrXef0Ong1Mc45CTXTIpvLafx7JO05sczmQZwdLEZvywrLOGdNC5+Rp5N1BQ==}
@@ -22501,6 +22634,19 @@ snapshots:
       - tsx
       - yaml
 
+  '@tsdown/css@0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)':
+    dependencies:
+      lightningcss: 1.33.0
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(yaml@2.9.0)
+      rolldown: 1.2.7
+      tsdown: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+    optionalDependencies:
+      postcss: 8.5.26
+    transitivePeerDependencies:
+      - jiti
+      - tsx
+      - yaml
+
   '@tufjs/canonical-json@2.0.0': {}
 
   '@tufjs/models@4.1.0':
@@ -23431,37 +23577,73 @@ snapshots:
   '@yuku-codegen/binding-android-arm64@0.8.7':
     optional: true
 
+  '@yuku-codegen/binding-android-arm64@0.9.4':
+    optional: true
+
   '@yuku-codegen/binding-darwin-arm64@0.8.7':
+    optional: true
+
+  '@yuku-codegen/binding-darwin-arm64@0.9.4':
     optional: true
 
   '@yuku-codegen/binding-darwin-x64@0.8.7':
     optional: true
 
+  '@yuku-codegen/binding-darwin-x64@0.9.4':
+    optional: true
+
   '@yuku-codegen/binding-freebsd-x64@0.8.7':
+    optional: true
+
+  '@yuku-codegen/binding-freebsd-x64@0.9.4':
     optional: true
 
   '@yuku-codegen/binding-linux-arm-gnu@0.8.7':
     optional: true
 
+  '@yuku-codegen/binding-linux-arm-gnu@0.9.4':
+    optional: true
+
   '@yuku-codegen/binding-linux-arm-musl@0.8.7':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm-musl@0.9.4':
     optional: true
 
   '@yuku-codegen/binding-linux-arm64-gnu@0.8.7':
     optional: true
 
+  '@yuku-codegen/binding-linux-arm64-gnu@0.9.4':
+    optional: true
+
   '@yuku-codegen/binding-linux-arm64-musl@0.8.7':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm64-musl@0.9.4':
     optional: true
 
   '@yuku-codegen/binding-linux-x64-gnu@0.8.7':
     optional: true
 
+  '@yuku-codegen/binding-linux-x64-gnu@0.9.4':
+    optional: true
+
   '@yuku-codegen/binding-linux-x64-musl@0.8.7':
+    optional: true
+
+  '@yuku-codegen/binding-linux-x64-musl@0.9.4':
     optional: true
 
   '@yuku-codegen/binding-win32-arm64@0.8.7':
     optional: true
 
+  '@yuku-codegen/binding-win32-arm64@0.9.4':
+    optional: true
+
   '@yuku-codegen/binding-win32-x64@0.8.7':
+    optional: true
+
+  '@yuku-codegen/binding-win32-x64@0.9.4':
     optional: true
 
   '@yuku-parser/binding-android-arm64@0.8.7':
@@ -23539,6 +23721,8 @@ snapshots:
   '@yuku-toolchain/types@0.8.7': {}
 
   '@yuku-toolchain/types@0.9.3': {}
+
+  '@yuku-toolchain/types@0.9.4': {}
 
   abbrev@3.0.1: {}
 
@@ -25504,6 +25688,10 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   get-tsconfig@5.0.0-beta.5:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  get-tsconfig@5.0.0-beta.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -28849,6 +29037,20 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
+  rolldown-plugin-dts@0.28.5(oxc-resolver@11.24.2)(rolldown@1.2.7)(typescript@7.0.2):
+    dependencies:
+      dts-resolver: 3.0.0(oxc-resolver@11.24.2)
+      get-tsconfig: 5.0.0-beta.6
+      obug: 2.1.4
+      rolldown: 1.2.7
+      yuku-ast: 0.9.3
+      yuku-codegen: 0.9.4
+      yuku-parser: 0.9.3
+    optionalDependencies:
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - oxc-resolver
+
   rolldown-string@0.3.1(rolldown@1.2.7):
     dependencies:
       magic-string: 1.2.3
@@ -30165,6 +30367,8 @@ snapshots:
 
   tinyexec@1.3.0: {}
 
+  tinyexec@1.3.1: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.7)
@@ -30258,6 +30462,33 @@ snapshots:
       verkit: 0.3.2
     optionalDependencies:
       '@tsdown/css': 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.22.14)(tsx@4.23.13)(yaml@2.9.0)
+      publint: 0.3.24
+      tsx: 4.23.13
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - '@typescript/native-preview'
+      - '@volar/typescript'
+      - oxc-resolver
+      - vue-tsc
+
+  tsdown@0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2):
+    dependencies:
+      cac: 7.0.0
+      defu: 6.1.7
+      empathic: 2.0.1
+      hookable: 6.1.1
+      import-without-cache: 0.4.0
+      obug: 2.1.4
+      picomatch: 4.0.7
+      rolldown: 1.2.7
+      rolldown-plugin-dts: 0.28.5(oxc-resolver@11.24.2)(rolldown@1.2.7)(typescript@7.0.2)
+      tinyexec: 1.3.1
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+      verkit: 0.4.0
+    optionalDependencies:
+      '@tsdown/css': 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)
       publint: 0.3.24
       tsx: 4.23.13
       typescript: 7.0.2
@@ -31297,6 +31528,23 @@ snapshots:
       '@yuku-codegen/binding-linux-x64-musl': 0.8.7
       '@yuku-codegen/binding-win32-arm64': 0.8.7
       '@yuku-codegen/binding-win32-x64': 0.8.7
+
+  yuku-codegen@0.9.4:
+    dependencies:
+      '@yuku-toolchain/types': 0.9.4
+    optionalDependencies:
+      '@yuku-codegen/binding-android-arm64': 0.9.4
+      '@yuku-codegen/binding-darwin-arm64': 0.9.4
+      '@yuku-codegen/binding-darwin-x64': 0.9.4
+      '@yuku-codegen/binding-freebsd-x64': 0.9.4
+      '@yuku-codegen/binding-linux-arm-gnu': 0.9.4
+      '@yuku-codegen/binding-linux-arm-musl': 0.9.4
+      '@yuku-codegen/binding-linux-arm64-gnu': 0.9.4
+      '@yuku-codegen/binding-linux-arm64-musl': 0.9.4
+      '@yuku-codegen/binding-linux-x64-gnu': 0.9.4
+      '@yuku-codegen/binding-linux-x64-musl': 0.9.4
+      '@yuku-codegen/binding-win32-arm64': 0.9.4
+      '@yuku-codegen/binding-win32-x64': 0.9.4
 
   yuku-parser@0.8.7:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@sanity/logos':
       specifier: ^2.2.5
       version: 2.2.5
+    '@tsdown/css':
+      specifier: ^0.23.0
+      version: 0.23.0
     '@types/node':
       specifier: ^24.13.3
       version: 24.13.3
@@ -97,7 +100,7 @@ importers:
         version: 2.1.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+        version: 0.23.0(@tsdown/css@0.23.0)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -696,7 +699,7 @@ importers:
         version: 0.3.24
       tsdown:
         specifier: 'catalog:'
-        version: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+        version: 0.23.0(@tsdown/css@0.23.0)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -721,9 +724,6 @@ importers:
       '@sanity/tsdown-config':
         specifier: workspace:^
         version: link:../tsdown-config
-      '@tsdown/css':
-        specifier: '*'
-        version: 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.22.14)(tsx@4.23.13)(yaml@2.9.0)
       '@typescript/typescript6':
         specifier: ^6.0.2
         version: 6.0.2
@@ -780,7 +780,7 @@ importers:
         version: 1.1.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+        version: 0.23.0(@tsdown/css@0.23.0)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
       tsx:
         specifier: ^4.23.13
         version: 4.23.13
@@ -794,6 +794,9 @@ importers:
       '@sanity/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
+      '@tsdown/css':
+        specifier: 'catalog:'
+        version: 0.23.0(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
@@ -888,8 +891,8 @@ importers:
         specifier: workspace:^
         version: link:../tsconfig
       '@tsdown/css':
-        specifier: ^0.22.14
-        version: 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)
+        specifier: 'catalog:'
+        version: 0.23.0(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
@@ -904,7 +907,7 @@ importers:
         version: 1.3.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+        version: 0.23.0(@tsdown/css@0.23.0)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -983,8 +986,8 @@ importers:
   packages/@sanity/tsdown-config/test/fixtures/vanilla-extract-css-modules-library:
     devDependencies:
       '@tsdown/css':
-        specifier: ^0.22.14
-        version: 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)
+        specifier: 'catalog:'
+        version: 0.23.0(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)
       '@vanilla-extract/css':
         specifier: ^1.21.2
         version: 1.21.2
@@ -1030,7 +1033,7 @@ importers:
         version: 0.3.24
       tsdown:
         specifier: 'catalog:'
-        version: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+        version: 0.23.0(@tsdown/css@0.23.0)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1067,7 +1070,7 @@ importers:
         version: 1.2.7
       tsdown:
         specifier: 'catalog:'
-        version: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+        version: 0.23.0(@tsdown/css@0.23.0)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1101,7 +1104,7 @@ importers:
         version: 1.2.7
       tsdown:
         specifier: 'catalog:'
-        version: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+        version: 0.23.0(@tsdown/css@0.23.0)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1132,7 +1135,7 @@ importers:
         version: 0.3.24
       tsdown:
         specifier: 'catalog:'
-        version: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+        version: 0.23.0(@tsdown/css@0.23.0)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1163,8 +1166,8 @@ importers:
         specifier: ^1.0.5
         version: 1.0.5
       '@tsdown/css':
-        specifier: ^0.22.14
-        version: 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)
+        specifier: 'catalog:'
+        version: 0.23.0(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)
 
   playground/css-export: {}
 
@@ -1174,8 +1177,8 @@ importers:
         specifier: ^1.0.5
         version: 1.0.5
       '@tsdown/css':
-        specifier: ^0.22.14
-        version: 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)
+        specifier: 'catalog:'
+        version: 0.23.0(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)
 
   playground/custom-dist: {}
 
@@ -7061,16 +7064,16 @@ packages:
   '@tsconfig/node20@20.1.10':
     resolution: {integrity: sha512-5OZgdnxbFuvwm05iVwPXMU5/7iPuVDDZzAnxPDLj+kjN7fwQZSSVgHQhKTNkBPOO6Qef2D5MxPAoPLCGqE2VuQ==}
 
-  '@tsdown/css@0.22.14':
-    resolution: {integrity: sha512-0NpbgqfhfjaAoLdY3DxjrMo08vKFEtvlybCS42Gtolx8OPoKUdZZDyls0qgNEqea0c7XGjlF0NIE1tIxgU8RqA==}
-    engines: {node: ^22.18.0 || >=24.11.0}
+  '@tsdown/css@0.23.0':
+    resolution: {integrity: sha512-EfSQCVAz24CRz92WdJj/Yb+gJMV3m2C/iDsFO4XJkd12Ez9WnW0KtpLohAFtc4gDzflFlh9I0UHTZc6BQmxSHw==}
+    engines: {node: ^22.18.0 || ^24.11.0 || >=26.0.0}
     peerDependencies:
       postcss: ^8.4.0
-      postcss-import: ^16.0.0
-      postcss-modules: ^6.0.0
+      postcss-import: ^16.0.0 || ^17.0.0
+      postcss-modules: ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
       sass: '*'
       sass-embedded: '*'
-      tsdown: 0.22.14
+      tsdown: 0.23.0
     peerDependenciesMeta:
       postcss:
         optional: true
@@ -7850,29 +7853,14 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
-  '@yuku-codegen/binding-android-arm64@0.8.7':
-    resolution: {integrity: sha512-C/0zV5IhgVdYhGJTwrY0v8dknxlhiKwtVJkMUaexu9/QvRmzlV4vfU3hZlUSgqc2BxQHntL1mCVbDq8j0FRFDw==}
-    cpu: [arm64]
-    os: [android]
-
   '@yuku-codegen/binding-android-arm64@0.9.4':
     resolution: {integrity: sha512-6ViGFAr+N2Yjnc8wBx16wJZGB0pGmClILO+FUC3kzwEydfjXQovWEdcFyl98RVtWdj9ahS41XXe2zKFl+L3uWg==}
     cpu: [arm64]
     os: [android]
 
-  '@yuku-codegen/binding-darwin-arm64@0.8.7':
-    resolution: {integrity: sha512-/u+REDMI4a0/lsJXTM4c53/w31OGZLOReZIyg62uhgLs0kc8NHsj/nOcxTdlQjq5gi0zhdkccD9LaLTXcdzPvw==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@yuku-codegen/binding-darwin-arm64@0.9.4':
     resolution: {integrity: sha512-0BTB70ha+wRsz6fI5HosevJpMmvgndmf+6ND1OneFKCrWhNzX/2xIQ36Z8rUgv5bpnWjKl6bRvzSFV3PU+WOlQ==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@yuku-codegen/binding-darwin-x64@0.8.7':
-    resolution: {integrity: sha512-sMMzFOwCo4WXR+/6zIBThOocSC50iIIZZdfiIDbaLvj0Ax/rWt/iavyfEAqajyvzydLyCqR/ZItdLWSRlu1umw==}
-    cpu: [x64]
     os: [darwin]
 
   '@yuku-codegen/binding-darwin-x64@0.9.4':
@@ -7880,21 +7868,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@yuku-codegen/binding-freebsd-x64@0.8.7':
-    resolution: {integrity: sha512-MpdpKXix9P+Y1rKgjvcNeNtGjXeL1CmttNhYINrWls8kRpm4xM/oBGTmn6w7to8lAlwj5jm8q03dQPl5mRv4Qw==}
-    cpu: [x64]
-    os: [freebsd]
-
   '@yuku-codegen/binding-freebsd-x64@0.9.4':
     resolution: {integrity: sha512-Qm3ky33Em9w1XVSryq+D/arLVapeqp0Bu1719UGV6olmfp4kTD+NfsLG9bRx5hOJSu1Zl3r9LbyTP1oTmcHAsg==}
     cpu: [x64]
     os: [freebsd]
-
-  '@yuku-codegen/binding-linux-arm-gnu@0.8.7':
-    resolution: {integrity: sha512-rr1srFLlPAmC1vtxfc9C1YLDe3iH09YjfSeeIidBqKhzx1MATjOAq4mjlRUOnhr/L27MotWIYOFKwVsd5JZFOg==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
 
   '@yuku-codegen/binding-linux-arm-gnu@0.9.4':
     resolution: {integrity: sha512-euKmS7pnkeJylEN6+9bfu0jHtGfbQRfFBIpmTe8YVnWzQ5Rjyrns13+1kao2RSS9DNkucX1RXIdiTvQoDUXF0w==}
@@ -7902,23 +7879,11 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@yuku-codegen/binding-linux-arm-musl@0.8.7':
-    resolution: {integrity: sha512-eAufXh8qBRpiSO6ueaMDL+yyoXIGLhpUce72YbcACtZU2qhExwBIJyEtQf5kH2Ki0X2aqkSjSfog4OPtKXan3Q==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
-
   '@yuku-codegen/binding-linux-arm-musl@0.9.4':
     resolution: {integrity: sha512-7JTizi2O+ks9/dLPDLYmVLsYQUC9Fxu0e6LNA+F6FFQ/sV2o7owBb1eTccMKkgauWGGUpJYQvlXrCKpGwguvhA==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
-
-  '@yuku-codegen/binding-linux-arm64-gnu@0.8.7':
-    resolution: {integrity: sha512-gw4w6wPoHObBrdIC4duVWLmJOvpdE25j5D7yrM5mACNlK4klRz/lv8hK+ssQk9EJHBgZjSaqZIJVFgqNYbfv7A==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   '@yuku-codegen/binding-linux-arm64-gnu@0.9.4':
     resolution: {integrity: sha512-f7eLYDwmcz56Jzvp8UmXUehFzTAn6hEHt64GDWNWGSqrphHRvWLEshQ+sQv8DfNpkXFaOQ49erl4gb2Wm0JM+A==}
@@ -7926,23 +7891,11 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@yuku-codegen/binding-linux-arm64-musl@0.8.7':
-    resolution: {integrity: sha512-L68N6Y4XkqcIaKo3Ra88JEvBEH4AHff44A4INcrxeVWZ8CZtu2tCpfVxe3hR8qQQMcvBSQlDn24KpkCKEhVvfA==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@yuku-codegen/binding-linux-arm64-musl@0.9.4':
     resolution: {integrity: sha512-bLdjCgo+u3dU3HH/t+WZ8FsAo2IgdOzruTHZ+XTFquj6j//QJjH9xfyRtu7h65lCT3CQVW9aGEe6/A/HPyA9KQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
-
-  '@yuku-codegen/binding-linux-x64-gnu@0.8.7':
-    resolution: {integrity: sha512-dzyAbltJmf3Cqlb8HcFuYIf5Yn0fl1vTr3XJ9HiVNNvOlhqPSArOqtw9vI1p6/VTXTjrMLXlU+s+/kNHiIy/Cw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
 
   '@yuku-codegen/binding-linux-x64-gnu@0.9.4':
     resolution: {integrity: sha512-hDMB71QCDx2AAxhlCBgakngMAa4KK6f6rcTt9v8nrzoXs681cmZultGeZk0tjONxli+N+VMhXQUoiVCSJuKiQg==}
@@ -7950,31 +7903,15 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@yuku-codegen/binding-linux-x64-musl@0.8.7':
-    resolution: {integrity: sha512-Otw4MH3404q0Bbvl+YTdW9aoUV5vXmUw8260bWvt1XlaoIX/ceSgI4ygheRDMfBPoHt6FDayQaO9OLVUZAgkFA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@yuku-codegen/binding-linux-x64-musl@0.9.4':
     resolution: {integrity: sha512-uk1hOZA79AqziAH9A/eSD05VchNRdnLb6zxFGHhCbLYeeGYL+KOEL0+kCIPtaKuQ7wdxDOooiKE1D0jpaWQ0aA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-codegen/binding-win32-arm64@0.8.7':
-    resolution: {integrity: sha512-qo/jyrzryiBuKEsFiuWaBCBe3tRMynQ0qFWFgOEjcCMQeZfBm+wKiVEUEFXXLc7bh8YezguAWp0Mtnhq4ARNyA==}
-    cpu: [arm64]
-    os: [win32]
-
   '@yuku-codegen/binding-win32-arm64@0.9.4':
     resolution: {integrity: sha512-IbZuNVrctjts5lAKUEd9ppnzvylaPdYBTv8AVDtY6EyQ5hpgUfsReqbqODJVGpn2/uIk1fa1jWP012orPoiK+A==}
     cpu: [arm64]
-    os: [win32]
-
-  '@yuku-codegen/binding-win32-x64@0.8.7':
-    resolution: {integrity: sha512-D5lDsVDx6m00E6bWySlWdH72Ca4TPSaphDqB6QjU6MpuNLIJqoGoatYyq2rOmBE8Zv/kunot/o58KGL03P3eiA==}
-    cpu: [x64]
     os: [win32]
 
   '@yuku-codegen/binding-win32-x64@0.9.4':
@@ -7982,29 +7919,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@yuku-parser/binding-android-arm64@0.8.7':
-    resolution: {integrity: sha512-eGKYiUDX7Y0V7tDTmg+JTVnXnjMqfXXsorZ+EDf5kxwchQ3Or1HS14MzI2fw+jFhHR85fCWt+mtX33Yao73hIQ==}
-    cpu: [arm64]
-    os: [android]
-
   '@yuku-parser/binding-android-arm64@0.9.3':
     resolution: {integrity: sha512-z3tDGTaUXD5Q4IuebFOY/QHxhR/SqujMhkMv9C5bh25upyFEXdafp0MsXQIIheWhVZzn5VMOniyxFni/7s9LgQ==}
     cpu: [arm64]
     os: [android]
 
-  '@yuku-parser/binding-darwin-arm64@0.8.7':
-    resolution: {integrity: sha512-Re0RHelKLnjEURulY2/KxW+Ngb8zuNA4BRZuMwgGQNzVumT6u4U2N2hc01oeYVNVof0i7GrXE4UCNBgbpRRnjQ==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@yuku-parser/binding-darwin-arm64@0.9.3':
     resolution: {integrity: sha512-hzKvKSKS7z3ufnu1VkQYEoxmS6A5uNnkwukKnc2atxpWdq648nLVOqut4h1jUXjbM2WcoTfuZLF6AHAGFf8cmg==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@yuku-parser/binding-darwin-x64@0.8.7':
-    resolution: {integrity: sha512-Hn8DROtQkjlA1ACbPgj4a7eP9IuVOI504oiTwpkWPbpaDWD9KdmnVYCqW+1LfenNK/g7O9NhWGpXEdaCNX7lIA==}
-    cpu: [x64]
     os: [darwin]
 
   '@yuku-parser/binding-darwin-x64@0.9.3':
@@ -8012,21 +7934,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@yuku-parser/binding-freebsd-x64@0.8.7':
-    resolution: {integrity: sha512-bAP2OV8wRuzplX/jYxv9+vvqQT8JxyNphI8fLfXGL054Xs+4/J5u33cIm3y4rxY8rdoLmmdiJs2Tq7r7lrDRfA==}
-    cpu: [x64]
-    os: [freebsd]
-
   '@yuku-parser/binding-freebsd-x64@0.9.3':
     resolution: {integrity: sha512-WMn9M4LHNVysGNwsAJ9gpRPqQIW2lcPrDNGcyk0agx3IYqCJq1MQugh6Be8Otc5U08eGdE39o8Kx9YWJmXz7GA==}
     cpu: [x64]
     os: [freebsd]
-
-  '@yuku-parser/binding-linux-arm-gnu@0.8.7':
-    resolution: {integrity: sha512-kTYwJQQgmZeAWdDIWabiReIZMpmfLueIj1tCmjStUtFGhR1Z0qwxonKVfUC4N7h/VhGGzLZ//7O1kgt1QKqgCg==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
 
   '@yuku-parser/binding-linux-arm-gnu@0.9.3':
     resolution: {integrity: sha512-vqKjwiyW1FWvbykYMEQIcAJwA17WxK3rxxqDuyCvQwcNVaLEUxI4BXiUdlF3kHucc7MnoFQhoRPkySgOzlLM+Q==}
@@ -8034,23 +7945,11 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm-musl@0.8.7':
-    resolution: {integrity: sha512-uL4jE8HPT2BLlxAXyD10LqgPuXa9eDa0BKpCdSANmzIJghq/2eZo3/gQNtaxPZMupWoxjYzSad9IXrwu7aYPXQ==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
-
   '@yuku-parser/binding-linux-arm-musl@0.9.3':
     resolution: {integrity: sha512-qohilhYOT+zkt2gYzym4F1T6BzRdvPqS9/sFB03pmnVV8LrvjOXVsGwEBAa3CEvzJKhAZjdTmVz7zsVdjyHWLg==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
-
-  '@yuku-parser/binding-linux-arm64-gnu@0.8.7':
-    resolution: {integrity: sha512-3gVN4pWSKZmXiNX7cU164dR9MPvesCHnlH6nPfpK+yQsCuYphjKKplcb4SnZBrhiqmXbgb2HR0c2TS0IZUPhgA==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   '@yuku-parser/binding-linux-arm64-gnu@0.9.3':
     resolution: {integrity: sha512-tvTIyUvTGkeee68i4JIo9o27As+Ug6LXOZvElGgFbTs6+KBdb5LGhvugaIQljdfIsm2XnIbOLG6OnQSXHMLB9w==}
@@ -8058,23 +7957,11 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm64-musl@0.8.7':
-    resolution: {integrity: sha512-S0mwfEjoLpxzXeZw802Wa4RaELsQiPtWqG6INcy8j4GtvNFtl4LCX3eGO1XLn9pyLAISLzTRyU3zUCBUPin8lg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@yuku-parser/binding-linux-arm64-musl@0.9.3':
     resolution: {integrity: sha512-OWZBHW1wuChBpFlrF+On1yiBcFPMRrj2g0VKsM/PCBGffu1OM0ORkS+vLS3Snu6wYwndM5Dd9Ctvux6eUlrQjA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
-
-  '@yuku-parser/binding-linux-x64-gnu@0.8.7':
-    resolution: {integrity: sha512-lnbWdPmerE5D1uH1G4IEZKnPzCrWCStRGrtgpSIe1RibAo5bZIjDbbbPYXmMHCEh4F+x/JaJpElh26a3r+BPbg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
 
   '@yuku-parser/binding-linux-x64-gnu@0.9.3':
     resolution: {integrity: sha512-/tbk1h0dlADOCngbiQO9V3SHwBIJkoGBq8BDEraSw2CC3nGxPEPTCCYUDp5738Ij2FxVwy1FWVuhFkHvpMrPbQ==}
@@ -8082,40 +7969,21 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-x64-musl@0.8.7':
-    resolution: {integrity: sha512-769uwndMvMzUvATWbAcEvyLHKA+DzhHSCl/obBUrRdYfRo26yxui6S8y3z7uJ+Naup7UKrDxrpK7OnQkxkl9KQ==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@yuku-parser/binding-linux-x64-musl@0.9.3':
     resolution: {integrity: sha512-u3+0sCso/mcjDvtc3866D2giV7l34PDyDVBkMesAWa3DWbIWPlybehi2SSnmScgArV22ctqSSgUzdBBVJ6zYAg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-win32-arm64@0.8.7':
-    resolution: {integrity: sha512-mEB/9PlaAkisJ6KWGz0zvywXoU6+80dTlR2LwS7s/jcXXoU6fm2+sitBZXtqu3+Q4DcDgPxM45uWMCzPs0TSRw==}
-    cpu: [arm64]
-    os: [win32]
-
   '@yuku-parser/binding-win32-arm64@0.9.3':
     resolution: {integrity: sha512-xnGEvdhyjRkXozHtpXVpEEkyGZWAxJ3RoILv7XRV5SvTEztaTCk5GQyfcOzI9An/EJtcL4ERCI8QmS0TpDPJiA==}
     cpu: [arm64]
-    os: [win32]
-
-  '@yuku-parser/binding-win32-x64@0.8.7':
-    resolution: {integrity: sha512-8vNB2DP0ou61nGb8tc/qfi41gfyDXz1MHr2zqL3nR+cJ6CEbiuWV/l/a/vv151gCgiZLLAyGkQGENpozdg716w==}
-    cpu: [x64]
     os: [win32]
 
   '@yuku-parser/binding-win32-x64@0.9.3':
     resolution: {integrity: sha512-N5eShGcuwnrXEprePFmEjtng6acZmtnC4zgazK9xxkavcx1q1uX8Nz8lU5RS973EMlNr902cIc6Cd2D4tqZDBg==}
     cpu: [x64]
     os: [win32]
-
-  '@yuku-toolchain/types@0.8.7':
-    resolution: {integrity: sha512-2Z53dNxAJL6UvFoIrDZvYf3zlO8s4VJK4O2hhaB4mXVwwpX/7ajtss3cmfqKvamlNLWyt9FSWs4eoYdlbxpnHA==}
 
   '@yuku-toolchain/types@0.9.3':
     resolution: {integrity: sha512-rFE+5P4g2wxko5C85MugJOlVjBHEQq87dIkhLkniLXLp63PEtgaFjD954i5HXlfnyzLxPcZHsSOVDVgmo1HToA==}
@@ -9867,10 +9735,6 @@ packages:
 
   get-tsconfig@5.0.0-beta.4:
     resolution: {integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==}
-    engines: {node: '>=20.20.0'}
-
-  get-tsconfig@5.0.0-beta.5:
-    resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
     engines: {node: '>=20.20.0'}
 
   get-tsconfig@5.0.0-beta.6:
@@ -12565,25 +12429,6 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
-  rolldown-plugin-dts@0.27.14:
-    resolution: {integrity: sha512-ZvuDDwoIpRK9RPxDXratCpklFO9QZZWndf/sd0VBFb4LEj0jj07UcHK9OCh7V4XiFz2Z89ziyBC2K6tJiDjrbw==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-    peerDependencies:
-      '@typescript/native-preview': '*'
-      '@volar/typescript': ~2.4.0
-      rolldown: ^1.0.0
-      typescript: ^5.0.0 || ^6.0.0 || ~7.0.0
-      vue-tsc: ~3.2.0 || ~3.3.0
-    peerDependenciesMeta:
-      '@typescript/native-preview':
-        optional: true
-      '@volar/typescript':
-        optional: true
-      typescript:
-        optional: true
-      vue-tsc:
-        optional: true
-
   rolldown-plugin-dts@0.28.5:
     resolution: {integrity: sha512-yYd3C9CeJwqjOc9X23m0Tyxcqic491uLZlfg51szT287S8zCCqLR2uoySoElgqy2CLn7PdXcEo1dlkBs4n1WHg==}
     engines: {node: ^22.18.0 || ^24.11.0 || >=26.0.0}
@@ -13398,40 +13243,6 @@ packages:
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
-
-  tsdown@0.22.14:
-    resolution: {integrity: sha512-ule7Y+fsAN2iZbLDoo7C4KYljFJNJJ+fLshyn+9gozeTspVersWHxwdGB+Dm2hzA38s6muFnUTl0jK3vJm9ifQ==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-    hasBin: true
-    peerDependencies:
-      '@arethetypeswrong/core': ^0.18.1
-      '@tsdown/css': 0.22.14
-      '@tsdown/exe': 0.22.14
-      '@vitejs/devtools': '*'
-      publint: ^0.3.8
-      tsx: '*'
-      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0
-      unplugin-unused: ^0.5.0
-      unrun: '*'
-    peerDependenciesMeta:
-      '@arethetypeswrong/core':
-        optional: true
-      '@tsdown/css':
-        optional: true
-      '@tsdown/exe':
-        optional: true
-      '@vitejs/devtools':
-        optional: true
-      publint:
-        optional: true
-      tsx:
-        optional: true
-      typescript:
-        optional: true
-      unplugin-unused:
-        optional: true
-      unrun:
-        optional: true
 
   tsdown@0.23.0:
     resolution: {integrity: sha512-BaT+ep1xnj5hdyICLd5r5SYYE+TXnI1ATePLykv9vcKpHpFTWUWRH+x1AF/E2qcu3YB6+vI8IdyxIIIffEqw5Q==}
@@ -14474,20 +14285,11 @@ packages:
   youch@4.1.1:
     resolution: {integrity: sha512-mxW3qiSnl+GRxXsaUMzv2Mbada1Y8CDltET9UxejDQe6DBYlSekghl5U5K0ReAikcHDi0G1vKZEmmo/NWAGKLA==}
 
-  yuku-ast@0.8.7:
-    resolution: {integrity: sha512-h6+4bDfyootiMB9vckk5uKo5r5j0GHrkr17FQTDNfEsFT3DWlN9uu1HJwQwc64pgmLCI945fWM3lbTIqxjT3GQ==}
-
   yuku-ast@0.9.3:
     resolution: {integrity: sha512-Kt0PXlPCXdKF1fWFTl7N3DaxsVk6DHF8VAXHJMkwPtJnWYgbx20pYgGSweuC/86mIM7k1NUITQ4JffgOLUWTCw==}
 
-  yuku-codegen@0.8.7:
-    resolution: {integrity: sha512-adwDZSh8oVDzhE6Du9PwVWxcOxeV0e2EVhUuMKWfhSY4wkrDq9eqixlxFF3l/XGUV1E7UFzhpz9393MUumkyNw==}
-
   yuku-codegen@0.9.4:
     resolution: {integrity: sha512-pPr8xA8wBjrebER5VFeqS1XqATED1dQXU7JoAectAi1RBG4YFJz5yBirnmmmHZHldgnMKs/pMGkDtwGVQX+Efg==}
-
-  yuku-parser@0.8.7:
-    resolution: {integrity: sha512-vRD9nwt4L3aYpxNqeSC4WqLv58xrXef0Ong1Mc45CTXTIpvLafx7JO05sczmQZwdLEZvywrLOGdNC5+Rp5N1BQ==}
 
   yuku-parser@0.9.3:
     resolution: {integrity: sha512-96wPoHnwaXfkZv7UIOUkDb+s7ZH8lv8Qtg+MxdvHUV1LFa5jV9iKOaams1942YQt+krFQrWiD6lSg2ermv5kHA==}
@@ -19718,7 +19520,7 @@ snapshots:
 
   '@publint/pack@0.1.7':
     dependencies:
-      tinyexec: 1.3.0
+      tinyexec: 1.3.1
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -22621,25 +22423,12 @@ snapshots:
 
   '@tsconfig/node20@20.1.10': {}
 
-  '@tsdown/css@0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.22.14)(tsx@4.23.13)(yaml@2.9.0)':
+  '@tsdown/css@0.23.0(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)':
     dependencies:
       lightningcss: 1.33.0
       postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(yaml@2.9.0)
       rolldown: 1.2.7
-      tsdown: 0.22.14(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
-    optionalDependencies:
-      postcss: 8.5.26
-    transitivePeerDependencies:
-      - jiti
-      - tsx
-      - yaml
-
-  '@tsdown/css@0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)':
-    dependencies:
-      lightningcss: 1.33.0
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(yaml@2.9.0)
-      rolldown: 1.2.7
-      tsdown: 0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
+      tsdown: 0.23.0(@tsdown/css@0.23.0)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2)
     optionalDependencies:
       postcss: 8.5.26
     transitivePeerDependencies:
@@ -23574,151 +23363,77 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
-  '@yuku-codegen/binding-android-arm64@0.8.7':
-    optional: true
-
   '@yuku-codegen/binding-android-arm64@0.9.4':
-    optional: true
-
-  '@yuku-codegen/binding-darwin-arm64@0.8.7':
     optional: true
 
   '@yuku-codegen/binding-darwin-arm64@0.9.4':
     optional: true
 
-  '@yuku-codegen/binding-darwin-x64@0.8.7':
-    optional: true
-
   '@yuku-codegen/binding-darwin-x64@0.9.4':
-    optional: true
-
-  '@yuku-codegen/binding-freebsd-x64@0.8.7':
     optional: true
 
   '@yuku-codegen/binding-freebsd-x64@0.9.4':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm-gnu@0.8.7':
-    optional: true
-
   '@yuku-codegen/binding-linux-arm-gnu@0.9.4':
-    optional: true
-
-  '@yuku-codegen/binding-linux-arm-musl@0.8.7':
     optional: true
 
   '@yuku-codegen/binding-linux-arm-musl@0.9.4':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm64-gnu@0.8.7':
-    optional: true
-
   '@yuku-codegen/binding-linux-arm64-gnu@0.9.4':
-    optional: true
-
-  '@yuku-codegen/binding-linux-arm64-musl@0.8.7':
     optional: true
 
   '@yuku-codegen/binding-linux-arm64-musl@0.9.4':
     optional: true
 
-  '@yuku-codegen/binding-linux-x64-gnu@0.8.7':
-    optional: true
-
   '@yuku-codegen/binding-linux-x64-gnu@0.9.4':
-    optional: true
-
-  '@yuku-codegen/binding-linux-x64-musl@0.8.7':
     optional: true
 
   '@yuku-codegen/binding-linux-x64-musl@0.9.4':
     optional: true
 
-  '@yuku-codegen/binding-win32-arm64@0.8.7':
-    optional: true
-
   '@yuku-codegen/binding-win32-arm64@0.9.4':
-    optional: true
-
-  '@yuku-codegen/binding-win32-x64@0.8.7':
     optional: true
 
   '@yuku-codegen/binding-win32-x64@0.9.4':
     optional: true
 
-  '@yuku-parser/binding-android-arm64@0.8.7':
-    optional: true
-
   '@yuku-parser/binding-android-arm64@0.9.3':
-    optional: true
-
-  '@yuku-parser/binding-darwin-arm64@0.8.7':
     optional: true
 
   '@yuku-parser/binding-darwin-arm64@0.9.3':
     optional: true
 
-  '@yuku-parser/binding-darwin-x64@0.8.7':
-    optional: true
-
   '@yuku-parser/binding-darwin-x64@0.9.3':
-    optional: true
-
-  '@yuku-parser/binding-freebsd-x64@0.8.7':
     optional: true
 
   '@yuku-parser/binding-freebsd-x64@0.9.3':
     optional: true
 
-  '@yuku-parser/binding-linux-arm-gnu@0.8.7':
-    optional: true
-
   '@yuku-parser/binding-linux-arm-gnu@0.9.3':
-    optional: true
-
-  '@yuku-parser/binding-linux-arm-musl@0.8.7':
     optional: true
 
   '@yuku-parser/binding-linux-arm-musl@0.9.3':
     optional: true
 
-  '@yuku-parser/binding-linux-arm64-gnu@0.8.7':
-    optional: true
-
   '@yuku-parser/binding-linux-arm64-gnu@0.9.3':
-    optional: true
-
-  '@yuku-parser/binding-linux-arm64-musl@0.8.7':
     optional: true
 
   '@yuku-parser/binding-linux-arm64-musl@0.9.3':
     optional: true
 
-  '@yuku-parser/binding-linux-x64-gnu@0.8.7':
-    optional: true
-
   '@yuku-parser/binding-linux-x64-gnu@0.9.3':
-    optional: true
-
-  '@yuku-parser/binding-linux-x64-musl@0.8.7':
     optional: true
 
   '@yuku-parser/binding-linux-x64-musl@0.9.3':
     optional: true
 
-  '@yuku-parser/binding-win32-arm64@0.8.7':
-    optional: true
-
   '@yuku-parser/binding-win32-arm64@0.9.3':
-    optional: true
-
-  '@yuku-parser/binding-win32-x64@0.8.7':
     optional: true
 
   '@yuku-parser/binding-win32-x64@0.9.3':
     optional: true
-
-  '@yuku-toolchain/types@0.8.7': {}
 
   '@yuku-toolchain/types@0.9.3': {}
 
@@ -25684,10 +25399,6 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   get-tsconfig@5.0.0-beta.4:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
-
-  get-tsconfig@5.0.0-beta.5:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -29023,20 +28734,6 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
-  rolldown-plugin-dts@0.27.14(oxc-resolver@11.24.2)(rolldown@1.2.7)(typescript@7.0.2):
-    dependencies:
-      dts-resolver: 3.0.0(oxc-resolver@11.24.2)
-      get-tsconfig: 5.0.0-beta.5
-      obug: 2.1.4
-      rolldown: 1.2.7
-      yuku-ast: 0.8.7
-      yuku-codegen: 0.8.7
-      yuku-parser: 0.8.7
-    optionalDependencies:
-      typescript: 7.0.2
-    transitivePeerDependencies:
-      - oxc-resolver
-
   rolldown-plugin-dts@0.28.5(oxc-resolver@11.24.2)(rolldown@1.2.7)(typescript@7.0.2):
     dependencies:
       dts-resolver: 3.0.0(oxc-resolver@11.24.2)
@@ -30443,35 +30140,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.22.14(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2):
-    dependencies:
-      ansis: 4.3.1
-      cac: 7.0.0
-      defu: 6.1.7
-      empathic: 2.0.1
-      hookable: 6.1.1
-      import-without-cache: 0.4.0
-      obug: 2.1.4
-      picomatch: 4.0.7
-      rolldown: 1.2.7
-      rolldown-plugin-dts: 0.27.14(oxc-resolver@11.24.2)(rolldown@1.2.7)(typescript@7.0.2)
-      tinyexec: 1.3.0
-      tinyglobby: 0.2.17
-      tree-kill: 1.2.2
-      unconfig-core: 7.5.0
-      verkit: 0.3.2
-    optionalDependencies:
-      '@tsdown/css': 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.22.14)(tsx@4.23.13)(yaml@2.9.0)
-      publint: 0.3.24
-      tsx: 4.23.13
-      typescript: 7.0.2
-    transitivePeerDependencies:
-      - '@typescript/native-preview'
-      - '@volar/typescript'
-      - oxc-resolver
-      - vue-tsc
-
-  tsdown@0.23.0(@tsdown/css@0.22.14)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2):
+  tsdown@0.23.0(@tsdown/css@0.23.0)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.13)(typescript@7.0.2):
     dependencies:
       cac: 7.0.0
       defu: 6.1.7
@@ -30488,7 +30157,7 @@ snapshots:
       unconfig-core: 7.5.0
       verkit: 0.4.0
     optionalDependencies:
-      '@tsdown/css': 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)
+      '@tsdown/css': 0.23.0(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.23.0)(tsx@4.23.13)(yaml@2.9.0)
       publint: 0.3.24
       tsx: 4.23.13
       typescript: 7.0.2
@@ -31504,30 +31173,9 @@ snapshots:
       cookie-es: 3.1.1
       youch-core: 0.3.3
 
-  yuku-ast@0.8.7:
-    dependencies:
-      '@yuku-toolchain/types': 0.8.7
-
   yuku-ast@0.9.3:
     dependencies:
       '@yuku-toolchain/types': 0.9.3
-
-  yuku-codegen@0.8.7:
-    dependencies:
-      '@yuku-toolchain/types': 0.8.7
-    optionalDependencies:
-      '@yuku-codegen/binding-android-arm64': 0.8.7
-      '@yuku-codegen/binding-darwin-arm64': 0.8.7
-      '@yuku-codegen/binding-darwin-x64': 0.8.7
-      '@yuku-codegen/binding-freebsd-x64': 0.8.7
-      '@yuku-codegen/binding-linux-arm-gnu': 0.8.7
-      '@yuku-codegen/binding-linux-arm-musl': 0.8.7
-      '@yuku-codegen/binding-linux-arm64-gnu': 0.8.7
-      '@yuku-codegen/binding-linux-arm64-musl': 0.8.7
-      '@yuku-codegen/binding-linux-x64-gnu': 0.8.7
-      '@yuku-codegen/binding-linux-x64-musl': 0.8.7
-      '@yuku-codegen/binding-win32-arm64': 0.8.7
-      '@yuku-codegen/binding-win32-x64': 0.8.7
 
   yuku-codegen@0.9.4:
     dependencies:
@@ -31545,24 +31193,6 @@ snapshots:
       '@yuku-codegen/binding-linux-x64-musl': 0.9.4
       '@yuku-codegen/binding-win32-arm64': 0.9.4
       '@yuku-codegen/binding-win32-x64': 0.9.4
-
-  yuku-parser@0.8.7:
-    dependencies:
-      '@yuku-toolchain/types': 0.8.7
-      yuku-ast: 0.8.7
-    optionalDependencies:
-      '@yuku-parser/binding-android-arm64': 0.8.7
-      '@yuku-parser/binding-darwin-arm64': 0.8.7
-      '@yuku-parser/binding-darwin-x64': 0.8.7
-      '@yuku-parser/binding-freebsd-x64': 0.8.7
-      '@yuku-parser/binding-linux-arm-gnu': 0.8.7
-      '@yuku-parser/binding-linux-arm-musl': 0.8.7
-      '@yuku-parser/binding-linux-arm64-gnu': 0.8.7
-      '@yuku-parser/binding-linux-arm64-musl': 0.8.7
-      '@yuku-parser/binding-linux-x64-gnu': 0.8.7
-      '@yuku-parser/binding-linux-x64-musl': 0.8.7
-      '@yuku-parser/binding-win32-arm64': 0.8.7
-      '@yuku-parser/binding-win32-x64': 0.8.7
 
   yuku-parser@0.9.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ catalog:
   lightningcss: ^1.33.0
   oxc-transform-react: ^0.148.0
   publint: ^0.3.24
-  tsdown: ^0.22.14
+  tsdown: ^0.23.0
   typescript: 7.0.2
   vitest: ^4.1.11
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,7 @@ catalog:
   '@sanity/client': ^7.26.2
   '@sanity/icons': ^5.2.1
   '@sanity/logos': ^2.2.5
+  '@tsdown/css': ^0.23.0
   '@types/node': ^24.13.3
   lightningcss: ^1.33.0
   oxc-transform-react: ^0.148.0
@@ -39,7 +40,6 @@ minimumReleaseAge: 1440
 # a release fresher than the gate.
 minimumReleaseAgeExclude:
   - '@types/react-dom@19.2.5'
-  - '@tsdown/css@0.22.14'
   - '@sanity/ui@4.0.1'
   - '@sanity/diff@6.9.2'
   - '@sanity/mutator@6.9.2'
@@ -78,7 +78,6 @@ minimumReleaseAgeExclude:
   - verkit@0.3.0
   - yuku-ast@0.9.3
   - yuku-parser@0.9.3
-  - tsdown@0.22.14
 
 minimumReleaseAgeExcludePrune: true
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

tsdown and `@tsdown/css` 0.23 must move together because each package requires the exact matching peer version. The two standalone Renovate PRs produce unsupported mixed graphs.

tsdown 0.23 also exposes native programmatic watch controls. `pkg watch` can use `TsdownHandle.watch.close()` for complete cleanup, but native `restart()` cannot replace package-config reloads because it reuses one resolved inline config and may run only once per handle.

tsdown still restarts itself when a watched path ends in `package.json` or `tsconfig.json`. That restart closes the handle `pkg watch` holds and leaves an orphaned watcher that abort cannot stop.

## Scope

- Put `tsdown` and `@tsdown/css` on one 0.23 catalog and Renovate group.
- Require tsdown `^0.23.0` in the `@sanity/tsdown-config` and `@sanity/vanilla-extract-tsdown-plugin` peers. tsdown 0.22 is dropped, so both packages get a `minor` (breaking for a 0.x package), matching the 0.6.0 and 0.7.0 releases that moved the peer to 0.21.x and 0.22.x.
- Align `@sanity/tsdown-config`'s `engines.node` with tsdown 0.23, which drops Node 25.
- Preserve the old `deps.resolveDepSubpath: true` behavior instead of inheriting 0.23's new default.
- Adapt `build()` call sites to the `TsdownHandle` return shape.
- Select dts generators through `dts.generator` and refresh declaration snapshots.
- Track native watch handles and close them on config reload, abort, or stale runs. Keep the RxJS config watcher and run-id race guard.
- In watch mode, set `ignoreWatch` on `package.json` and `tsconfig.json` so tsdown does not restart itself. Watch `tsconfig.json` in the outer `watchConfigFiles` loop instead.
- Align `@sanity/pkg-utils`'s Node engine with its embedded tsdown 0.23 dependency, and leave the optional `@tsdown/css` peer unconstrained so tsdown's own exact pin is the single source of truth.

## Tradeoffs

`watch.close()` replaces per-bundle async disposal because it also closes tsdown's keyboard-shortcut resources. `watch.restart()` stays unused because it cannot re-read `package.config.ts`, `package.json`, or a changed tsconfig selection.

The changeset marks `@sanity/pkg-utils` as major. Removed `dts` / `deps` config forms and the loss of Node 25 build support are real consumer breaks.

An earlier revision widened the two peers to `^0.22.7 || ^0.23.0` and `^0.22.5 || ^0.23.0`, and that did work on both majors. It was dropped in review: the widened promise had no CI lane exercising tsdown 0.22, so it would have decayed silently.

## Blast Radius

Every package built through `pkg` or the workspace tsdown catalog. Consumers of `@sanity/tsdown-config` and `@sanity/vanilla-extract-tsdown-plugin` must move to tsdown 0.23 and off Node 25. CSS users need `@tsdown/css@0.23.0`.

tsdown 0.23 emits declarations with inline `export declare` modifiers and no trailing export list. A `.d.ts` without an export statement is an export context, so a type the source left unexported becomes importable and API Extractor reports `ae-missing-release-tag`. `playground/multi-export` hit this; its `PluginOptions` is now exported and `@public`. The changeset documents the behavior for downstream packages.

`pkg watch` users no longer get doubled rebuilds after editing `package.json`. A `tsconfig.json` that a later `package.config.ts` edit introduces is still not added to the watch list for the running session.

## Verification

On Node 24.18.0:

- `pnpm lint --deny-warnings`, `pnpm typecheck`, and `pnpm build` passed.
- `pnpm test` passed on the upgrade: 42 files, 523 tests passed, 15 skipped.
- `pnpm playground:build` and `pnpm playground:typecheck` passed across 39 projects.
- `pnpm css-playground:build` and `pnpm css-playground:test` passed across 21 projects.
- `@sanity/tsdown-config` (158 tests) and `@sanity/vanilla-extract-tsdown-plugin` (9 tests, no type errors) passed after the peer narrowing.
- The lockfile holds only the supported `tsdown@0.23.0` + `@tsdown/css@0.23.0` pair, and `pnpm peers check` reports no tsdown-related issue.
- `test/watch-orphan.test.ts` failed before `ignoreWatch` (dist mtime changed after abort) and passed after it.
- Exported symbol sets of all nine published entry declarations are unchanged from `main`, and emitted JS is byte-identical except where source changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07aff-a89c-7aa9-9314-cce3c3282567?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07aff-a89c-7aa9-9314-cce3c3282567&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

